### PR TITLE
Follow Symlinks while Globbing File List

### DIFF
--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -4,6 +4,10 @@ module.exports = ({ commandProcessor, root }) => {
 	const compileOptions = {
 		'target': {
 			description: 'The firmware version to compile against. Defaults to latest version, or version on device for cellular.'
+		},
+		'followSymlinks': {
+			boolean: true,
+			description: 'Follow symlinks when collecting files'
 		}
 	};
 

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -218,7 +218,7 @@ module.exports = {
 			if (basepath){
 				line = path.join(basepath, line);
 			}
-			found = glob.sync(line, { nodir: true });
+			found = glob.sync(line, { nodir: true, follow: true });
 
 			if (found && (found.length > 0)){
 				files = files.concat(found);

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -211,14 +211,14 @@ module.exports = {
 		});
 	},
 
-	globList(basepath, arr){
+	globList(basepath, arr, { followSymlinks } = {}){
 		let line, found, files = [];
 		for (let i=0;i<arr.length;i++){
 			line = arr[i];
 			if (basepath){
 				line = path.join(basepath, line);
 			}
-			found = glob.sync(line, { nodir: true, follow: true });
+			found = glob.sync(line, { nodir: true, follow: !!followSymlinks });
 
 			if (found && (found.length > 0)){
 				files = files.concat(found);

--- a/test/__fixtures__/projects/symlink/main-project/app.ino
+++ b/test/__fixtures__/projects/symlink/main-project/app.ino
@@ -1,0 +1,12 @@
+#include "shared/sub_dir/helper.h"
+// Demo app with an include that points to a symlink
+
+void setup() {
+  if (DOIT) {
+    Particle.function("test", testFn);
+  }
+}
+
+int testFn(String) {
+  return 0;
+}

--- a/test/__fixtures__/projects/symlink/main-project/project.properties
+++ b/test/__fixtures__/projects/symlink/main-project/project.properties
@@ -1,0 +1,1 @@
+name=main-project

--- a/test/__fixtures__/projects/symlink/main-project/shared
+++ b/test/__fixtures__/projects/symlink/main-project/shared
@@ -1,0 +1,1 @@
+../shared-project

--- a/test/__fixtures__/projects/symlink/shared-project/sub_dir/helper.cpp
+++ b/test/__fixtures__/projects/symlink/shared-project/sub_dir/helper.cpp
@@ -1,0 +1,3 @@
+#include "helper.h"
+
+const int DOIT = 1;

--- a/test/__fixtures__/projects/symlink/shared-project/sub_dir/helper.h
+++ b/test/__fixtures__/projects/symlink/shared-project/sub_dir/helper.h
@@ -1,0 +1,2 @@
+#pragma once
+extern const int DOIT;

--- a/test/e2e/compile.e2e.js
+++ b/test/e2e/compile.e2e.js
@@ -249,6 +249,27 @@ describe('Compile Command', () => {
 		expect(exitCode).to.equal(0);
 	});
 
+	it('Compiles a project with symlinks to parent/other file locations', async () => {
+		const name = 'symlinks';
+		const platform = 'photon';
+		const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
+		const destination = path.join(PATH_TMP_DIR, `${name}-${platform}.bin`);
+		const args = ['compile', platform, '*', '--saveTo', destination];
+		const { stdout, stderr, exitCode } = await cli.run(args, { cwd, shell: true });
+		const log = [
+			`Compiling code for ${platform}`,
+			'Including:',
+			'    shared/sub_dir/helper.h',
+			'    app.ino',
+			'    shared/sub_dir/helper.cpp',
+			'    project.properties',
+		];
+
+		expect(stdout.split('\n')).to.include.members(log);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
 	it('Compiles a project using its directory name', async () => {
 		const name = 'dirname';
 		const platform = 'photon';

--- a/test/e2e/compile.e2e.js
+++ b/test/e2e/compile.e2e.js
@@ -20,8 +20,9 @@ describe('Compile Command', () => {
 		'  -q, --quiet    Decreases how much logging to display  [count]',
 		'',
 		'Options:',
-		'  --target  The firmware version to compile against. Defaults to latest version, or version on device for cellular.  [string]',
-		'  --saveTo  Filename for the compiled binary  [string]',
+		'  --target          The firmware version to compile against. Defaults to latest version, or version on device for cellular.  [string]',
+		'  --followSymlinks  Follow symlinks when collecting files  [boolean]',
+		'  --saveTo          Filename for the compiled binary  [string]',
 		'',
 		'Examples:',
 		'  particle compile photon                                  Compile the source code in the current directory in the cloud for a Photon',
@@ -216,8 +217,8 @@ describe('Compile Command', () => {
 		const platform = 'photon';
 		const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'multiple-header-extensions');
 		const destination = path.join(PATH_TMP_DIR, `${name}-${platform}.bin`);
-		const args = ['compile', platform, '*', '--saveTo', destination];
-		const { stdout, stderr, exitCode } = await cli.run(args, { cwd, shell: true });
+		const args = ['compile', platform, '--saveTo', destination];
+		const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
 		const log = [
 			`Compiling code for ${platform}`,
 			'',
@@ -254,8 +255,8 @@ describe('Compile Command', () => {
 		const platform = 'photon';
 		const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
 		const destination = path.join(PATH_TMP_DIR, `${name}-${platform}.bin`);
-		const args = ['compile', platform, '*', '--saveTo', destination];
-		const { stdout, stderr, exitCode } = await cli.run(args, { cwd, shell: true });
+		const args = ['compile', platform, '--saveTo', destination, '--followSymlinks'];
+		const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
 		const log = [
 			`Compiling code for ${platform}`,
 			'Including:',


### PR DESCRIPTION
## Description

This PR sets `follow` to `true` when resolving files for compilation.

Docs of `glob` module: https://www.npmjs.com/package/glob

## How to Test

Run `particle compile photon test/__fixtures__/projects/symlink/main-project`. It should include thie following files:
```
Including:
    test/__fixtures__/projects/symlink/main-project/shared/sub_dir/helper.h
    test/__fixtures__/projects/symlink/main-project/app.ino
    test/__fixtures__/projects/symlink/main-project/shared/sub_dir/helper.cpp
    test/__fixtures__/projects/symlink/main-project/project.properties
```

Without this PR, the output is the following:
```
Including:
    test/__fixtures__/projects/symlink/main-project/app.ino
    test/__fixtures__/projects/symlink/main-project/project.properties
```
...which results in a compilation error due to missing header files/includes.

## Related Issues / Discussions
Fixes #510 

