### PR TITLE
Show NCP firmware modules in the output of `serial inspect`

### DIFF
--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -40,6 +40,10 @@ function protip(){
 }
 
 
+// An LTE device may take up to 18 seconds to power up the modem
+const MODULE_INFO_COMMAND_TIMEOUT = 20000;
+const IDENTIFY_COMMAND_TIMEOUT = 20000;
+
 class SerialCommand {
 	constructor() {
 		spinnerMixin(this);
@@ -285,7 +289,8 @@ class SerialCommand {
 				u: 'User',
 				b: 'Bootloader',
 				r: 'Reserved',
-				m: 'Monolithic'
+				m: 'Monolithic',
+				c: 'NCP'
 			};
 			const locationMap = {
 				m: 'main',
@@ -1300,11 +1305,11 @@ class SerialCommand {
 	}
 
 	getSystemInformation(device) {
-		return this._issueSerialCommand(device, 's');
+		return this._issueSerialCommand(device, 's', MODULE_INFO_COMMAND_TIMEOUT);
 	}
 
 	askForDeviceID(device) {
-		return this._issueSerialCommand(device, 'i').then((data) => {
+		return this._issueSerialCommand(device, 'i', IDENTIFY_COMMAND_TIMEOUT).then((data) => {
 			const matches = data.match(/Your (core|device) id is\s+(\w+)/);
 			if (matches && matches.length === 3) {
 				return matches[2];


### PR DESCRIPTION
This PR introduces the following changes:

- Show NCP firmware modules in the output of the `serial inspect` command.
- Increase the timeout of the `s` and `i` serial commands sent to the device.

Example output of the `serial inspect` command with an Argon device:
```
Platform: 12 
Modules
  Bootloader module #0 - version 300, main location, 49152 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
  System module #1 - version 1002, main location, 671744 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      Bootloader module #0 - version 201
  User module #1 - version 6, main location, 131072 bytes max size
    UUID: 8C3E879F1032133D7F456603A8A52DDFBA1102CF472FFC376CED0D69075FB7C3
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      System module #1 - version 1002
  NCP module #0 - version 5, main location, 1536000 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
```