### PR TITLE
flash: fixes a regression in flash command for known apps

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -74,7 +74,7 @@ class FlashCommand {
 		}).then(() => {
 			destSegment = factory ? 'factoryReset' : 'userFirmware';
 			if (flashingKnownApp) {
-				return;
+				return binary;
 			}
 
 			const parser = new ModuleParser();


### PR DESCRIPTION
This PR resolves a regression introduced in #493 when flashing known apps (e.g. tinker).

Closes #501 