### PR TITLE
add timeout to `particle serial wifi` command to catch if device isn't listening

### DIFF
--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -929,7 +929,11 @@ module.exports = class SerialCommand {
 			.then(() => {
 				console.log('Done! Your device should now restart.');
 			}, (err) => {
-				log.error('Something went wrong:', err);
+				if (err && err.message) {
+					log.error('Something went wrong:', err.message);
+				} else {
+					log.error('Something went wrong:', err);
+				}
 			});
 	}
 

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -921,12 +921,11 @@ module.exports = class SerialCommand {
 	}
 
 	/**
-	 * This is a wrapper function created so _serialWifiConfig can return the
-	 * true promise state, but the wrapper can still act like it handled any
-	 * failures gracefully as it acted before testing was attempted.
+	 * This is a wrapper function so _serialWifiConfig can return the
+	 * true promise state for testing.
 	 */
 	serialWifiConfig(...args) {
-		return this._serialWifiConfig.apply(this, args)
+		return this._serialWifiConfig(...args)
 			.then(() => {
 				console.log('Done! Your device should now restart.');
 			}, (err) => {
@@ -1221,16 +1220,16 @@ module.exports = class SerialCommand {
 				serialPort.drain();
 
 				// In case device is not in listening mode.
-				startTimeout(5000, 'Serial timed out while initially listening to device, please ensure device is in listening mode with particle usb start-listening');
+				startTimeout(5000, 'Serial timed out while initially listening to device, please ensure device is in listening mode with particle usb start-listening', 'InitialTimeoutError');
 			});
 
 			function serialClosedEarly(){
 				reject('Serial port closed early');
 			}
 
-			function startTimeout(to, message = timeoutError){
+			function startTimeout(to, message = timeoutError, name = 'TimeoutError'){
 				self._serialTimeout = setTimeout(() => {
-					reject(message);
+					reject(VError({name}, message));
 				}, to);
 			}
 

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -1233,7 +1233,7 @@ module.exports = class SerialCommand {
 
 			function startTimeout(to, message = timeoutError, name = 'TimeoutError'){
 				self._serialTimeout = setTimeout(() => {
-					reject(VError({name}, message));
+					reject(new VError({ name }, message));
 				}, to);
 			}
 

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -23,6 +23,7 @@ const ensureError = require('../lib/utilities').ensureError;
 const cmd = path.basename(process.argv[1]);
 const arrow = chalk.green('>');
 const alert = chalk.yellow('!');
+const timeoutError = 'Serial timed out';
 
 function protip(){
 	const args = Array.prototype.slice.call(arguments);
@@ -30,7 +31,6 @@ function protip(){
 	console.log.apply(null, args);
 }
 
-const TIMEOUT_ERROR_MESSAGE = 'Serial timed out';
 
 // An LTE device may take up to 18 seconds to power up the modem
 const MODULE_INFO_COMMAND_TIMEOUT = 20000;
@@ -617,7 +617,7 @@ module.exports = class SerialCommand {
 				return !!matches;
 			})
 			.catch((err) => {
-				if (err !== TIMEOUT_ERROR_MESSAGE){
+				if (err !== timeoutError){
 					throw err;
 				}
 				return false;
@@ -898,7 +898,7 @@ module.exports = class SerialCommand {
 			}
 
 			function startTimeout(to){
-				self._serialTimeout = setTimeout(() => reject(TIMEOUT_ERROR_MESSAGE), to);
+				self._serialTimeout = setTimeout(() => reject(timeoutError), to);
 			}
 
 			function resetTimeout(){
@@ -1228,7 +1228,7 @@ module.exports = class SerialCommand {
 				reject('Serial port closed early');
 			}
 
-			function startTimeout(to, message = TIMEOUT_ERROR_MESSAGE){
+			function startTimeout(to, message = timeoutError){
 				self._serialTimeout = setTimeout(() => {
 					reject(message);
 				}, to);
@@ -1319,7 +1319,7 @@ module.exports = class SerialCommand {
 			serialPort.pipe(parser);
 
 			const failTimer = setTimeout(() => {
-				reject(TIMEOUT_ERROR_MESSAGE);
+				reject(timeoutError);
 			}, failDelay);
 
 			parser.on('data', (data) => {

--- a/src/cmd/serial.test.js
+++ b/src/cmd/serial.test.js
@@ -79,7 +79,6 @@ describe('Serial Command', () => {
 
 			serial.serialPort = mockSerial;
 
-
 			let error;
 
 			try {

--- a/src/cmd/serial.test.js
+++ b/src/cmd/serial.test.js
@@ -69,6 +69,8 @@ describe('Serial Command', () => {
 			const mockSerial = new MockSerial();
 			serial.serialPort = mockSerial;
 			const wifiPromise = serial._serialWifiConfig(device);
+			// This allows _serialWifiConfig's internal promises to run and try to
+			// connect to the serial device before moving time forward.
 			process.nextTick(() => {
 				clock.tick(5010);
 			});

--- a/test/__mocks__/serial.mock.js
+++ b/test/__mocks__/serial.mock.js
@@ -15,7 +15,7 @@ MockSerial.prototype.write = function write(chunk) {
 	this.data += chunk;
 };
 
-MockSerial.prototype.drain = function drain(cb) {
+MockSerial.prototype.drain = function drain(cb = () => {}) {
 	this.emit('drain');
 	process.nextTick(cb);
 };


### PR DESCRIPTION
## Description

Previously when `particle serial wifi` was used and the device wasn't put in listening mode ahead of time, the command would appear to hang, forcing the user to ctrl+c or otherwise kill the process.

This patch adds the missing timeout, and adds the first tests around the `SerialCommand`'s wifi handling. 


## How to Test

`src/cmd/serial.test.js` contains automated testing for this.

### Manual testing instructions:

1. Have no devices plugged into your machine.
2. Plug in device with wifi such as a Photon and wait for it to boot to breathing cyan
3. Run `particle serial wifi` and answer no to the scan question.
4. Without patch: this would wait forever, with patch after 5s you should get a message suggesting you try `particle usb start-listening`.


## Related Issues / Discussions

This is related to, but does not solve this clubhouse ticket: https://app.clubhouse.io/particle/story/37086

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [ ] Docs have been updated
- [x] CI is passing

