### PR TITLE
Add Xenon support, set initial response timeout to 10 seconds

### DIFF
--- a/src/lib/deviceSpecs/specifications.js
+++ b/src/lib/deviceSpecs/specifications.js
@@ -328,6 +328,39 @@ const specs = {
 		features: [
 			'wifi',
 		],
+	},
+	'2b04:d00e': {
+		productName: 'Xenon',
+		tcpServerKey: {
+			address: '2082',
+			size: 512,
+			format: 'der',
+			alt: '1',
+			alg: 'rsa',
+			addressOffset: 384,
+			portOffset: 450
+		},
+		tcpPrivateKey: {
+			address: '34',
+			size: 612,
+			format: 'der',
+			alt: '1',
+			alg: 'rsa'
+		},
+		systemFirmwareOne: {
+			address: '0x00030000',
+			alt: '0'
+		},
+		knownApps: {
+
+		},
+		serial: {
+			vid: '2b04',
+			pid: 'c00e',
+			serialNumber: 'Particle_Xenon'
+		},
+		defaultProtocol: 'tcp',
+		productId: 14,
 	}
 };
 

--- a/src/lib/ymodem.js
+++ b/src/lib/ymodem.js
@@ -125,7 +125,7 @@ class YModem {
 				self.port.on('readable', cmdResponse);
 				self.port.write('f');
 			});
-		}).timeout(5000).catch(when.TimeoutError, () => {
+		}).timeout(10000).catch(when.TimeoutError, () => {
 			return when.reject('Timed out waiting for initial response from device');
 		});
 	}


### PR DESCRIPTION
### Feature

Support Xenon YModem firmware updating, set initial response timeout to 10 seconds because it takes about 6 seconds to send initial response on Xenon.