### PR TITLE
adds support for radio stack modules

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2045,9 +2045,9 @@
       "optional": true
     },
     "binary-version-reader": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-0.6.4.tgz",
-      "integrity": "sha512-8AS9TgrqxA4Q5zFhf7Z2LC9QhGl02WPJn+3fbz/zI8zAJS7JPN894ZzNsYd7QUv9YRzhEbkGbegwVzKIg8ZBqQ==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-0.6.5.tgz",
+      "integrity": "sha512-/7qMz4ta+/5LGz3aalMNWXXGLAeOgvs8Oscl+0f2yAgJBSxuhU6OuY2tWMysMiLM4gIP0ka9MnE8chx8//9OBw==",
       "requires": {
         "buffer-crc32": "^0.2.5",
         "chai": "^3.5.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     }
   ],
   "dependencies": {
-    "binary-version-reader": "^0.6.4",
+    "binary-version-reader": "^0.6.5",
     "chalk": "^2.4.2",
     "cli-spinner": "^0.2.10",
     "cli-table": "^0.3.1",

--- a/src/cmd/binary.js
+++ b/src/cmd/binary.js
@@ -91,7 +91,8 @@ class BinaryCommand {
 			'a system module',
 			'an application module',
 			'a settings module',
-			'a network coprocessor (NCP) module'
+			'a network coprocessor (NCP) module',
+			'a radio stack module'
 		];
 		let moduleFunction = fileInfo.prefixInfo.moduleFunction;
 		if (moduleFunction >= functions.length) {
@@ -108,6 +109,13 @@ class BinaryCommand {
 				+ ' number ' + chalk.bold(fileInfo.prefixInfo.depModuleIndex.toString())
 				+ ' at version '
 				+ chalk.bold(fileInfo.prefixInfo.depModuleVersion.toString()));
+		}
+		if (fileInfo.prefixInfo.dep2ModuleFunction) {
+			console.log(` It ${fileInfo.prefixInfo.depModuleFunction ? 'also ' : ''}depends on `
+				+ chalk.bold(functions[fileInfo.prefixInfo.dep2ModuleFunction])
+				+ ' number ' + chalk.bold(fileInfo.prefixInfo.dep2ModuleIndex.toString())
+				+ ' at version '
+				+ chalk.bold(fileInfo.prefixInfo.dep2ModuleVersion.toString()));
 		}
 	}
 }

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -2,12 +2,11 @@ const fs = require('fs');
 const VError = require('verror');
 const dfu = require('../lib/dfu');
 const ModuleParser = require('binary-version-reader').HalModuleParser;
+const ModuleInfo = require('binary-version-reader').ModuleInfo;
 const deviceSpecs = require('../lib/deviceSpecs');
 const ensureError = require('../lib/utilities').ensureError;
-
-const MONOLITHIC = 3;
-const SYSTEM_MODULE = 4;
-const APPLICATION_MODULE = 5;
+const temp = require('temp').track();
+const when = require('when');
 
 const systemModuleIndexToString = {
 	1: 'systemFirmwareOne',
@@ -97,16 +96,20 @@ class FlashCommand {
 				}
 
 				switch (info.prefixInfo.moduleFunction) {
-					case MONOLITHIC:
+					case ModuleInfo.Function.MONO_FIRMWARE:
 						// only override if modular capable
 						destSegment = specs.systemFirmwareOne ? 'systemFirmwareOne' : destSegment;
 						break;
-					case SYSTEM_MODULE:
+					case ModuleInfo.Function.SYSTEM_PART:
 						destSegment = systemModuleIndexToString[info.prefixInfo.moduleIndex];
 						destAddress = '0x0' + info.prefixInfo.moduleStartAddy;
 						break;
-					case APPLICATION_MODULE:
+					case ModuleInfo.Function.USER_PART:
 						// use existing destSegment for userFirmware/factoryReset
+						break;
+					case ModuleInfo.Function.RADIO_STACK:
+						destSegment = 'radioStack';
+						destAddress = '0x0' + info.prefixInfo.moduleStartAddy;
 						break;
 					default:
 						if (!force) {
@@ -114,8 +117,14 @@ class FlashCommand {
 						}
 						break;
 				}
+
+				if (info.prefixInfo.moduleFlags & ModuleInfo.Flags.DROP_MODULE_INFO) {
+					return this._dropModuleInfo(binary);
+				}
+
+				return binary;
 			});
