### PR TITLE
bugfix/keys-quote-spaces

### DIFF
--- a/src/cmd/doctor.js
+++ b/src/cmd/doctor.js
@@ -102,6 +102,9 @@ module.exports = class DoctorCommand {
 		const deviceName = this.device.type || 'Device';
 		console.log('');
 		console.log('The Doctor will operate on your ' + deviceName + ' connected over USB');
+		console.log('');
+		console.log('PLEASE DISCONNECT ALL OTHER DEVICES BEFORE PROCEEDING');
+		console.log('');
 		console.log("You'll be asked to put your device in DFU mode several times to reset different settings.");
 	}
 


### PR DESCRIPTION
## Description

Calling `particle keys doctor <device>` on a machine that uses a temporary directory path which includes spaces - e.g. `C:\path\to my temp\dir" causes error

https://app.clubhouse.io/particle/story/41811/cli-fails-key-commands-when-user-has-spaces-in-name

## How to Test

1. create a new directory with a space in its name: `mkdir /test temp dir`
2. temporarily override your temp directory env var: `TMPDIR="/test temp dir"`
3. connect your test device
4. run `particle keys doctor <device>`

the command should succeed, no errors should be reported 


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [ ] CI is passing

