### PR TITLE
Add note about enterprise support to github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report---.md
+++ b/.github/ISSUE_TEMPLATE/bug-report---.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-  Please fill out each section below. This info helps maintainers diagnose and fix your issue as quickly as possible.
+  Thanks for reporting your issue. Please fill out each section below. This info helps maintainers diagnose and fix your issue as quickly as possible. If you have an enterprise support contract with Particle, please also open a support request at support.particle.io with a link to this issue.
 
   Useful Links:
   - Documentation: https://docs.particle.io/cli/


### PR DESCRIPTION
## Description

Minor text update within Github issue template alerting Particle enterprise customers to also contact support

## How to Test

N/A

## Related Issues / Discussions

N/A

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [ ] CI is passing

