### PR TITLE
Use current LTS for deployment and add latest stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - 8
   - 10
   - 11
+  - 12
 
 cache:
   directories:
@@ -20,7 +21,7 @@ jobs:
   include:
     - stage: npm release
       script: echo "Deploying to npm..."
-      node_js: 8
+      node_js: 10
       if: tag =~ ^v\d+\.\d+\.\d+$
       deploy:
         provider: npm


### PR DESCRIPTION
The LTS is v10 (see [nodejs.org](https://nodejs.org)).

Also, there is now Node.js v12, which should be supported, since #509 we now use `node-serialport` `^7.1.5`.