### PR TITLE
moves hardcoded 5ms timeout to settings file

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -47,7 +47,7 @@ var settings = {
 
 	wirelessSetupFilter: /^Photon-.*$/,
 
-	serial_follow_check_frequency: 5,
+	serial_follow_delay: 5,
 
 	notSourceExtensions: [
 		'.ds_store',

--- a/settings.js
+++ b/settings.js
@@ -47,6 +47,8 @@ var settings = {
 
 	wirelessSetupFilter: /^Photon-.*$/,
 
+	serial_follow_check_frequency: 5,
+
 	notSourceExtensions: [
 		'.ds_store',
 		'.jpg',

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -178,7 +178,11 @@ module.exports = class SerialCommand {
 			if (!device){
 				if (follow){
 					setTimeout(() => {
-						this.whatSerialPortDidYouMean(port, true).then(handlePortFn);
+						if (cleaningUp) {
+							return;
+						} else {
+							this.whatSerialPortDidYouMean(port, true).then(handlePortFn);
+						}
 					}, settings.serial_follow_delay);
 					return;
 				} else {

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -179,7 +179,7 @@ module.exports = class SerialCommand {
 				if (follow){
 					setTimeout(() => {
 						this.whatSerialPortDidYouMean(port, true).then(handlePortFn);
-					}, 5);
+					}, settings.serial_follow_delay);
 					return;
 				} else {
 					throw new VError('No serial port identified');
@@ -212,7 +212,7 @@ module.exports = class SerialCommand {
 		function reconnect(){
 			setTimeout(() => {
 				openPort(selectedDevice);
-			}, 5);
+			}, settings.serial_follow_delay);
 		}
 
 		process.on('SIGINT', handleInterrupt);


### PR DESCRIPTION
Background:

     We're investigating a CLI crash on a long-running `particle serial monitor --follow` invocation that runs out of memory after ~4 hours or so.

Theory:

    The follow command has a 5ms timeout before it checks for serial ports again, heavily taxing the operating system.  By making this a setting, we can more easily test a longer timeout without changing behavior for everyone.  We suspect a 50, or 100ms timeout will be easier on the host OS, and provide equivalent behavior.

Thanks!