### PR TITLE
feature/library-json

### DIFF
--- a/src/app/command-processor.js
+++ b/src/app/command-processor.js
@@ -105,7 +105,7 @@ class CLICommandItem {
 	 * @param {function} version    A function to retrieve the version
 	 * @param {string} epilogue     Printed at the end of the command block.
 	 */
-	configure(yargs, { options, setup, examples, version, epilogue }=this.buildOptions()){
+	configure(yargs, { options, setup, examples, version, epilogue } = this.buildOptions()){
 		if (options){
 			this.fetchAliases(options);
 			this.configureOptions(options);

--- a/src/app/command-processor.js
+++ b/src/app/command-processor.js
@@ -27,8 +27,8 @@ const yargsFactory = require('yargs/yargs');
 const Yargs = yargsFactory(process.argv.slice(2), path.resolve(__dirname, '../..'));
 Yargs.$0 = 'particle';
 
-class CLICommandItem {
 
+class CLICommandItem {
 	/**
 	 * Constructor.
 	 * @param {string} name             The name of the command. This is the text the command is recognized by.
@@ -39,8 +39,8 @@ class CLICommandItem {
 	 *  - examples: an object of examples to add to yargs (key is the command, value is the description)
 	 *  - version: the version function to pass to yargs
 	 */
-	constructor(name, description = '', options = {}) {
-		if (!name) {
+	constructor(name, description = '', options = {}){
+		if (!name){
 			throw Error('name must be defined');
 		}
 		this.commands = {};
@@ -54,7 +54,7 @@ class CLICommandItem {
 	 * In cases where a command has an alias, this returns the canonical form of the command.
 	 * @returns {Array<String>} The command path as an array of simple names.
 	 */
-	get path() {
+	get path(){
 		return this.parent
 			? this.parent.path.concat([this.name])
 			: [this.name];
@@ -65,7 +65,7 @@ class CLICommandItem {
 	 * @param {string} name  The name of the sub item to retrieve.
 	 * @returns {CLICommandItem} A command item matching the name, or `undefined` if the named item doesn't exist.
 	 */
-	item(name) {
+	item(name){
 		return this.commands[name];
 	}
 
@@ -74,8 +74,8 @@ class CLICommandItem {
 	 * @param {Array<string>} path  The command path to find from this command
 	 * @returns {CliCommandItem}  the item found at the path or undefined
 	 */
-	find(path) {
-		if (!path || !path.length) {
+	find(path){
+		if (!path || !path.length){
 			return this;
 		}
 		const name = path[0];
@@ -89,7 +89,7 @@ class CLICommandItem {
 	 * @param {CLICommandItem} item     the command to add.
 	 * @returns {CLICommandItem} this
 	 */
-	addItem(item) {
+	addItem(item){
 		this.commands[item.name] = item;
 		item.parent = this;
 		return this;
@@ -105,8 +105,8 @@ class CLICommandItem {
 	 * @param {function} version    A function to retrieve the version
 	 * @param {string} epilogue     Printed at the end of the command block.
 	 */
-	configure(yargs, { options, setup, examples, version, epilogue }=this.buildOptions()) {
-		if (options) {
+	configure(yargs, { options, setup, examples, version, epilogue }=this.buildOptions()){
+		if (options){
 			this.fetchAliases(options);
 			this.configureOptions(options);
 			// avoid converting positional arguments to numbers by default
@@ -114,45 +114,46 @@ class CLICommandItem {
 			yargs.options(optionsWithDefaults);
 		}
 
-		if (setup) {
+		if (setup){
 			setup(yargs, this);
 		}
 
-		if (examples) {
+		if (examples){
 			const command = this.path.join(' ');
 			Object.keys(examples).forEach(cmd => {
 				yargs.example(cmd.replace(/\$command/, command), examples[cmd]);
 			});
 		}
 
-		if (version) {
+		if (version){
 			this.version = version;
 		}
 
-		if (epilogue) {
+		if (epilogue){
 			yargs.epilogue(epilogue);
 		}
 
 		yargs.exitProcess(false);
 	}
 
-	fetchAliases(options) {
+	fetchAliases(options){
 		Object.keys(options).forEach((key) => {
 			const option = options[key];
 			const alias = option.alias;
-			if (alias) {
+			if (alias){
 				this.aliases[alias] = key;
 			}
 		});
 	}
 
-	configureOptions(options) {
+	configureOptions(options){
 		Object.keys(options).forEach((key) => {
 			const option = options[key];
+
 			if (!option.hasOwnProperty('nargs') &&
 				!option.boolean &&
 				!option.count &&
-				!option.array) {
+				!option.array){
 				option.nargs = 1;
 			}
 
@@ -160,7 +161,7 @@ class CLICommandItem {
 				!option.hasOwnProperty('boolean') &&
 				!option.hasOwnProperty('string') &&
 				!option.hasOwnProperty('count') &&
-				!option.hasOwnProperty('array')) {
+				!option.hasOwnProperty('array')){
 				option.string = true;
 			}
 		});
@@ -171,7 +172,7 @@ class CLICommandItem {
 	 * @param {string} name The option name to unalias.
 	 * @returns {string} The original option name
 	 */
-	unaliasOption(name) {
+	unaliasOption(name){
 		return this.aliases[name] || (this.parent ? this.parent.unaliasOption(name) : undefined);
 	}
 
@@ -183,9 +184,8 @@ class CLICommandItem {
 	 *  clierror: any errors produces (mutually exclusive with clicommand)
 	 *  *: properties corresponding to any options specified on the command line.
 	 */
-	parse(args, yargs) {
-
-		if (yargs===undefined) {
+	parse(args, yargs){
+		if (yargs === undefined){
 			yargs = Yargs;
 		}
 
@@ -195,12 +195,12 @@ class CLICommandItem {
 		});
 
 		const argv = this.configureAndParse(args, yargs);
-		if (!error) {
-			if (this.options.parsed) {
+
+		if (!error){
+			if (this.options.parsed){
 				this.options.parsed(argv);
 			}
-
-			if (this.matches(argv)) {
+			if (this.matches(argv)){
 				argv.clicommand = this;
 			}
 		} else {
@@ -210,27 +210,30 @@ class CLICommandItem {
 		return argv;
 	}
 
-	configureAndParse(args, yargs) {
+	configureAndParse(args, yargs){
 		this.configureParser(args, yargs);
 		return yargs.parse(args);
 	}
 
-	matches(argv) {
+	matches(argv){
 		return this.matchesArgs(argv._);
 	}
 
-	matchesArgs(args) {
-		if (!this.path.length) {
+	matchesArgs(args){
+		if (!this.path.length){
 			return !args.length;
 		}
 
 		// walk the argv matching each command in sequence
-		const last = args[args.length-1];
-		return this.matchesName(last) && (!this.parent || this.parent.matchesArgs(args.slice(0, args.length-1)));
+		const last = args[args.length - 1];
+		return this.matchesName(last) && (!this.parent || this.parent.matchesArgs(args.slice(0, args.length - 1)));
 	}
 
-	matchesName(name) {
-		return this.name===name || (this.options.alias && this.options.alias===name);
+	matchesName(name){
+		if (this.name === name){
+			return true;
+		}
+		return this.options.alias && this.options.alias === name;
 	}
 
 	/**
@@ -238,38 +241,39 @@ class CLICommandItem {
 	 * @param {object} argv  The parsed arguments for the cli command.
 	 * @returns {Promise} to run the comand
 	 */
-	exec(argv) {
-		if (this.options.handler) {
+	exec(argv){
+		if (this.options.handler){
 			return Promise.resolve().then(() => this.options.handler(argv));
-		} else if (argv.version && this.version) {
-			return Promise.resolve(this.version(argv));
-		} else {
-			return this.showHelp();
 		}
+		if (argv.version && this.version){
+			return Promise.resolve(this.version(argv));
+		}
+		return this.showHelp();
 	}
 
-	showHelp() {
+	showHelp(){
 		Yargs.showHelp();
 	}
 
-	addInheritedOptions(target) {
+	addInheritedOptions(target){
 		const parent = this.parent;
-		if (parent) {
+
+		if (parent){
 			parent.addInheritedOptions(target);
 		}
 		this.assign(target, this.inherited);
 	}
 
-	buildOptions() {
+	buildOptions(){
 		const target = {};
 		this.addInheritedOptions(target);
 		this.assign(target, this.options);
 		return target;
 	}
 
-	assign(target, value) {
-		if (value) {
-			// this is a dirty hack! for now, only merge the options
+	assign(target, value){
+		if (value){
+			// TODO (mirande): this is a dirty hack! for now, only merge the options
 			const options = target.options || {};
 			Object.assign(target, value);
 			target.options = Object.assign(options, value.options);
@@ -277,13 +281,14 @@ class CLICommandItem {
 	}
 }
 
+
 /**
  * Describes a container of commands, and whose path has a common prefix.
  * Uses the container pattern where child items can be further nested categories or
  * CLICommand instance.
  */
 class CLICommandCategory extends CLICommandItem {
-	constructor(name, description, options) {
+	constructor(name, description, options){
 		super(name, description, options);
 		this.parent = null;
 	}
@@ -295,10 +300,9 @@ class CLICommandCategory extends CLICommandItem {
 	 * @param {object} argv  the parsed yargs arguments
 	 * @returns {boolean} the validity of the check.
 	 */
-	check(yargs, argv) {
-
+	check(yargs, argv){
 		// ensure common prefix
-		if (!this.matches(argv)) {
+		if (!this.matches(argv)){
 			throw unknownCommandError(argv._, this);
 		}
 
@@ -308,28 +312,25 @@ class CLICommandCategory extends CLICommandItem {
 		// Additionally, `yargs.strict()` does not seem to handle pre-
 		// negated params like `--no-run`.
 		checkForUnknownArguments(yargs, argv, this);
-
 		return true;
 	}
 
-	get commandNames() {
+	get commandNames(){
 		return Object.keys(this.commands);
 	}
 
-	configureParser(args, yargs) {
-
+	configureParser(args, yargs){
 		this.configure(yargs);
-
 		// add the subcommands of this category
 		this.commandNames.forEach((commandName) => {
 			const command = this.commands[commandName];
-
 			const builder = (yargs) => {
 				return { argv: command.parse(args, yargs) };
 			};
 
 			yargs.command(command.name, command.description, builder);
-			if (command.options && command.options.alias) {
+
+			if (command.options && command.options.alias){
 				// hidden command
 				yargs.command(command.options.alias, false, builder);
 			}
@@ -345,39 +346,37 @@ class CLICommandCategory extends CLICommandItem {
 	}
 }
 
+
 class CLIRootCategory extends CLICommandCategory {
-	constructor(options) {
+	constructor(options){
 		super('$0', options && options.description, options);
 	}
 
-	get path() {
+	get path(){
 		return [];
 	}
 
-	get commandNames() {
+	get commandNames(){
 		return super.commandNames.sort();
 	}
-
 }
+
 
 class CLICommand extends CLICommandItem {
 	/**
 	 * @param {string} name The invocation name of the command on the command line
 	 * @param {string} description Description of the command. Used to produce help text.
 	 * @param {object} options  In addition to attributes defined by the base class:
- 	 *  - params: the positional arguments in this format: <required> [optional] <rest...>
+	 *  - params: the positional arguments in this format: <required> [optional] <rest...>
 	 *  - handler: the function that is invoked with `this` and the parsed commandline.
 	 */
-	constructor(name, description, options) {
-		super(name, description, _.defaultsDeep(options || {}, {
-			params: '',
-		}));
+	constructor(name, description, options){
+		super(name, description, _.defaultsDeep(options || {}, { params: '' }));
 		this.name = name || '$0';
 		this.parent = null;
 	}
 
-	configureParser(args, yargs) {
-
+	configureParser(args, yargs){
 		this.configure(yargs);
 
 		yargs
@@ -388,9 +387,7 @@ class CLICommand extends CLICommandItem {
 				// Additionally, `yargs.strict()` does not seem to handle pre-
 				// negated params like `--no-run`.
 				checkForUnknownArguments(yargs, argv, this);
-
 				parseParams(yargs, argv, this.path, this.options.params);
-
 				return true;
 			})
 			.usage((this.description ? this.description + '\n' : '')
@@ -401,52 +398,54 @@ class CLICommand extends CLICommandItem {
 	}
 }
 
+
 /**
  * Creates an error handler. The handler displays the error message if there is one,
  * or displays the help if there ie no error or it is a usage error.
  * @param {object} yargs
  * @returns {function(err)} the error handler function
  */
-function createErrorHandler(yargs) {
-	if (!yargs) {
+function createErrorHandler(yargs){
+	if (!yargs){
 		yargs = Yargs;
 	}
 	return consoleErrorLogger.bind(undefined, console, yargs, true);
 }
 
-function stringify(err) {
+function stringify(err){
 	return _.isString(err) ? err : util.inspect(err);
 }
 
 /**
  * Logs an error to the console given and optionally calls yargs.showHelp() if the
  * error is a usage error.
- * @param {object} console   The console to log to.
+ * @param {object} console  the console to log to.
  * @param {Yargs} yargs     the yargs instance
- * @param {boolean} exit     if true, process.exit() is called.
- * @param {object} err      The error to log. If it has a `message` property, that is logged, otherwise
+ * @param {boolean} exit    if true, process.exit() is called.
+ * @param {object} error    the error to log. If it has a `message` property, that is logged, otherwise
  *  the error is converted to a string by calling `stringify(err)`.
  */
-function consoleErrorLogger(console, yargs, exit, err) {
-	const usage = (!err || err.isUsageError);
-	if (usage) {
+function consoleErrorLogger(console, yargs, exit, error){
+	const usage = (!error || error.isUsageError);
+
+	if (usage){
 		yargs.showHelp();
 	}
 
-	if (err) {
-		console.log(chalk.red(err.message || stringify(err)));
+	if (error){
+		console.log(chalk.red(error.message || stringify(error)));
 	}
-	if (!usage && (err.stack && ((global.verboseLevel || 0)>1))) {
-		console.log(VError.fullStack(err));
+	if (!usage && (error.stack && ((global.verboseLevel || 0) > 1))){
+		console.log(VError.fullStack(error));
 	}
-	// todo - try to find a more controllable way to singal an error - this isn't easily testable.
-	if (exit) {
+	// TODO (mirande): try to find a more controllable way to singal an error - this isn't easily testable.
+	if (exit){
 		process.exit(1);
 	}
 }
 
 // Adapted from: https://github.com/bcoe/yargs/blob/master/lib/validation.js#L83-L110
-function checkForUnknownArguments(yargs, argv, command) {
+function checkForUnknownArguments(yargs, argv, command){
 	const aliasLookup = {};
 	const flags = yargs.getOptions().key;
 	const demanded = yargs.getDemanded();
@@ -458,7 +457,7 @@ function checkForUnknownArguments(yargs, argv, command) {
 		});
 	});
 
-	function isUnknown(key) {
+	function isUnknown(key){
 		return (key !== '$0' && key !== '_' && key !== 'params' &&
 			!demanded.hasOwnProperty(key) &&
 			!flags.hasOwnProperty(key) &&
@@ -466,18 +465,18 @@ function checkForUnknownArguments(yargs, argv, command) {
 			!aliasLookup.hasOwnProperty(key));
 	}
 
-	function aliasFor(key) {
+	function aliasFor(key){
 		return command.unaliasOption(key);
 	}
 
 	Object.keys(argv).forEach((key) => {
 		const alias = aliasFor(key);
-		if (isUnknown(key) && (!alias || isUnknown(alias))) {
+		if (isUnknown(key) && (!alias || isUnknown(alias))){
 			unknown.push(key);
 		}
 	});
 
-	if (unknown.length) {
+	if (unknown.length){
 		throw unknownArgumentError(unknown);
 	}
 }
@@ -490,7 +489,7 @@ function checkForUnknownArguments(yargs, argv, command) {
  * @param {Array<String>} path     The command path the params apply to
  * @param {string} params   The params to parse.
  */
-function parseParams(yargs, argv, path, params) {
+function parseParams(yargs, argv, path, params){
 	let required = 0;
 	let optional = 0;
 	let variadic = false;
@@ -501,57 +500,59 @@ function parseParams(yargs, argv, path, params) {
 
 	argv._ = argv._.slice(0, path.length);
 
-	params.replace(/(<[^>]+>|\[[^\]]+\])/g,
-		(match) => {
-			if (variadic) {
-				throw variadicParameterPositionError(variadic);
-			}
+	params.replace(/(<[^>]+>|\[[^\]]+\])/g, (match) => {
+		if (variadic){
+			throw variadicParameterPositionError(variadic);
+		}
 
-			const isRequired = match[0] === '<';
-			const param = match
-				.slice(1, -1)
-				.replace(/(.*)\.\.\.$/, (m, param) => {
-					variadic = true;
-					return param;
-				});
-			let value;
-			if (isRequired) {
-				required++;
-			} else {
-				optional++;
-			}
-
-			if (variadic) {
-				variadic = param; // save the name
-				value = extra.slice(-1 + required + optional).map(String);
-
-				if (isRequired && !value.length) {
-					throw variadicParameterRequiredError(param);
-				}
-			} else {
-				if (isRequired && optional > 0) {
-					throw requiredParameterPositionError(param);
-				}
-
-				value = extra[-1 + required + optional];
-
-				if (value) {
-					value = String(value);
-				}
-
-				if (isRequired && typeof value === 'undefined') {
-					throw requiredParameterError(param);
-				}
-			}
-
-			const params = param.split('|');
-			params.forEach(p => {
-				argv.params[p] = value;
+		const isRequired = match[0] === '<';
+		const param = match
+			.slice(1, -1)
+			.replace(/(.*)\.\.\.$/, (m, param) => {
+				variadic = true;
+				return param;
 			});
-		});
 
-	if (!variadic && required+optional < extra.length) {
-		throw unknownParametersError(extra.slice(required+optional));
+		if (isRequired){
+			required++;
+		} else {
+			optional++;
+		}
+
+		let value;
+
+		if (variadic){
+			variadic = param; // save the name
+			value = extra.slice(-1 + required + optional).map(String);
+
+			if (isRequired && !value.length){
+				throw variadicParameterRequiredError(param);
+			}
+		} else {
+			if (isRequired && optional > 0){
+				throw requiredParameterPositionError(param);
+			}
+
+			value = extra[-1 + required + optional];
+
+			if (value){
+				value = String(value);
+			}
+
+			if (isRequired && typeof value === 'undefined'){
+				throw requiredParameterError(param);
+			}
+		}
+
+		const params = param.split('|');
+
+		params.forEach(p => {
+			argv.params[p] = value;
+		});
+	});
+
+	if (!variadic && required+optional < extra.length){
+		throw unknownParametersError(extra.slice(required + optional));
 	}
 }
 
@@ -559,12 +560,12 @@ function parseParams(yargs, argv, path, params) {
  * @param {object} options
  * @returns {CLIRootCategory} The root category for the app command line args.
  */
-function createAppCategory(options) {
+function createAppCategory(options){
 	return new CLIRootCategory(options);
 }
 
-function createCategory(parent, name, description, options) {
-	if (_.isObject(description)) {
+function createCategory(parent, name, description, options){
+	if (_.isObject(description)){
 		options = description;
 		description = '';
 	}
@@ -574,14 +575,14 @@ function createCategory(parent, name, description, options) {
 	return cat;
 }
 
-function createCommand(category, name, description, options) {
-	if (_.isObject(name)) {
+function createCommand(category, name, description, options){
+	if (_.isObject(name)){
 		options = name;
 		name = '$0';
 		description = '';
 	}
 
-	if (_.isObject(description)) {
+	if (_.isObject(description)){
 		options = description;
 		description = '';
 	}
@@ -599,13 +600,13 @@ function createCommand(category, name, description, options) {
  * Options/booleans are attributes of the object. The property `clicommand` contains the command corresponding
  * to the requested command. `clierror` contains any error encountered durng parsing.
  */
-function parse(command, args) {
+function parse(command, args){
 	Yargs.reset();
 	Yargs.wrap(Yargs.terminalWidth());
 	return command.parse(args, Yargs);
 }
 
-function baseError(message, data) {
+function baseError(message, data){
 	const error = new Error();
 	// yargs doesn't pass the full error if a message is defined, only the message
 	// since we need the full object, use an alias
@@ -614,7 +615,7 @@ function baseError(message, data) {
 	return error;
 }
 
-function usageError(message, data, type, item) {
+function usageError(message, data, type, item){
 	const error = baseError(message, data);
 	error.isUsageError = true;
 	error.type = type;
@@ -622,43 +623,72 @@ function usageError(message, data, type, item) {
 	return error;
 }
 
-function applicationError(message, data, type) {
+function applicationError(message, data, type){
 	const error = baseError(message, data);
 	error.isApplicationError = true;
 	error.type = type;
 	return error;
 }
 
-function unknownCommandError(command, item) {
+function unknownCommandError(command, item){
 	const commandString = command.join(' ');
-	return usageError(`No such command '${commandString}'`, command, unknownCommandError, item);
+	return usageError(
+		`No such command '${commandString}'`,
+		command,
+		unknownCommandError,
+		item
+	);
 }
 
-function unknownArgumentError(argument) {
+function unknownArgumentError(argument){
 	const argsString = argument.join(', ');
 	const s = argument.length > 1 ? 's' : '';
-	return usageError(`Unknown argument${s} '${argsString}'`, argument, unknownArgumentError);
+	return usageError(
+		`Unknown argument${s} '${argsString}'`,
+		argument,
+		unknownArgumentError
+	);
 }
 
-function requiredParameterError(param) {
-	return usageError(`Parameter '${param}' is required.`, param, requiredParameterError);
+function requiredParameterError(param){
+	return usageError(
+		`Parameter '${param}' is required.`,
+		param,
+		requiredParameterError
+	);
 }
 
-function variadicParameterRequiredError(param) {
-	return usageError(`Parameter '${param}' must have at least one item.`, param, variadicParameterRequiredError);
+function variadicParameterRequiredError(param){
+	return usageError(
+		`Parameter '${param}' must have at least one item.`,
+		param,
+		variadicParameterRequiredError
+	);
 }
 
-function variadicParameterPositionError(param) {
-	return applicationError(`Variadic parameter '${param}' must the final parameter.`, param, variadicParameterPositionError);
+function variadicParameterPositionError(param){
+	return applicationError(
+		`Variadic parameter '${param}' must the final parameter.`,
+		param,
+		variadicParameterPositionError
+	);
 }
 
-function requiredParameterPositionError(param) {
-	return applicationError(`Required parameter '${param}' must be placed before all optional parameters.`, param, requiredParameterPositionError);
+function requiredParameterPositionError(param){
+	return applicationError(
+		`Required parameter '${param}' must be placed before all optional parameters.`,
+		param,
+		requiredParameterPositionError
+	);
 }
 
-function unknownParametersError(params) {
+function unknownParametersError(params){
 	const paramsString = params.join(' ');
-	return usageError(`Command parameters '${paramsString}' are not expected here.`, params, unknownParametersError);
+	return usageError(
+		`Command parameters '${paramsString}' are not expected here.`,
+		params,
+		unknownParametersError
+	);
 }
 
 const errors = {
@@ -675,7 +705,7 @@ const test = {
 	consoleErrorLogger
 };
 
-function showHelp(cb) {
+function showHelp(cb){
 	Yargs.showHelp(cb);
 }
 
@@ -687,5 +717,5 @@ module.exports = {
 	createErrorHandler,
 	showHelp,
 	errors,
-	test,
+	test
 };

--- a/src/app/command-processor.js
+++ b/src/app/command-processor.js
@@ -22,6 +22,7 @@ const util = require('util');
 const chalk = require('chalk');
 const VError = require('verror');
 const yargsFactory = require('yargs/yargs');
+const { JSONErrorResult } = require('../lib/json-result');
 
 // It's important to run yargs in the directory of the script so it picks up options from package.json
 const Yargs = yargsFactory(process.argv.slice(2), path.resolve(__dirname, '../..'));
@@ -432,7 +433,7 @@ function consoleErrorLogger(console, yargs, exit, error){
 	if (error){
 		if (error.asJSON){
 			console.log(
-				serializeError(error)
+				new JSONErrorResult(error).toString()
 			);
 		} else {
 			console.log(
@@ -454,17 +455,6 @@ function consoleErrorLogger(console, yargs, exit, error){
 
 function stringify(err){
 	return _.isString(err) ? err : util.inspect(err);
-}
-
-function serializeError(error){
-	const names = Object.getOwnPropertyNames(error);
-	const out = {};
-
-	for (const name of names){
-		out[name] = error[name];
-	}
-
-	return JSON.stringify({ error: out }, null, 4);
 }
 
 // Adapted from: https://github.com/bcoe/yargs/blob/master/lib/validation.js#L83-L110

--- a/src/app/command-processor.test.js
+++ b/src/app/command-processor.test.js
@@ -443,11 +443,12 @@ describe('command-line parsing', () => {
 
 			const json = JSON.parse(fakeConsole.log.firstCall.args[0]);
 
-			expect(json).to.have.property('error').that.is.an('object');
-			expect(json.error).to.have.all.keys('message', 'stack', 'asJSON');
+			expect(json).to.have.all.keys('meta', 'error');
+			expect(json.meta).to.have.all.keys('version');
+			expect(json.meta.version).to.equal('1.0.0');
+			expect(json.error).to.have.all.keys('message', 'stack');
 			expect(json.error.message).to.equal('nope!');
 			expect(json.error).to.have.property('stack').that.is.a('string');
-			expect(json.error.asJSON).to.equal(true);
 		});
 
 		it('logs the stack trace to the console when verbose mode is enabled', () => {

--- a/src/app/command-processor.test.js
+++ b/src/app/command-processor.test.js
@@ -394,48 +394,51 @@ describe('command-line parsing', () => {
 
 	describe('consoleErrorLogger()', () => {
 		const { consoleErrorLogger } = commandProcessor.test;
-		let fakeConsole;
+		let fakeConsole, fakeYargs;
 
 		beforeEach(() => {
 			fakeConsole = { log: sandbox.stub() };
+			fakeYargs = { showHelp: sandbox.stub() };
+		});
+
+		afterEach(() => {
+			sandbox.restore();
 		});
 
 		it('calls yargs.showHelp if the error is falsey', () => {
-			const yargs = { showHelp: sinon.stub() };
 			const error = '';
-			consoleErrorLogger(fakeConsole, yargs, false, error);
-			expect(yargs.showHelp).to.have.been.calledOnce;
+			consoleErrorLogger(fakeConsole, fakeYargs, false, error);
+			expect(fakeYargs.showHelp).to.have.property('callCount', 1);
 		});
 
 		it('calls yargs.showHelp if the error is a usage error', () => {
-			const yargs = { showHelp: sinon.stub() };
 			const error = { isUsageError: true };
-			consoleErrorLogger(fakeConsole, yargs, false, error);
-			expect(yargs.showHelp).to.have.been.calledOnce;
+			consoleErrorLogger(fakeConsole, fakeYargs, false, error);
+			expect(fakeYargs.showHelp).to.have.property('callCount', 1);
 		});
 
 		it('logs the error message to the console', () => {
-			const yargs = { };
 			const message = 'we come in peace';
 			const error = { message };
-			consoleErrorLogger(fakeConsole, yargs, false, error);
+			consoleErrorLogger(fakeConsole, fakeYargs, false, error);
 			expect(fakeConsole.log).to.have.been.calledWithMatch(message);
+			expect(fakeYargs.showHelp).to.have.property('callCount', 0);
 		});
 
 		it('logs the error to the console when no message is given', () => {
-			const yargs = { };
 			const error = { bass: 'ice ice baby' };
-			consoleErrorLogger(fakeConsole, yargs, false, error);
+			consoleErrorLogger(fakeConsole, fakeYargs, false, error);
 			expect(fakeConsole.log).to.have.been.calledWithMatch('{ bass: \'ice ice baby\' }');
+			expect(fakeYargs.showHelp).to.have.property('callCount', 0);
 		});
 
 		it('logs the error as JSON when `asJSON` field is true', () => {
-			const yargs = { };
 			const error = new Error('nope!');
 			error.asJSON = true;
 
-			consoleErrorLogger(fakeConsole, yargs, false, error);
+			consoleErrorLogger(fakeConsole, fakeYargs, false, error);
 
+			expect(fakeYargs.showHelp).to.have.property('callCount', 0);
 			expect(fakeConsole.log).to.have.property('callCount', 1);
 
 			const json = JSON.parse(fakeConsole.log.firstCall.args[0]);
@@ -464,9 +467,9 @@ describe('command-line parsing', () => {
 
 		it('does not log the stack for usage errors.', () => {
 			const error = { stack: '1\n2\n3', isUsageError:true, message: 'hey' };
-			const yargs = { showHelp: sinon.stub() };
-			consoleErrorLogger(fakeConsole, yargs, false, error);
+			consoleErrorLogger(fakeConsole, fakeYargs, false, error);
 			expect(fakeConsole.log).to.have.been.calledWithMatch('hey').and.calledOnce;
+			expect(fakeYargs.showHelp).to.have.property('callCount', 1);
 		});
 	});
 

--- a/src/app/command-processor.test.js
+++ b/src/app/command-processor.test.js
@@ -52,8 +52,8 @@ describe('command-line parsing', () => {
 			expect(result.type).to.be.equal(commandProcessor.errors.unknownArgumentError);
 		});
 
-		const param = 'param';
 		it('variadic parameter position', () => {
+			const param = 'param';
 			const result = commandProcessor.errors.variadicParameterPositionError(param);
 			expect(result.data).to.be.equal(param);
 			expect(result.message).to.be.equal('Variadic parameter \'param\' must the final parameter.');
@@ -62,6 +62,7 @@ describe('command-line parsing', () => {
 		});
 
 		it('optional parameter position', () => {
+			const param = 'param';
 			const result = commandProcessor.errors.requiredParameterPositionError(param);
 			expect(result.data).to.be.equal(param);
 			expect(result.message).to.be.equal('Required parameter \'param\' must be placed before all optional parameters.');
@@ -70,6 +71,7 @@ describe('command-line parsing', () => {
 		});
 
 		it('parameter required', () => {
+			const param = 'param';
 			const result = commandProcessor.errors.requiredParameterError(param);
 			expect(result.data).to.be.equal(param);
 			expect(result.message).to.be.equal('Parameter \'param\' is required.');
@@ -78,6 +80,7 @@ describe('command-line parsing', () => {
 		});
 
 		it('variadic parameter required', () => {
+			const param = 'param';
 			const result = commandProcessor.errors.variadicParameterRequiredError(param);
 			expect(result.data).to.be.equal(param);
 			expect(result.message).to.be.equal('Parameter \'param\' must have at least one item.');
@@ -236,9 +239,9 @@ describe('command-line parsing', () => {
 				}
 			});
 			const result = commandProcessor.parse(app, ['cmd'].concat(args));
+
 			// only one of them set
 			expect(result.clicommand || result.clierror).to.be.ok;
-
 			expect(result.clicommand && result.clierror).to.be.not.ok;
 			if (result.clicommand) {
 				expect(result.clicommand).to.be.equal(cmd);
@@ -267,7 +270,6 @@ describe('command-line parsing', () => {
 		it('rejects varadic parameters not in final position', () => {
 			const argv = paramsCommand('[a] [b...] [c]', ['1','2', '3']);
 			const error = commandProcessor.errors.variadicParameterPositionError('b');
-
 			expect(argv.clicommand).to.equal(undefined);
 			expectCLIError(argv.clierror, error);
 		});
@@ -275,7 +277,6 @@ describe('command-line parsing', () => {
 		it('rejects omitted required varadic parameters', () => {
 			const argv = paramsCommand('[a] <b...>', ['1']);
 			const error = commandProcessor.errors.variadicParameterRequiredError('b');
-
 			expect(argv.clicommand).to.equal(undefined);
 			expectCLIError(argv.clierror, error);
 		});
@@ -283,7 +284,6 @@ describe('command-line parsing', () => {
 		it('rejects omitted required parameters', () => {
 			const argv = paramsCommand('<a> <b>', ['1']);
 			const error = commandProcessor.errors.requiredParameterError('b');
-
 			expect(argv.clicommand).to.equal(undefined);
 			expectCLIError(argv.clierror, error);
 		});
@@ -291,7 +291,6 @@ describe('command-line parsing', () => {
 		it('rejects required parameters after optional parameters', () => {
 			const argv = paramsCommand('[a] <b>', ['1']);
 			const error = commandProcessor.errors.requiredParameterPositionError('b');
-
 			expect(argv.clicommand).to.equal(undefined);
 			expectCLIError(argv.clierror, error);
 		});
@@ -317,7 +316,6 @@ describe('command-line parsing', () => {
 		it('rejects commands with unfilled required parameters', () => {
 			const argv = paramsCommand('<a> <b>', ['1']);
 			const error = commandProcessor.errors.requiredParameterError('b');
-
 			expect(argv.clicommand).to.equal(undefined);
 			expectCLIError(argv.clierror, error);
 		});
@@ -346,7 +344,6 @@ describe('command-line parsing', () => {
 		it('rejects parameterized command with surplus arguments', () => {
 			const argv = paramsCommand('[a]', ['hey', 'there', 'you']);
 			const error = commandProcessor.errors.unknownParametersError(['there', 'you']);
-
 			expect(argv.clicommand).to.equal(undefined);
 			expectCLIError(argv.clierror, error);
 		});
@@ -394,7 +391,6 @@ describe('command-line parsing', () => {
 	});
 
 	describe('consoleErrorHandler', () => {
-
 		it('calls yargs.showHelp if the error is falsey', () => {
 			const yargs = { showHelp: sinon.stub() };
 			const error = '';
@@ -450,7 +446,6 @@ describe('command-line parsing', () => {
 			expect(console.log).to.have.been.calledWithMatch('hey').and.calledOnce;
 		});
 	});
-
 
 	describe('CLICommand', () => {
 		function assertCanSetDescription(desc) {

--- a/src/cli/library.js
+++ b/src/cli/library.js
@@ -150,8 +150,12 @@ module.exports = ({ commandProcessor, root }) => {
 			'header': {
 				boolean: true,
 				description: 'display the main header file for the library'
+			},
+			// TODO (mirande): should be a global flag supported by all commands
+			'json': {
+				boolean: true,
+				description: 'output in JSON format instead of human friendly'
 			}
-
 		},
 		params: '<name>',
 		handler: (...args) => require('./library_view').command(api(), ...args)

--- a/src/cli/library.js
+++ b/src/cli/library.js
@@ -107,6 +107,13 @@ module.exports = ({ commandProcessor, root }) => {
 
 	commandProcessor.createCommand(lib, 'search', 'Search available libraries', {
 		params: '<name>',
+		options: {
+			// TODO (mirande): should be a global flag supported by all commands
+			'json': {
+				boolean: true,
+				description: 'output in JSON format instead of human friendly'
+			}
+		},
 		handler: (...args) => require('./library_search').command(api(), ...args)
 	});
 

--- a/src/cli/library.js
+++ b/src/cli/library.js
@@ -85,7 +85,7 @@ module.exports = ({ commandProcessor, root }) => {
 			// TODO (mirande): should be a global flag supported by all commands
 			'json': {
 				boolean: true,
-				description: 'output in JSON format instead of human friendly'
+				description: 'output JSON formatted data [experimental]'
 			}
 		},
 		params: '[sections...]',
@@ -116,7 +116,7 @@ module.exports = ({ commandProcessor, root }) => {
 			// TODO (mirande): should be a global flag supported by all commands
 			'json': {
 				boolean: true,
-				description: 'output in JSON format instead of human friendly'
+				description: 'output JSON formatted data [experimental]'
 			}
 		},
 		handler: (...args) => require('./library_search').command(api(), ...args)
@@ -154,7 +154,7 @@ module.exports = ({ commandProcessor, root }) => {
 			// TODO (mirande): should be a global flag supported by all commands
 			'json': {
 				boolean: true,
-				description: 'output in JSON format instead of human friendly'
+				description: 'output JSON formatted data [experimental]'
 			}
 		},
 		params: '<name>',

--- a/src/cli/library.js
+++ b/src/cli/library.js
@@ -81,6 +81,11 @@ module.exports = ({ commandProcessor, root }) => {
 			'limit': {
 				number: true,
 				description: 'The number of items to show per page'
+			},
+			// TODO (mirande): should be a global flag supported by all commands
+			'json': {
+				boolean: true,
+				description: 'output in JSON format instead of human friendly'
 			}
 		},
 		params: '[sections...]',

--- a/src/cli/library_install.js
+++ b/src/cli/library_install.js
@@ -46,15 +46,24 @@ class CLILibraryInstallCommandSite extends LibraryInstallCommandSite {
 	}
 
 	async notifyCheckingLibrary(libName){
+		if (this.argv.json){
+			return;
+		}
 		return console.log(`Checking library ${chalk.green(libName)}...`);
 	}
 
 	async notifyFetchingLibrary(lib, targetDir){
+		if (this.argv.json){
+			return;
+		}
 		const dest = ` to ${targetDir}`;
 		return console.log(`Installing library ${chalk.blue(lib.name)} ${lib.version}${dest} ...`);
 	}
 
 	async notifyInstalledLibrary(lib){
+		if (this.argv.json){
+			return;
+		}
 		return console.log(`Library ${chalk.blue(lib.name)} ${lib.version} installed.`);
 	}
 }

--- a/src/cli/library_list.js
+++ b/src/cli/library_list.js
@@ -5,6 +5,7 @@ const { convertApiError } = require('../cmd/api');
 const { buildAPIClient } = require('./apiclient');
 const { formatLibrary } = require('./library_ui');
 const { LibraryListCommand, LibraryListCommandSite } = require('../cmd');
+const { JSONResult } = require('../lib/json-result');
 
 
 class CLILibraryListCommandSite extends LibraryListCommandSite {
@@ -114,16 +115,15 @@ class CLILibraryListCommandSite extends LibraryListCommandSite {
 				const sections = this.sectionNames();
 
 				if (json){
-					const meta = { previous: page - 1, current: page, next: page + 1 };
-					let out = { meta, data: [] };
+					let data = [];
 					for (let name of sections){
 						const list = results[name];
 						if (list){
-							out.data.push(...list);
+							data.push(...list);
 						}
 					}
 					return console.log(
-						JSON.stringify(out, null, 4)
+						this.createJSONResult(page, data)
 					);
 				}
 
@@ -140,6 +140,11 @@ class CLILibraryListCommandSite extends LibraryListCommandSite {
 				}
 				return results;
 			});
+	}
+
+	createJSONResult(page, data){
+		const meta = { previous: page - 1, current: page, next: page + 1 };
+		return new JSONResult(meta, data).toString();
 	}
 
 	printSection(name, section, libraries) {

--- a/src/cli/library_list.js
+++ b/src/cli/library_list.js
@@ -107,7 +107,7 @@ class CLILibraryListCommandSite extends LibraryListCommandSite {
 
 	notifyFetchLists(promise) {
 		const { json } = this.argv;
-		const page = this._page || 0;
+		const page = this._page || 1;
 		const msg = page === 1 ? 'Searching for libraries...' : `Retrieving libraries page ${page}`;
 
 		return (json ? promise : spin(promise, msg))

--- a/src/cli/library_search.js
+++ b/src/cli/library_search.js
@@ -22,20 +22,32 @@ class CLILibrarySearchCommandSite extends LibrarySearchCommandSite {
 	}
 
 	notifyListLibrariesStart(promise, filter) {
+		const { json } = this.argv;
+
+		if (json){
+			return promise;
+		}
 		return spin(promise, `Searching for libraries matching ${chalk.green(filter)}`);
 	}
 
 	notifyListLibrariesComplete(promise, filter, libraries, error) {
-		if (error) {
-			log.error(error);
-		} else {
-			const count = libraries ? libraries.length : 0;
-			const library = count===1 ? 'library' : 'libraries';
-			log.success(`Found ${count} ${library} matching ${chalk.green(filter)}`);
-			for (let idx in libraries) {
-				const lib = libraries[idx];
-				console.log(formatLibrary(lib));
-			}
+		const { json } = this.argv;
+
+		if (error){
+			throw error;
+		}
+
+		if (json){
+			const out = createJSONOutput(filter, libraries);
+			return console.log(out);
+		}
+
+		const count = libraries ? libraries.length : 0;
+		const library = count === 1 ? 'library' : 'libraries';
+		log.success(`Found ${count} ${library} matching ${chalk.green(filter)}`);
+		for (let idx in libraries) {
+			const lib = libraries[idx];
+			console.log(formatLibrary(lib));
 		}
 	}
 }
@@ -45,6 +57,18 @@ module.exports.CLILibrarySearchCommandSite = CLILibrarySearchCommandSite;
 module.exports.command = (apiJS, argv) => {
 	const site = new CLILibrarySearchCommandSite(argv, buildAPIClient(apiJS));
 	const cmd = new LibrarySearchCommand();
-	return site.run(cmd);
+	return site.run(cmd)
+		.catch(error => {
+			error.asJSON = argv.json;
+			throw error;
+		});
 };
+
+
+// UTILS //////////////////////////////////////////////////////////////////////
+function createJSONOutput(filter, libraries){
+	const meta = { filter };
+	const out = { meta, data: libraries };
+	return JSON.stringify(out, null, 4);
+}
 

--- a/src/cli/library_search.js
+++ b/src/cli/library_search.js
@@ -4,6 +4,7 @@ const { spin } = require('../app/ui');
 const { buildAPIClient } = require('./apiclient');
 const { formatLibrary } = require('./library_ui');
 const { LibrarySearchCommandSite, LibrarySearchCommand } = require('../cmd');
+const { JSONResult } = require('../lib/json-result');
 
 
 class CLILibrarySearchCommandSite extends LibrarySearchCommandSite {
@@ -38,8 +39,9 @@ class CLILibrarySearchCommandSite extends LibrarySearchCommandSite {
 		}
 
 		if (json){
-			const out = createJSONOutput(filter, libraries);
-			return console.log(out);
+			return console.log(
+				this.createJSONResult(filter, libraries)
+			);
 		}
 
 		const count = libraries ? libraries.length : 0;
@@ -49,6 +51,10 @@ class CLILibrarySearchCommandSite extends LibrarySearchCommandSite {
 			const lib = libraries[idx];
 			console.log(formatLibrary(lib));
 		}
+	}
+
+	createJSONResult(filter, libraries){
+		return new JSONResult({ filter }, libraries).toString();
 	}
 }
 
@@ -63,12 +69,4 @@ module.exports.command = (apiJS, argv) => {
 			throw error;
 		});
 };
-
-
-// UTILS //////////////////////////////////////////////////////////////////////
-function createJSONOutput(filter, libraries){
-	const meta = { filter };
-	const out = { meta, data: libraries };
-	return JSON.stringify(out, null, 4);
-}
 

--- a/src/cli/library_view.js
+++ b/src/cli/library_view.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const { buildAPIClient } = require('./apiclient');
 const { LibraryInstallCommand } = require('../cmd');
 const { CLILibraryInstallCommandSite } = require('./library_install');
+const { JSONResult } = require('../lib/json-result');
 
 
 class CLILibraryViewCommandSite extends CLILibraryInstallCommandSite {
@@ -103,7 +104,7 @@ class CLILibraryViewCommandSite extends CLILibraryInstallCommandSite {
 	createJSONResult(content = null){
 		const data = Object.assign({ content }, this.metadata);
 		const meta = { filter: data.name, location: this.targetDir };
-		return JSON.stringify({ meta, data }, null, 4);
+		return new JSONResult(meta, data).toString();
 	}
 
 	loadFile(filename){

--- a/src/cli/library_view.js
+++ b/src/cli/library_view.js
@@ -25,41 +25,90 @@ class CLILibraryViewCommandSite extends CLILibraryInstallCommandSite {
 	}
 
 	view(){
-		if (this.argv.readme){
-			this.showFile('No readme files found for the library.', ['README.md', 'README.txt']);
+		const { readme, source, header, json } = this.argv;
+		const { name } = this.metadata;
+		const { targetDir } = this;
+
+		if (readme){
+			this.showFile(
+				'No readme files found for the library.',
+				[
+					path.join(targetDir, 'README.md'),
+					path.join(targetDir, 'README.txt')
+				]
+			);
 		}
 
-		if (this.argv.source){
-			this.showFile('No source files found for the library.', [path.join('src', this.metadata.name+'.cpp')]);
+		if (source){
+			this.showFile(
+				'No source files found for the library.',
+				[
+					path.join(targetDir, 'src', `${name}.cpp`)
+				]
+			);
 		}
 
-		if (this.argv.header){
-			this.showFile('No header files found for the library.', [path.join('src', this.metadata.name+'.h')]);
+		if (header){
+			this.showFile(
+				'No header files found for the library.',
+				[
+					path.join(targetDir, 'src', `${name}.h`)
+				]
+			);
 		}
 
-		console.log(`To view the library documentation and sources directly, please change to the directory ${chalk.bold(this.targetDir)}`);
+		if (json){
+			if (readme || source || header){
+				return;
+			}
+			return console.log(
+				this.createJSONResult()
+			);
+		}
+		console.log(`To view the library documentation and sources directly, please change to the directory ${chalk.bold(targetDir)}`);
 	}
 
-	showFile(missing, files){
+	showFile(missing, filenames){
+		const { json } = this.argv;
 		let shown = false;
-		for (let file of files){
-			const content = this.loadFile(file);
+
+		for (let filename of filenames){
+			const content = this.loadFile(filename);
+
 			if (content !== undefined){
-				console.log(content);
+				if (json){
+					console.log(
+						this.createJSONResult(content)
+					);
+				} else {
+					console.log(content);
+				}
+
 				shown = true;
 				break;
 			}
 		}
 
 		if (!shown){
-			console.log(missing);
+			if (json){
+				console.log(
+					this.createJSONResult()
+				);
+			} else {
+				console.log(missing);
+			}
 		}
 	}
 
-	loadFile(file){
-		const full = path.join(this.targetDir, file);
+	createJSONResult(content = null){
+		const data = Object.assign({ content }, this.metadata);
+		const meta = { filter: data.name, location: this.targetDir };
+		return JSON.stringify({ meta, data }, null, 4);
+	}
+
+	loadFile(filename){
 		try {
-			return fs.readFileSync(full, 'utf-8');
+			return fs.readFileSync(filename, 'utf-8');
 		} catch (error){
 			return undefined;
 		}
@@ -70,6 +119,11 @@ class CLILibraryViewCommandSite extends CLILibraryInstallCommandSite {
 module.exports.command = (apiJS, argv) => {
 	const site = new CLILibraryViewCommandSite(argv, process.cwd(), buildAPIClient(apiJS));
 	const cmd = new LibraryInstallCommand();
-	return site.run(cmd).then(() => site.view());
+	return site.run(cmd)
+		.then(() => site.view())
+		.catch(error => {
+			error.asJSON = argv.json;
+			throw error;
+		});
 };
 

--- a/src/lib/json-result.js
+++ b/src/lib/json-result.js
@@ -1,0 +1,43 @@
+const version = '1.0.0';
+
+
+module.exports.JSONResult = class JSONResult {
+	constructor(meta, data = {}){
+		this.meta = Object.assign({ version }, meta);
+		this.data = data;
+	}
+
+	toString(){
+		return JSON.stringify(this, null, 4);
+	}
+
+	toJSON(){
+		const { meta, data } = this;
+		return { meta, data };
+	}
+};
+
+module.exports.JSONErrorResult = class JSONErrorResult extends Error {
+	constructor(cause = new Error('Something went wrong')){
+		super(cause.message);
+		this.cause = cause;
+		this.meta = { version };
+	}
+
+	toString(){
+		return JSON.stringify(this, null, 4);
+	}
+
+	toJSON(){
+		const { meta, cause } = this;
+		const names = Object.getOwnPropertyNames(cause);
+		const error = {};
+
+		for (const name of names){
+			error[name] = this[name];
+		}
+
+		return { meta, error };
+	}
+};
+

--- a/src/lib/json-result.test.js
+++ b/src/lib/json-result.test.js
@@ -1,0 +1,103 @@
+const { expect, sinon } = require('../../test/setup');
+const { JSONResult, JSONErrorResult } = require('./json-result');
+
+
+describe('JSON Formatted Command Results', () => {
+	const sandbox = sinon.createSandbox();
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('JSON Result Object', () => {
+		it('Formats an empty JSON result', () => {
+			const result = new JSONResult();
+			expect(result).to.have.all.keys('meta', 'data');
+			expect(result.meta).to.eql({ version: '1.0.0' });
+			expect(result.data).to.eql({});
+		});
+
+		it('Formats an JSON result with customized `meta`', () => {
+			const meta = { test: true };
+			const result = new JSONResult(meta);
+			expect(result).to.have.all.keys('meta', 'data');
+			expect(result.meta).to.eql({ version: '1.0.0', test: true });
+			expect(result.data).to.eql({});
+		});
+
+		it('Formats an JSON result with customized `data`', () => {
+			const data = { id: '123A' };
+			const result = new JSONResult(undefined, data);
+			expect(result).to.have.all.keys('meta', 'data');
+			expect(result.meta).to.eql({ version: '1.0.0' });
+			expect(result.data).to.eql({ id: '123A' });
+		});
+
+		it('Formats an JSON result with customized `meta` and `data`', () => {
+			const meta = { test: true };
+			const data = { id: '123A' };
+			const result = new JSONResult(meta, data);
+			expect(result).to.have.all.keys('meta', 'data');
+			expect(result.meta).to.eql({ version: '1.0.0', test: true });
+			expect(result.data).to.eql({ id: '123A' });
+		});
+
+		it('Serializes result as JSON', () => {
+			const meta = { test: true };
+			const data = { id: '123A' };
+			const result = new JSONResult(meta, data);
+			const json = JSON.stringify(result);
+			expect(json).to.equal('{"meta":{"version":"1.0.0","test":true},"data":{"id":"123A"}}');
+		});
+
+		it('Converts result to string', () => {
+			const meta = { test: true };
+			const data = { id: '123A' };
+			const result = new JSONResult(meta, data);
+			expect(`${result}`).to.equal('{\n    "meta": {\n        "version": "1.0.0",\n        "test": true\n    },\n    "data": {\n        "id": "123A"\n    }\n}');
+		});
+	});
+
+	describe('JSON Error Result Object', () => {
+		it('Formats an empty JSON Error result', () => {
+			const result = new JSONErrorResult();
+			expect(result).to.have.all.keys('meta', 'cause');
+			expect(result.meta).to.eql({ version: '1.0.0' });
+			expect(result.cause).to.be.an.instanceof(Error);
+			expect(result.cause.message).to.equal('Something went wrong');
+		});
+
+		it('Formats a JSON Error result with customized `cause`', () => {
+			const cause = new Error('test');
+			const result = new JSONErrorResult(cause);
+			expect(result).to.have.all.keys('meta', 'cause');
+			expect(result.meta).to.eql({ version: '1.0.0' });
+			expect(result.cause).to.be.an.instanceof(Error);
+			expect(result.cause.message).to.equal('test');
+		});
+
+		it('Serializes result as JSON', () => {
+			const cause = new Error('test');
+			const result = new JSONErrorResult(cause);
+			const json = JSON.stringify(result);
+			const obj = JSON.parse(json);
+
+			expect(obj).to.have.all.keys('meta', 'error');
+			expect(obj.meta).to.eql({ version: '1.0.0' });
+			expect(obj.error).to.have.all.keys('message', 'stack');
+			expect(obj.error.message).to.equal('test');
+		});
+
+		it('Converts result to string', () => {
+			const cause = new Error('test');
+			const result = new JSONErrorResult(cause);
+			const obj = JSON.parse(`${result}`);
+
+			expect(obj).to.have.all.keys('meta', 'error');
+			expect(obj.meta).to.eql({ version: '1.0.0' });
+			expect(obj.error).to.have.all.keys('message', 'stack');
+			expect(obj.error.message).to.equal('test');
+		});
+	});
+});
+

--- a/test/e2e/library.e2e.js
+++ b/test/e2e/library.e2e.js
@@ -128,7 +128,8 @@ describe('Library Commands', () => {
 
 			expect(json).to.be.an('object');
 			expect(json).to.have.all.keys('meta', 'data');
-			expect(json.meta).to.have.all.keys('filter');
+			expect(json.meta).to.have.all.keys('version', 'filter');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.meta.filter).to.equal('dotstar');
 			expect(json.data).to.lengthOf.above(1);
 			expect(stderr).to.equal('');
@@ -142,7 +143,8 @@ describe('Library Commands', () => {
 
 			expect(json).to.be.an('object');
 			expect(json).to.have.all.keys('meta', 'data');
-			expect(json.meta).to.have.all.keys('filter');
+			expect(json.meta).to.have.all.keys('version', 'filter');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.meta.filter).to.equal('WATNOPEWATWATNOPENOPE');
 			expect(json.data).to.lengthOf(0);
 			expect(stderr).to.equal('');
@@ -169,7 +171,9 @@ describe('Library Commands', () => {
 			const json = JSON.parse(stdout);
 
 			expect(json).to.be.an('object');
-			expect(json).to.have.all.keys('error');
+			expect(json).to.have.all.keys('meta', 'error');
+			expect(json.meta).to.have.all.keys('version');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.error).to.have.property('message').that.is.a('string');
 			expect(json.error.message).include('HTTP error 400');
 			expect(json.error.message).include('The access token was not found');
@@ -206,7 +210,8 @@ describe('Library Commands', () => {
 			const libPath = getExpectedLibraryPath(name, json.data.version);
 
 			expect(json).to.have.all.keys('meta', 'data');
-			expect(json.meta).to.have.all.keys('filter', 'location');
+			expect(json.meta).to.have.all.keys('version', 'filter', 'location');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.meta.filter).to.equal(name);
 			expect(json.meta.location).to.equal(libPath);
 			expect(json.data).to.have.all.keys('architectures', 'author',
@@ -240,7 +245,8 @@ describe('Library Commands', () => {
 			const libPath = getExpectedLibraryPath(name, json.data.version);
 
 			expect(json).to.have.all.keys('meta', 'data');
-			expect(json.meta).to.have.all.keys('filter', 'location');
+			expect(json.meta).to.have.all.keys('version', 'filter', 'location');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.meta.filter).to.equal(name);
 			expect(json.meta.location).to.equal(libPath);
 			expect(json.data).to.have.all.keys('architectures', 'author',
@@ -275,7 +281,8 @@ describe('Library Commands', () => {
 			const libPath = getExpectedLibraryPath(name, json.data.version);
 
 			expect(json).to.have.all.keys('meta', 'data');
-			expect(json.meta).to.have.all.keys('filter', 'location');
+			expect(json.meta).to.have.all.keys('version', 'filter', 'location');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.meta.filter).to.equal(name);
 			expect(json.meta.location).to.equal(libPath);
 			expect(json.data).to.have.all.keys('architectures', 'author',
@@ -309,7 +316,8 @@ describe('Library Commands', () => {
 			const libPath = getExpectedLibraryPath(name, json.data.version);
 
 			expect(json).to.have.all.keys('meta', 'data');
-			expect(json.meta).to.have.all.keys('filter', 'location');
+			expect(json.meta).to.have.all.keys('version', 'filter', 'location');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.meta.filter).to.equal(name);
 			expect(json.meta.location).to.equal(libPath);
 			expect(json.data).to.have.all.keys('architectures', 'author',
@@ -340,7 +348,9 @@ describe('Library Commands', () => {
 			const json = JSON.parse(stdout);
 
 			expect(json).to.be.an('object');
-			expect(json).to.have.all.keys('error');
+			expect(json).to.have.all.keys('meta', 'error');
+			expect(json.meta).to.have.all.keys('version');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.error).to.have.property('message').that.is.a('string');
 			expect(json.error.message).to.equal('Library WATNOPEWATWATNOPENOPE not found');
 			expect(stderr).to.equal('');
@@ -356,7 +366,9 @@ describe('Library Commands', () => {
 			const json = JSON.parse(stdout);
 
 			expect(json).to.be.an('object');
-			expect(json).to.have.all.keys('error');
+			expect(json).to.have.all.keys('meta', 'error');
+			expect(json.meta).to.have.all.keys('version');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.error).to.have.property('message').that.is.a('string');
 			expect(json.error.message).include('HTTP error 400');
 			expect(json.error.message).include('The access token was not found');
@@ -444,7 +456,8 @@ describe('Library Commands', () => {
 
 			expect(json).to.be.an('object');
 			expect(json).to.have.all.keys('meta', 'data');
-			expect(json.meta).to.have.all.keys('previous', 'current', 'next');
+			expect(json.meta).to.have.all.keys('version', 'previous', 'current', 'next');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.meta.previous).to.equal(0);
 			expect(json.meta.current).to.equal(1);
 			expect(json.meta.next).to.equal(2);
@@ -459,7 +472,8 @@ describe('Library Commands', () => {
 
 			expect(json).to.be.an('object');
 			expect(json).to.have.all.keys('meta', 'data');
-			expect(json.meta).to.have.all.keys('previous', 'current', 'next');
+			expect(json.meta).to.have.all.keys('version', 'previous', 'current', 'next');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.meta.previous).to.equal(2);
 			expect(json.meta.current).to.equal(3);
 			expect(json.meta.next).to.equal(4);
@@ -487,7 +501,9 @@ describe('Library Commands', () => {
 			const json = JSON.parse(stdout);
 
 			expect(json).to.be.an('object');
-			expect(json).to.have.all.keys('error');
+			expect(json).to.have.all.keys('meta', 'error');
+			expect(json.meta).to.have.all.keys('version');
+			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.error).to.have.property('message').that.is.a('string');
 			expect(json.error.message).include('HTTP error 400');
 			expect(json.error.message).include('The access token was not found');


### PR DESCRIPTION
## Description

Adds support for a `--json` flag to return machine readable JSON from the following commands:

```
particle library search
particle library list
particle library view
```

## How to Test

verify help content:

```
particle library search --help
particle library list --help
particle library view --help
```

verify JSON output - run these commands while signed-in and while signed-out:

```
particle library search dotstar --json
particle library search DOESNOTEXIST --json
particle library list --json
particle library list --json --page 2
particle library list --json --page 2 --limit 50
particle library view dotstar --json
particle library view DOESNOTEXIST --json
particle library view dotstar --json --readme
particle library view DOESNOTEXIST --json --readme
particle library view dotstar --json --source
particle library view DOESNOTEXIST --json --source
particle library view dotstar --json --header
particle library view DOESNOTEXIST --json --header
```

in all cases you should see properly formatted JSON output via `stdout` with appropriate exit codes.

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

