### PR TITLE
Force deviceId to be a string in subscribe command

### DIFF
--- a/src/cli/subscribe.js
+++ b/src/cli/subscribe.js
@@ -8,6 +8,7 @@ export default ({ commandProcessor, root }) => {
 			},
 			'device': {
 				describe: 'Listen to events from this device only',
+				string: true,
 				nargs: 1
 			}
 		},


### PR DESCRIPTION
Fixes #409 