-		}).then(() => {
+		}).then((binary) => {
 			if (!destAddress && destSegment) {
 				const segment = dfu._validateSegmentSpecs(destSegment);
 				if (segment.error) {
@@ -133,6 +142,18 @@ class FlashCommand {
 			console.log ('\nFlash success!');
 		}).catch((err) => {
 			throw new VError(ensureError(err), 'Error writing firmware');
+		});
+	}
+
+	_dropModuleInfo(binary) {
+		// Creates a temporary binary with module info stripped out and returns the path to it
+
+		return when.promise((resolve, reject) => {
+			const rStream = fs.createReadStream(binary, { start: ModuleInfo.HEADER_SIZE });
+			const wStream = temp.createWriteStream({ suffix: '.bin' });
+			rStream.pipe(wStream)
+				.on('error', reject)
+				.on('finish', () => resolve(wStream.path));
 		});
 	}
 }

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -96,18 +96,18 @@ class FlashCommand {
 				}
 
 				switch (info.prefixInfo.moduleFunction) {
-					case ModuleInfo.Function.MONO_FIRMWARE:
+					case ModuleInfo.FunctionType.MONO_FIRMWARE:
 						// only override if modular capable
 						destSegment = specs.systemFirmwareOne ? 'systemFirmwareOne' : destSegment;
 						break;
-					case ModuleInfo.Function.SYSTEM_PART:
+					case ModuleInfo.FunctionType.SYSTEM_PART:
 						destSegment = systemModuleIndexToString[info.prefixInfo.moduleIndex];
 						destAddress = '0x0' + info.prefixInfo.moduleStartAddy;
 						break;
-					case ModuleInfo.Function.USER_PART:
+					case ModuleInfo.FunctionType.USER_PART:
 						// use existing destSegment for userFirmware/factoryReset
 						break;
-					case ModuleInfo.Function.RADIO_STACK:
+					case ModuleInfo.FunctionType.RADIO_STACK:
 						destSegment = 'radioStack';
 						destAddress = '0x0' + info.prefixInfo.moduleStartAddy;
 						break;
@@ -124,7 +124,7 @@ class FlashCommand {
 
 				return binary;
 			});
-		}).then((binary) => {
+		}).then((finalBinary) => {
 			if (!destAddress && destSegment) {
 				const segment = dfu._validateSegmentSpecs(destSegment);
 				if (segment.error) {
@@ -137,7 +137,7 @@ class FlashCommand {
 			}
 			const alt = 0;
 			const leave = destSegment === 'userFirmware'; // todo - leave on factory firmware write too?
-			return dfu.writeDfu(alt, binary, destAddress, leave);
+			return dfu.writeDfu(alt, finalBinary, destAddress, leave);
 		}).then(() => {
 			console.log ('\nFlash success!');
 		}).catch((err) => {

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -290,7 +290,8 @@ class SerialCommand {
 				b: 'Bootloader',
 				r: 'Reserved',
 				m: 'Monolithic',
-				c: 'NCP'
+				c: 'NCP',
+				a: 'Radio stack'
 			};
 			const locationMap = {
 				m: 'main',

--- a/src/lib/deviceSpecs/specifications.js
+++ b/src/lib/deviceSpecs/specifications.js
@@ -398,6 +398,10 @@ const specs = {
 			alt: '1',
 			size: '1'
 		},
+		radioStack: {
+			address: '0x00001000',
+			alt: '0'
+		},
 		knownApps: {
 			'tinker': 'tinker-0.8.0-rc.27-argon.bin'
 		},
@@ -461,6 +465,10 @@ const specs = {
 			alt: '1',
 			size: '1'
 		},
+		radioStack: {
+			address: '0x00001000',
+			alt: '0'
+		},
 		knownApps: {
 		},
 		serial: {
@@ -522,6 +530,10 @@ const specs = {
 			address: '1753',
 			alt: '1',
 			size: '1'
+		},
+		radioStack: {
+			address: '0x00001000',
+			alt: '0'
 		},
 		knownApps: {
 			'tinker': 'tinker-0.8.0-rc.27-boron.bin'
@@ -586,6 +598,10 @@ const specs = {
 			alt: '1',
 			size: '1'
 		},
+		radioStack: {
+			address: '0x00001000',
+			alt: '0'
+		},
 		knownApps: {
 		},
 		serial: {
@@ -647,6 +663,10 @@ const specs = {
 			address: '1753',
 			alt: '1',
 			size: '1'
+		},
+		radioStack: {
+			address: '0x00001000',
+			alt: '0'
 		},
 		knownApps: {
 			'tinker': 'tinker-0.8.0-rc.27-xenon.bin'
@@ -711,6 +731,10 @@ const specs = {
 			address: '1753',
 			alt: '1',
 			size: '1'
+		},
+		radioStack: {
+			address: '0x00001000',
+			alt: '0'
 		},
 		knownApps: {
 		},


### PR DESCRIPTION
### Description

This PR:
1. adds support for 'radio stack' modules
2. adds support for `DROP_MODULE_INFO` module flag introduced in https://github.com/particle-iot/device-os/pull/1816 when flashing over DFU
3. prints secondary module dependency information in `binary inspect`

### Testing

Follow the guide in https://github.com/particle-iot/device-os/pull/1816, or use the following pre-built [Argon binaries](https://github.com/particle-iot/particle-cli/files/3276558/argon-binaries.zip) and flash `system-part1` and `bootloader` to the device.

1. `particle binary inspect argon-softdevice-6.1.1.bin` should work correctly:
```console
 CRC is ok (78715fba)
 Compiled for argon
 This is a radio stack module number 0 at version 182
 It depends on a system module number 1 at version 1300
 It also depends on a bootloader number 0 at version 311
```
2. `particle serial inspect` should work correcty and should report a radio stack module with version 169 (SoftDevice 6.0.0)
```console
Platform: 12 - Argon
Modules
  Bootloader module #0 - version 311, main location, 49152 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
  System module #1 - version 1300, main location, 671744 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      Bootloader module #0 - version 311
  User module #1 - version 6, main location, 131072 bytes max size
    UUID: A7979068CD4812DA30511222456D3E613D8F5AA38DB4D780000565E85F2ECF97
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      System module #1 - version 1300
  NCP module #0 - version 5, main location, 1536000 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
  Radio stack module #0 - version 169, main location, 196608 bytes max size
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
```
3. `particle flash --usb argon-softdevice-6.1.1.bin` should update the SoftDevice to 6.1.1 and it should boot normally. Running `particle serial inspect` afterwards should report version 182 (SoftDevice 6.1.1) for radio stack module.

### References
- [CH31496]
- [DeviceOS PR](https://github.com/particle-iot/device-os/pull/1816)
- [binary-version-reader PR](particle-iot/binary-version-reader#24)
