### PR TITLE
Mesh command fixes

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4433,6 +4433,26 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
+      },
+      "dependencies": {
+        "combined-stream": {
+          "version": "1.0.7",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
+          "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
+        }
+      }
+    },
     "format": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
@@ -7907,35 +7927,15 @@
       }
     },
     "particle-api-js": {
-      "version": "7.4.0",
-      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-7.4.0.tgz",
-      "integrity": "sha512-Bk1tgzBCdVtTQvLirbIA6i1GopL/86JHsq20gniMtR72jRkHVHEA7M279ZO6ci9BZkihsJ+IpaRj/yorI9LTNw==",
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-7.4.1.tgz",
+      "integrity": "sha512-ln1yYuwRmPrROQ95M5Kg4FyLXIVbupwQBU36nE2K8NqcSX46b+B+6GZjvKIRk2F8XKgtz2WjORc8rArRE0sJnA==",
       "requires": {
         "babel-runtime": "^6.9.2",
         "form-data": ">2.2.0",
         "stream-http": "https://github.com/particle-iot/stream-http/archive/v2.2.1.tar.gz",
         "superagent": "^3.6.0",
         "superagent-prefix": "0.0.2"
-      },
-      "dependencies": {
-        "combined-stream": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-          "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
-          "requires": {
-            "delayed-stream": "~1.0.0"
-          }
-        },
-        "form-data": {
-          "version": "2.3.3",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-          "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.6",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "particle-commands": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
     "node-wifiscanner2": "^1.2.0",
-    "particle-api-js": "^7.4.0",
+    "particle-api-js": "^7.4.1",
     "particle-commands": "0.3.0",
     "particle-library-manager": "0.1.13",
     "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",

--- a/src/cmd/mesh.js
+++ b/src/cmd/mesh.js
@@ -24,11 +24,7 @@ module.exports = class MeshCommand {
 		})
 			.then(d => {
 				usbDevice = d;
-				// Check if the device is already a member of some network
-				return this._getDeviceNetworkId(device);
-			})
-			.then(networkId => {
-				if (!networkId) {
+				if (!device.network) {
 					return;
 				}
 				// Remove the device from its current network
@@ -46,10 +42,10 @@ module.exports = class MeshCommand {
 							}
 						});
 				}
-				return p.then(() => this._removeDevice(usbDevice, networkId));
+				return p.then(() => this._removeDeviceFromNetwork(usbDevice));
 			})
 			.then(() => {
-			// Get a password for the new network
+				// Get a password for the new network
 				if (args.password) {
 					return args.password;
 				}
@@ -72,24 +68,24 @@ module.exports = class MeshCommand {
 			.then(password => {
 				networkPassword = password;
 				if (usbDevice.isCellularDevice) {
-				// Get the ICCID of the active SIM card
+					// Get the ICCID of the active SIM card
 					const p = usbDevice.getIccid();
 					return spin(p, 'Getting the ICCID...');
 				}
 			})
 			.then(iccid => {
-			// Register the network with the cloud and get the network ID
+				// Register the network with the cloud and get the network ID
 				const p = this._api.createMeshNetwork({ name: args.params.network_name, deviceId: device.id, iccid, auth: this._auth })
 					.then(r => r.body.network.id);
 				return spin(p, 'Registering the network with the cloud...');
 			})
 			.then(networkId => {
-			// Create the network
+				// Create the network
 				const p = usbDevice.createMeshNetwork({ id: networkId, name: args.params.network_name, password: networkPassword, channel: args.channel });
 				return spin(p, 'Creating the network...');
 			})
 			.then(() => {
-			// Leave the listening mode
+				// Leave the listening mode
 				return usbDevice.leaveListeningMode();
 			})
 			.then(() => {
@@ -111,24 +107,20 @@ module.exports = class MeshCommand {
 		// Get the assisting device
 		return this._getDevice(args.params.assisting_device).then(d => {
 			assistDevice = d;
-			// Get the joiner device. Do not fail if the device is not claimed
-			return this._getDevice(args.params.new_device, true);
+			if (!assistDevice.network) {
+				throw new Error('The assisting device is not a member of any mesh network');
+			}
+			networkId = assistDevice.network.id;
+			// Open the assisting device
+			return this._openUsbDeviceById(assistDevice.id, args.params.assisting_device);
 		})
 			.then(d => {
-				joinerDevice = d; // Can be null
-				// Get the ID of the assisting device's network
-				return this._getDeviceNetworkId(assistDevice);
-			})
-			.then(id => {
-				networkId = id;
-				if (!networkId) {
-					throw new Error('The assisting device is not a member of any mesh network');
-				}
-				// Open the assisting device
-				return this._openUsbDeviceById(assistDevice.id, args.params.assisting_device);
+				assistUsbDevice = d;
+				// Get the joiner device. Do not fail if the device is not claimed
+				return this._getDevice(args.params.new_device, true);
 			})
 			.then(d => {
-				assistUsbDevice = d;
+				joinerDevice = d; // Can be null
 				// Open the joiner device
 				let idOrName = args.params.new_device;
 				if (joinerDevice) {
@@ -139,15 +131,9 @@ module.exports = class MeshCommand {
 			.then(d => {
 				joinerUsbDevice = d;
 				// Check if the joiner device is already a member of some network
-				if (!joinerDevice) {
-					return null;
-				}
-				return this._getDeviceNetworkId(joinerDevice);
-			})
-			.then(joinerNetworkId => {
 				let p = when.resolve();
-				if (joinerNetworkId) {
-					if (joinerNetworkId === networkId) {
+				if (joinerDevice && joinerDevice.network) {
+					if (joinerDevice.network.id === networkId) {
 						console.log('The device is already a member of the network.');
 						return p; // Done
 					}
@@ -164,7 +150,7 @@ module.exports = class MeshCommand {
 								}
 							});
 					}
-					p = p.then(() => this._removeDevice(joinerUsbDevice, joinerNetworkId));
+					p = p.then(() => this._removeDeviceFromNetwork(joinerUsbDevice));
 				}
 				return p.then(() => {
 					if (args.password) {
@@ -184,8 +170,14 @@ module.exports = class MeshCommand {
 						return spin(p, 'Preparing the assisting device...');
 					})
 					.then(() => {
+						let p = when.resolve();
+						if (!joinerDevice) {
+							// The cloud will refuse to add an unclaimed device to a network, if the device is
+							// already a member of some other network
+							p = p.then(() => this._api.removeMeshNetworkDevice({ deviceId: joinerUsbDevice.id, auth: this._auth }));
+						}
 						// Register the joiner device with the cloud
-						const p = this._api.addMeshNetworkDevice({ networkId, deviceId: joinerUsbDevice.id, auth: this._auth });
+						p = p.then(() => this._api.addMeshNetworkDevice({ networkId, deviceId: joinerUsbDevice.id, auth: this._auth }));
 						return spin(p, 'Registering the device with the cloud...');
 					})
 					.then(() => {
@@ -232,41 +224,37 @@ module.exports = class MeshCommand {
 		let usbDevice = null;
 		return this._getDevice(args.params.device).then(d => {
 			device = d;
-			// Check if the device is a member of a network
-			return this._getDeviceNetworkId(device);
-		})
-			.then(networkId => {
-				let p = when.resolve();
-				if (!networkId) {
-					console.log('This device is not a member of any mesh network.');
-					return p; // Done
-				}
-				if (!args.yes) {
-					p = p.then(() => prompt({
-						name: 'remove',
-						type: 'confirm',
-						message: 'Are you sure you want to remove this device from the network?',
-						default: false
-					}))
-						.then(r => {
-							if (!r.remove) {
-								throw new Error('Cancelled');
-							}
-						});
-				}
-				return p.then(() => {
-				// Open the device
-					return this._openUsbDeviceById(device.id, args.params.device);
-				})
-					.then(d => {
-						usbDevice = d;
-						// Remove the device from the network
-						return this._removeDevice(usbDevice, networkId);
-					})
-					.then(() => {
-						console.log('Done.');
+			let p = when.resolve();
+			if (!device.network) {
+				console.log('This device is not a member of any mesh network.');
+				return p; // Done
+			}
+			if (!args.yes) {
+				p = p.then(() => prompt({
+					name: 'remove',
+					type: 'confirm',
+					message: 'Are you sure you want to remove this device from the network?',
+					default: false
+				}))
+					.then(r => {
+						if (!r.remove) {
+							throw new Error('Cancelled');
+						}
 					});
+			}
+			return p.then(() => {
+				// Open the device
+				return this._openUsbDeviceById(device.id, args.params.device);
 			})
+				.then(d => {
+					usbDevice = d;
+					// Remove the device from the network
+					return this._removeDeviceFromNetwork(usbDevice);
+				})
+				.then(() => {
+					console.log('Done.');
+				});
+		})
 			.finally(() => {
 				if (usbDevice) {
 					return usbDevice.close();
@@ -294,7 +282,7 @@ module.exports = class MeshCommand {
 				}
 				const listDevices = !args['networks-only'];
 				if (listDevices) {
-				// Get network devices
+					// Get network devices
 					p = p.then(() => sequence(networks.map(network => () => {
 						return this._api.listMeshNetworkDevices({ networkId: network.id, auth: this._auth }).then(r => {
 							network.devices = r.body.sort((a, b) => (a.name || '').localeCompare(b.name || '')); // Sort devices by name
@@ -363,32 +351,9 @@ module.exports = class MeshCommand {
 			});
 	}
 
-	_getDeviceNetworkId(device) {
-		const network = device.network;
-		if (!network || !network.id) {
-			return when.resolve(null);
-		}
-		// FIXME: The API service shows that a device is a member of a network even if the network is
-		// pending, so we have to check the network status explicitly:
-		// https://github.com/particle-iot/api-service/pull/601
-		if (network.role && network.role.state === 'confirmed') {
-			return when.resolve(network.id);
-		}
-		const p = when.resolve().then(() => this._api.getMeshNetwork({ networkId: network.id, auth: this._auth })).then(() => {
-			return network.id; // The device is a member of a confirmed network
-		})
-			.catch(e => {
-				if (e.statusCode === 404) {
-					return null; // The device is a member of a pending network
-				}
-				throw e;
-			});
-		return spin(p, 'Getting network information...');
-	}
-
-	_removeDevice(usbDevice, networkId) {
-		return spin(this._api.removeMeshNetworkDevice({ networkId, deviceId: usbDevice.id, auth: this._auth }),
-			'Removing the device from the network...').then(() => {
+	_removeDeviceFromNetwork(usbDevice) {
+		return spin(this._api.removeMeshNetworkDevice({ deviceId: usbDevice.id, auth: this._auth }),
+				'Removing the device from the network...').then(() => {
 			return spin(usbDevice.leaveMeshNetwork(), 'Clearing the network credentials...');
 		});
 	}

--- a/src/cmd/mesh.js
+++ b/src/cmd/mesh.js
@@ -340,6 +340,13 @@ module.exports = class MeshCommand {
 				if (networks.length === 0) {
 					console.log('No networks found.');
 				} else {
+					// Device OS versions prior to 1.2.0 might report the same network multiple times:
+					// https://github.com/particle-iot/device-os/pull/1760. As a workaround, we're filtering
+					// out duplicate network entries at the client side as well
+					networks = networks.filter((n1, i1) => {
+						const i2 = networks.findIndex(n2 => n1.name === n2.name && n1.panId === n2.panId && n1.extPanId === n2.extPanId);
+						return i1 === i2;
+					});
 					networks = networks.sort((a, b) => a.name.localeCompare(b.name)); // Sort networks by name
 					networks.forEach(network => console.log(network.name));
 				}
@@ -353,7 +360,7 @@ module.exports = class MeshCommand {
 
 	_removeDeviceFromNetwork(usbDevice) {
 		return spin(this._api.removeMeshNetworkDevice({ deviceId: usbDevice.id, auth: this._auth }),
-				'Removing the device from the network...').then(() => {
+			'Removing the device from the network...').then(() => {
 			return spin(usbDevice.leaveMeshNetwork(), 'Clearing the network credentials...');
 		});
 	}


### PR DESCRIPTION
This PR introduces the following changes:

- When adding an unclaimed device to a network, make sure the device is removed from its current network first (see [ch30101](https://app.clubhouse.io/particle/story/30101/half-initialized-mesh-networks-make-mesh-device-unable-to-be-provisioned) for the details).
- Filter out duplicate entries from the list of discovered networks (see [this](https://s.slack.com/archives/CG6D5KB43/p1555091439015800?thread_ts=1554999936.004900&cid=CG6D5KB43) discussion and the related [fixes](https://github.com/particle-iot/device-os/pull/1760) in the Device OS).
- Remove the workaround for the API service issue that was fixed in https://github.com/particle-iot/api-service/pull/601.
