### PR TITLE
Add aliases for usb mode change commands

### DIFF
--- a/src/cli/usb.js
+++ b/src/cli/usb.js
@@ -35,7 +35,7 @@ module.exports = ({ commandProcessor, root }) => {
 		}
 	};
 
-	commandProcessor.createCommand(usb, 'start-listening', 'Put a device into the listening mode', {
+	const startListeningOptions = {
 		params: '[devices...]',
 		options: commonOptions,
 		examples: {
@@ -45,7 +45,10 @@ module.exports = ({ commandProcessor, root }) => {
 		handler: (args) => {
 			return usbCommand().startListening(args);
 		}
-	});
+	};
+
+	commandProcessor.createCommand(usb, 'start-listening', 'Put a device into the listening mode', startListeningOptions);
+	commandProcessor.createCommand(usb, 'listen', 'alias for start-listening', startListeningOptions);
 
 	commandProcessor.createCommand(usb, 'stop-listening', 'Make a device exit the listening mode', {
 		params: '[devices...]',

--- a/test/e2e/help.e2e.js
+++ b/test/e2e/help.e2e.js
@@ -60,7 +60,7 @@ describe('Help & Unknown Command / Argument Handling', () => {
 		'serial mac', 'serial inspect', 'serial flash', 'serial claim',
 		'serial', 'setup', 'subscribe', 'token list', 'token revoke',
 		'token create', 'token', 'udp send', 'udp listen', 'udp', 'update',
-		'update-cli', 'usb list', 'usb start-listening', 'usb stop-listening',
+		'update-cli', 'usb list', 'usb start-listening', 'usb listen', 'usb stop-listening',
 		'usb safe-mode', 'usb dfu', 'usb reset', 'usb configure', 'usb',
 		'variable list', 'variable get', 'variable monitor', 'variable',
 		'webhook create', 'webhook list', 'webhook delete', 'webhook POST',


### PR DESCRIPTION
## Description

This is a quality of life improvement. The `particle usb start-listening` command is long. I'd prefer typing `particle usb listen`.

I considered adding single letter aliases for all mode change commands like `particle usb l` (listen), `particle usb x` (exit listening), `particle usb s` (safe mode), `particle usb d` (dfu), `particle usb r` (reset) but that seemed excessive.

## How to Test

- Connect a device
- Run `particle usb l` to enter listening mode

## Related Issues / Discussions

This alias should be documented here: https://github.com/particle-iot/docs/blob/master/src/content/reference/developer-tools/cli.md#particle-usb

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing