### PR TITLE
Add a command to set the setup done flag

### DIFF
--- a/src/cli/usb.js
+++ b/src/cli/usb.js
@@ -98,6 +98,25 @@ module.exports = ({ commandProcessor, root }) => {
 		}
 	});
 
+	commandProcessor.createCommand(usb, 'setup-done', 'Set the setup done flag', {
+		params: '[devices...]',
+		options: {
+			'reset': {
+				description: 'Reset the setup done flag',
+				boolean: true
+			},
+			...commonOptions
+		},
+		examples: {
+			'$0 $command my_device': 'Set the setup done flag on the device "my_device"',
+			'$0 $command --reset my_device': 'Reset the setup done flag on the device "my_device"',
+			'$0 $command --all': 'Set the setup done flag on all devices connected to the host computer',
+		},
+		handler: (args) => {
+			return usbCommand().setSetupDone(args);
+		}
+	});
+
 	commandProcessor.createCommand(usb, 'configure', 'Update the system USB configuration', {
 		handler: (args) => {
 			return usbCommand().configure(args);

--- a/src/cli/usb.js
+++ b/src/cli/usb.js
@@ -109,7 +109,7 @@ module.exports = ({ commandProcessor, root }) => {
 		},
 		examples: {
 			'$0 $command my_device': 'Set the setup done flag on the device "my_device"',
-			'$0 $command --clear my_device': 'Clear the setup done flag on the device "my_device"',
+			'$0 $command --reset my_device': 'Clear the setup done flag on the device "my_device"',
 			'$0 $command --all': 'Set the setup done flag on all devices connected to the host computer',
 		},
 		handler: (args) => {

--- a/src/cli/usb.js
+++ b/src/cli/usb.js
@@ -102,14 +102,14 @@ module.exports = ({ commandProcessor, root }) => {
 		params: '[devices...]',
 		options: {
 			'reset': {
-				description: 'Reset the setup done flag',
+				description: 'Clear the setup done flag',
 				boolean: true
 			},
 			...commonOptions
 		},
 		examples: {
 			'$0 $command my_device': 'Set the setup done flag on the device "my_device"',
-			'$0 $command --reset my_device': 'Reset the setup done flag on the device "my_device"',
+			'$0 $command --clear my_device': 'Clear the setup done flag on the device "my_device"',
 			'$0 $command --all': 'Set the setup done flag on all devices connected to the host computer',
 		},
 		handler: (args) => {

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -113,7 +113,13 @@ module.exports = class UsbCommand {
 		const done = !args.reset;
 		return this._forEachUsbDevice(args, usbDevice => {
 			if (usbDevice.isMeshDevice) {
-				return usbDevice.setSetupDone(done);
+				return usbDevice.setSetupDone(done)
+					.then(() => {
+						if (done) {
+							return usbDevice.leaveListeningMode();
+						}
+						return usbDevice.enterListeningMode();
+					});
 			}
 		})
 			.then(() => {

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -109,6 +109,18 @@ module.exports = class UsbCommand {
 			});
 	}
 
+	setSetupDone(args) {
+		const done = !args.reset;
+		return this._forEachUsbDevice(args, usbDevice => {
+			if (usbDevice.isMeshDevice) {
+				return usbDevice.setSetupDone(done);
+			}
+		})
+			.then(() => {
+				console.log('Done.');
+			});
+	}
+
 	configure() {
 		if (!systemSupportsUdev()) {
 			console.log('The system does not require configuration.');

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -36,11 +36,30 @@ module.exports = class UsbCommand {
 							}
 						})
 						.then(device => {
-							const type = platformsById[usbDevice.platformId];
+							let info = [device, usbDevice.isInDfuMode];
+
+							if (!usbDevice.isInDfuMode){
+								info.push(usbDevice.getDeviceMode());
+							}
+
+							return Promise.all(info);
+						})
+						.then(([device, isInDfuMode, mode]) => {
+							const platform = platformsById[usbDevice.platformId];
+							const type = [platform];
+
+							if (isInDfuMode){
+								type.push('DFU');
+							}
+
+							if (mode && mode !== 'UNKNOWN'){
+								type.push(mode);
+							}
+
 							return {
 								id: usbDevice.id,
-								type: usbDevice.isInDfuMode ? `${type}, DFU` : type,
-								name: (device && device.name) ? device.name : ''
+								name: (device && device.name) ? device.name : '',
+								type: `${type.join(', ')}`
 							};
 						})
 						.finally(() => usbDevice.close());

--- a/test/e2e/help.e2e.js
+++ b/test/e2e/help.e2e.js
@@ -61,7 +61,7 @@ describe('Help & Unknown Command / Argument Handling', () => {
 		'serial', 'setup', 'subscribe', 'token list', 'token revoke',
 		'token create', 'token', 'udp send', 'udp listen', 'udp', 'update',
 		'update-cli', 'usb list', 'usb start-listening', 'usb listen', 'usb stop-listening',
-		'usb safe-mode', 'usb dfu', 'usb reset', 'usb configure', 'usb',
+		'usb safe-mode', 'usb dfu', 'usb reset', 'usb setup-done', 'usb configure', 'usb',
 		'variable list', 'variable get', 'variable monitor', 'variable',
 		'webhook create', 'webhook list', 'webhook delete', 'webhook POST',
 		'webhook GET', 'webhook', 'whoami'];

--- a/test/e2e/help.e2e.js
+++ b/test/e2e/help.e2e.js
@@ -60,11 +60,11 @@ describe('Help & Unknown Command / Argument Handling', () => {
 		'serial mac', 'serial inspect', 'serial flash', 'serial claim',
 		'serial', 'setup', 'subscribe', 'token list', 'token revoke',
 		'token create', 'token', 'udp send', 'udp listen', 'udp', 'update',
-		'update-cli', 'usb list', 'usb start-listening', 'usb listen', 'usb stop-listening',
-		'usb safe-mode', 'usb dfu', 'usb reset', 'usb setup-done', 'usb configure', 'usb',
-		'variable list', 'variable get', 'variable monitor', 'variable',
-		'webhook create', 'webhook list', 'webhook delete', 'webhook POST',
-		'webhook GET', 'webhook', 'whoami'];
+		'update-cli', 'usb list', 'usb start-listening', 'usb listen',
+		'usb stop-listening', 'usb safe-mode', 'usb dfu', 'usb reset',
+		'usb setup-done', 'usb configure', 'usb', 'variable list', 'variable get',
+		'variable monitor', 'variable', 'webhook create', 'webhook list',
+		'webhook delete', 'webhook POST', 'webhook GET', 'webhook', 'whoami'];
 
 	const mainCmds = dedupe(allCmds.map(c => c.split(' ')[0]));
 

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -116,7 +116,7 @@ describe('USB Commands [@device]', () => {
 		expect(subproc.exitCode).to.equal(1);
 	});
 
-	it('Sets and clears the setup done flag', async function () {
+	it.only('Sets and clears the setup done flag', async function test() {
 		await openUsbDevice();
 		if (!usbDevice.isMeshDevice) {
 			this.skip();

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -116,7 +116,7 @@ describe('USB Commands [@device]', () => {
 		expect(subproc.exitCode).to.equal(1);
 	});
 
-	it.only('Sets and clears the setup done flag', async function test() {
+	it('Sets and clears the setup done flag', async function test() {
 		await openUsbDevice();
 		if (!usbDevice.isMeshDevice) {
 			this.skip();

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -1,5 +1,4 @@
 const capitalize = require('lodash/capitalize');
-const usb = require('particle-usb');
 const { expect } = require('../setup');
 const { delay } = require('../lib/mocha-utils');
 const cli = require('../lib/cli');
@@ -31,36 +30,15 @@ describe('USB Commands [@device]', () => {
 		'  -q, --quiet    Decreases how much logging to display  [count]'
 	];
 
-	let usbDevice = null;
-
-	const closeUsbDevice = async () => {
-		if (usbDevice) {
-			await usbDevice.close();
-			usbDevice = null;
-		}
-	};
-
-	const openUsbDevice = async () => {
-		await closeUsbDevice();
-		const devs = await usb.getDevices();
-		if (!devs.length) {
-			throw new Error('No USB devices found');
-		}
-		await devs[0].open();
-		usbDevice = devs[0];
-	};
-
 	before(async () => {
 		await cli.setTestProfileAndLogin();
 	});
 
 	after(async () => {
+		await cli.run(['usb', 'setup-done']);
+		await delay(2000);
 		await cli.logout();
 		await cli.setDefaultProfile();
-	});
-
-	afterEach(async () => {
-		await closeUsbDevice();
 	});
 
 	it('Shows `help` content', async () => {
@@ -117,32 +95,21 @@ describe('USB Commands [@device]', () => {
 	});
 
 	it('Sets and clears the setup done flag', async function test() {
-		await openUsbDevice();
-		if (!usbDevice.isMeshDevice) {
-			this.skip();
-			return;
-		}
-
-		// Clear the setup done flag
 		await cli.run(['usb', 'setup-done', '--reset']);
-
-		// Reset and reopen the device
-		await usbDevice.reset();
 		await delay(2000);
-		await openUsbDevice();
 
-		let mode = await usbDevice.getDeviceMode();
-		expect(mode).to.equal('LISTENING'); // FIXME: particle-usb doesn't export DeviceMode
+		const platform = capitalize(DEVICE_PLATFORM_NAME);
+		const { stdout, stderr, exitCode } = await cli.run(['usb', 'list']);
+		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, LISTENING)`);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
 
-		// Set the setup done flag
 		await cli.run(['usb', 'setup-done']);
-
-		// Reset and reopen the device
-		await usbDevice.reset();
 		await delay(2000);
-		await openUsbDevice();
 
-		mode = await usbDevice.getDeviceMode();
-		expect(mode).to.not.equal('LISTENING');
+		const subproc = await cli.run(['usb', 'list']);
+		expect(subproc.stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+		expect(subproc.stderr).to.equal('');
+		expect(subproc.exitCode).to.equal(0);
 	});
 });


### PR DESCRIPTION
## Description

This PR implements a new command that sets/clears the setup done flag on Gen 3 devices:
```
particle usb setup-done my_device
particle usb setup-done --reset my_device
```

## How to Test

```
npm run test:e2e
```

## Related Issues / Discussions

- [ch46416]
