### PR TITLE
always send lowercase device id when claiming a device

### DIFF
--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -12,10 +12,10 @@ module.exports = ({ commandProcessor, root }) => {
 	};
 
 	commandProcessor.createCommand(cloud, 'claim', 'Register a device with your user account with the cloud', {
-		params: '<device>',
+		params: '<deviceID>',
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
-			return new CloudCommands().claimDevice(args.params.device);
+			return new CloudCommands().claimDevice(args.params.deviceID);
 		},
 		examples: {
 			'$0 $command 123456789': 'Claim device by id to your account'

--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -383,7 +383,7 @@ module.exports = class ApiClient {
 				method: 'POST',
 				json: true,
 				form: {
-					id: deviceId,
+					id: (deviceId || '').toLowerCase(),
 					access_token: token,
 					request_transfer: requestTransfer ? true : undefined
 				}

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -175,11 +175,26 @@ describe('Cloud Commands [@device]', () => {
 	});
 
 	it('Claims device', async () => {
-		const args = ['cloud', 'claim', DEVICE_ID];
+		const id = DEVICE_ID.toLowerCase();
+		const args = ['cloud', 'claim', id];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 		const log = [
-			`Claiming device ${DEVICE_ID}`,
-			`Successfully claimed device ${DEVICE_ID}`
+			`Claiming device ${id}`,
+			`Successfully claimed device ${id}`
+		];
+
+		expect(stdout.split('\n')).to.include.members(log);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Claims device when device id is capitalized', async () => {
+		const id = DEVICE_ID.toUpperCase();
+		const args = ['cloud', 'claim', id];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+		const log = [
+			`Claiming device ${id}`,
+			`Successfully claimed device ${id}`
 		];
 
 		expect(stdout.split('\n')).to.include.members(log);


### PR DESCRIPTION
## Description

`particle cloud claim` fails when a mixed-case device id is provided.

## How to Test

**Repro Steps**
1. run `particle cloud claim <device id w/ all lowercase characters>`
2. run `particle cloud claim <device id w/ uppercase characters>`

**Expected**
both commands should succeed

**Actual**
1st command succeeds, 2nd command fails w/ "Failed to claim device: device not found"

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

