### PR TITLE
Fixes issue #498 where `particle update` fails on Photon/P1

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -86,16 +86,22 @@ var settings = {
 	},
 	updates: {
 		'2b04:d006': {
-			systemFirmwareOne: 'photon-system-part1@1.2.1.bin',
-			systemFirmwareTwo: 'photon-system-part2@1.2.1.bin',
+			// Need to flash Bootloader and OTA Flag before system parts for Photon/P1
+			// because as soon as the system parts are flashed they will change the location
+			// of DFU read/write functions which live in system firmware.
 			otaRegion: 'photon-bootloader@1.2.1.bin',
-			otaFlag: 'ota-flag-a5.bin'
+			otaFlag: 'ota-flag-a5.bin',
+			systemFirmwareOne: 'photon-system-part1@1.2.1.bin',
+			systemFirmwareTwo: 'photon-system-part2@1.2.1.bin'
 		},
 		'2b04:d008': {
-			systemFirmwareOne: 'p1-system-part1@1.2.1.bin',
-			systemFirmwareTwo: 'p1-system-part2@1.2.1.bin',
+			// Need to flash Bootloader and OTA Flag before system parts for Photon/P1
+			// because as soon as the system parts are flashed they will change the location
+			// of DFU read/write functions which live in system firmware.
 			otaRegion: 'p1-bootloader@1.2.1.bin',
-			otaFlag: 'ota-flag-a5.bin'
+			otaFlag: 'ota-flag-a5.bin',
+			systemFirmwareOne: 'p1-system-part1@1.2.1.bin',
+			systemFirmwareTwo: 'p1-system-part2@1.2.1.bin'
 		},
 		'2b04:d00a': {
 			// The bin files MUST be in this order to be flashed to the correct memory locations


### PR DESCRIPTION
## Problem

When updating system firmware with `particle update` with CLI 1.43.0 on Photon/P1, the device locks up at the last step where DCT is written to.

## Solution

**Short term solution:** Need to flash Bootloader and OTA Flag before system parts for Photon/P1 because as soon as the system parts are flashed they will change the location of DFU read/write functions which live in system firmware.

**Long term solution:** Add a dirty flag in Device OS that would cause the bootloader to reload DCT functions from system parts if their flash area has been modified.  Will be added to a future Device OS release.

## Reference

Fixes #498 
https://community.particle.io/t/device-os-1-2-1-and-particle-cli-1-43-fail-in-particle-update/51140