### PR TITLE
Fix UI spinner stopping immediately

### DIFF
--- a/src/app/ui.js
+++ b/src/app/ui.js
@@ -24,12 +24,8 @@ module.exports.spin = async (promise, str) => {
 		return promise;
 	}
 
-	try {
-		spinner = new Spinner(str);
-		spinner.start();
-		return promise;
-	} finally {
-		spinner.stop(true);
-	}
+	spinner = new Spinner(str);
+	spinner.start();
+	return promise.finally(() => spinner.stop(true));
 };
 


### PR DESCRIPTION
## Description

Commands like `particle mesh` and `particle usb` often include a terminal spinner, that spinner was not moving. This patch fixes that by changing the call to `spinner.stop` to be asynchronous. I opted to not include a test as this is a minor UI feature

## How to Test

1. Hook up a device
2. `particle usb reset`
3. observe spinner being awesome

## Related Issues / Discussions

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [x] CI is passing

