### PR TITLE
Feature/products device get var

### DIFF
--- a/src/cli/variable.js
+++ b/src/cli/variable.js
@@ -17,7 +17,11 @@ module.exports = ({ commandProcessor, root }) => {
 
 	commandProcessor.createCommand(variable, 'get', 'Retrieve a value from your device', {
 		params: '[device] [variableName]',
-		options: timeOption,
+		options: Object.assign({}, timeOption, {
+			'product': {
+				description: 'product id or slug'
+			}
+		}),
 		handler: (args) => {
 			const VariableCommand = require('../cmd/variable');
 			return new VariableCommand().getValue(args);

--- a/src/cli/variable.js
+++ b/src/cli/variable.js
@@ -20,7 +20,7 @@ module.exports = ({ commandProcessor, root }) => {
 		options: timeOption,
 		handler: (args) => {
 			const VariableCommand = require('../cmd/variable');
-			return new VariableCommand().getValue(args.params.device, args.params.variableName, args);
+			return new VariableCommand().getValue(args);
 		},
 		examples: {
 			'$0 $command basement temperature': 'Read the temperature variable from the device basement',
@@ -39,7 +39,7 @@ module.exports = ({ commandProcessor, root }) => {
 		}),
 		handler: (args) => {
 			const VariableCommand = require('../cmd/variable');
-			return new VariableCommand().monitorVariables(args.params.device, args.params.variableName, args);
+			return new VariableCommand().monitorVariables(args);
 		},
 		examples: {
 			'$0 $command up temp --delay 2000': 'Read the temp variable from the device up every 2 seconds'

--- a/src/cli/variable.test.js
+++ b/src/cli/variable.test.js
@@ -88,6 +88,7 @@ describe('Variable Command-Line Interface', () => {
 					'',
 					'Options:',
 					'  --time     Show the time when the variable was received  [boolean]',
+					'  --product  product id or slug  [string]',
 					'',
 					'Examples:',
 					'  particle variable get basement temperature  Read the temperature variable from the device basement',

--- a/src/cli/variable.test.js
+++ b/src/cli/variable.test.js
@@ -1,0 +1,143 @@
+const os = require('os');
+const { expect } = require('../../test/setup');
+const commandProcessor = require('../app/command-processor');
+const variable = require('./variable');
+
+
+describe('Variable Command-Line Interface', () => {
+	const termWidth = null; // don't right-align option type labels so testing is easier
+	let root;
+
+	beforeEach(() => {
+		root = commandProcessor.createAppCategory();
+		variable({ root, commandProcessor });
+	});
+
+	describe('Top-Level `variable` Namespace', () => {
+		it('Handles `variable` command', () => {
+			const argv = commandProcessor.parse(root, ['variable']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.equal(undefined);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['variable', '--help']);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Retrieve and monitor variables on your device',
+					'Usage: particle variable <command>',
+					'Help:  particle help variable <command>',
+					'',
+					'Commands:',
+					'  list     Show variables provided by your device(s)',
+					'  get      Retrieve a value from your device',
+					'  monitor  Connect and display messages from a device',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `variable list` Namespace', () => {
+		it('Handles `list` command', () => {
+			const argv = commandProcessor.parse(root, ['variable', 'list']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Includes help', () => {
+			commandProcessor.parse(root, ['variable', 'list', '--help']);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Show variables provided by your device(s)',
+					'Usage: particle variable list [options]',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `variable get` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['variable', 'get']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: undefined, variableName: undefined });
+			expect(argv.time).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['variable', 'get', 'my-device', 'my-var']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', variableName: 'my-var' });
+			expect(argv.time).to.equal(false);
+		});
+
+		it('Parses options flags', () => {
+			const argv = commandProcessor.parse(root, ['variable', 'get', 'my-device', 'my-var', '--time']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', variableName: 'my-var' });
+			expect(argv.time).to.equal(true);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['variable', 'get', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Retrieve a value from your device',
+					'Usage: particle variable get [options] [device] [variableName]',
+					'',
+					'Options:',
+					'  --time     Show the time when the variable was received  [boolean]',
+					'',
+					'Examples:',
+					'  particle variable get basement temperature  Read the temperature variable from the device basement',
+					'  particle variable get all temperature       Read the temperature variable from all my devices',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `variable monitor` Command', () => {
+		// TODO (mirande): seems like a bug - 'device' should probably be required
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['variable', 'monitor']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: undefined, variableName: undefined });
+			expect(argv.time).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['variable', 'monitor', 'my-device', 'my-var']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', variableName: 'my-var' });
+			expect(argv.time).to.equal(false);
+		});
+
+		it('Parses options flags', () => {
+			const argv = commandProcessor.parse(root, ['variable', 'monitor', 'my-device', 'my-var', '--time']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', variableName: 'my-var' });
+			expect(argv.time).to.equal(true);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['variable', 'monitor', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Connect and display messages from a device',
+					'Usage: particle variable monitor [options] [device] [variableName]',
+					'',
+					'Options:',
+					'  --time   Show the time when the variable was received  [boolean]',
+					'  --delay  Interval in milliseconds between variable fetches  [number]',
+					'',
+					'Examples:',
+					'  particle variable monitor up temp --delay 2000  Read the temp variable from the device up every 2 seconds',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+});
+

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -128,8 +128,8 @@ module.exports = class ParticleApi {
 	_checkToken(err){
 		const { UnauthorizedError } = module.exports;
 
-		if (err.statusCode === 401){
-			return Promise.reject(new UnauthorizedError());
+		if ([400, 401].includes(err.statusCode)){
+			return Promise.reject(new UnauthorizedError(err.shortErrorDescription));
 		}
 		return Promise.reject(err);
 	}

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -102,6 +102,17 @@ module.exports = class ParticleApi {
 		return this._wrap(this.api.compileCode({ files, platformId, targetVersion, auth: this.accessToken }));
 	}
 
+	getVariable(deviceId, name, product){
+		return this._wrap(
+			this.api.getVariable({
+				name,
+				deviceId,
+				product,
+				auth: this.accessToken
+			})
+		);
+	}
+
 	downloadFirmwareBinary(binaryId, downloadPath){
 		return new Promise((resolve, reject) => {
 			const req = this.api.downloadFirmwareBinary({ binaryId, auth: this.accessToken });

--- a/src/cmd/variable.js
+++ b/src/cmd/variable.js
@@ -1,69 +1,78 @@
-const _ = require('lodash');
 const VError = require('verror');
 const moment = require('moment');
+const has = require('lodash/has');
+const map = require('lodash/map');
+const find = require('lodash/find');
+const filter = require('lodash/filter');
 const prompt = require('inquirer').prompt;
 const settings = require('../../settings');
-const ApiClient = require('../lib/api-client');
+const LegacyApiClient = require('../lib/api-client');
 
 
 module.exports = class VariableCommand {
-	disambiguateGetValue({ deviceId, variableName }) {
-		//if their deviceId actually matches a device, list those variables.
-		//if their deviceId is null, get that var from the relevant devices
-
-		//this gets cached after the first request
-		return this.getAllVariables()
+	listVariables(){
+		return this.getAllVariablesWithCache()
 			.then((devices) => {
-				if (deviceId) {
-					const device = _.find(devices, (d) => {
-						return d.id === deviceId || d.name === deviceId;
-					});
+				let lines = [];
 
-					if (!device) {
-						// see if any devices have a variable name matching value of deviceId
-						variableName = deviceId;
-						const maybeDeviceIds = _.map(_.filter(devices, (c) => {
-							return _.has(c.variables, variableName);
-						}), 'id');
+				for (let i = 0; i < devices.length; i++){
+					const device = devices[i];
+					const available = [];
 
-						if (maybeDeviceIds.length === 0) {
-							throw new VError('No matching device');
+					if (device.variables){
+						for (const key in device.variables){
+							const type = device.variables[key];
+							available.push('  ' + key + ' (' + type + ')');
 						}
-
-						return { deviceIds: maybeDeviceIds, variableName: variableName };
 					}
 
-					return prompt([{
-						type: 'list',
-						name: 'variableName',
-						message: 'Which variable did you want?',
-						choices: () => {
-							return _.map(device.variables, (type, key) => {
-								return {
-									name: `${key} (${type})`,
-									value: key
-								};
-							});
-						}
-					}]).then((answers) => {
-						return { deviceIds: [deviceId], variableName: answers.variableName };
-					});
+					let status = device.name + ' (' + device.id + ') has ' + available.length + ' variables ';
+					if (available.length === 0){
+						status += ' (or is offline) ';
+					}
+
+					lines.push(status);
+					lines = lines.concat(available);
 				}
-
-				const deviceIds = _.map(_.filter(devices, (c) => {
-					return _.has(c.variables, variableName);
-				}), 'id');
-
-				return { deviceIds: deviceIds, variableName: variableName };
+				console.log(lines.join('\n'));
+			})
+			.catch(err => {
+				const api = new LegacyApiClient();
+				throw new VError(api.normalizedApiError(err), 'Error while listing variables');
 			});
 	}
 
-	_getValue(deviceId, variableName, { time }) {
-		if (!_.isArray(deviceId)) {
+	getValue({ time, params: { device, variableName } }){
+		return Promise.resolve()
+			.then(() => {
+				if (!device && !variableName){
+					//they just didn't provide any args...
+					return this.listVariables();
+				} else if (device && !variableName){
+					//try to figure out if they left off a variable name, or if they want to pull a var from all devices.
+					return this.disambiguateGetValue({ device }).then(({ deviceIds, variableName }) => {
+						return this._getValue(deviceIds, variableName, { time });
+					});
+				} else if (device === 'all' && variableName){
+					return this.disambiguateGetValue({ variableName }).then(({ deviceIds, variableName }) => {
+						return this._getValue(deviceIds, variableName, { time });
+					});
+				}
+
+				return this._getValue(device, variableName, { time });
+			})
+			.catch(err => {
+				const api = new LegacyApiClient();
+				throw new VError(api.normalizedApiError(err), 'Error while reading value');
+			});
+	}
+
+	_getValue(deviceId, variableName, { time }){
+		if (!Array.isArray(deviceId)){
 			deviceId = [deviceId];
 		}
 
-		const api = new ApiClient();
+		const api = new LegacyApiClient();
 		api.ensureToken();
 
 		const multipleCores = deviceId.length > 1;
@@ -74,21 +83,21 @@ module.exports = class VariableCommand {
 				const now = moment().format();
 				let hasErrors = false;
 
-				for (let i = 0; i < results.length; i++) {
+				for (let i = 0; i < results.length; i++){
 					const parts = [];
 					const result = results[i];
 
-					if (result.error) {
+					if (result.error){
 						console.log('Error:', result.error);
 						hasErrors = true;
 						continue;
 					}
 
-					if (multipleCores) {
+					if (multipleCores){
 						parts.push(result.coreInfo.deviceID);
 					}
 
-					if (time) {
+					if (time){
 						parts.push(now);
 					}
 
@@ -96,7 +105,7 @@ module.exports = class VariableCommand {
 					console.log(parts.join(', '));
 				}
 
-				if (hasErrors) {
+				if (hasErrors){
 					throw new VError('Some variables could not be read');
 				}
 
@@ -104,52 +113,114 @@ module.exports = class VariableCommand {
 			});
 	}
 
-	getValue(deviceId, variableName, { time }) {
+	monitorVariables({ time, delay = settings.minimumApiDelay, params: { device, variableName } }){
 		return Promise.resolve()
 			.then(() => {
-				if (!deviceId && !variableName) {
-					//they just didn't provide any args...
-					return this.listVariables();
-				} else if (deviceId && !variableName) {
-					//try to figure out if they left off a variable name, or if they want to pull a var from all devices.
-					return this.disambiguateGetValue({ deviceId }).then(({ deviceIds, variableName }) => {
-						return this._getValue(deviceIds, variableName, { time });
-					});
-				} else if (deviceId === 'all' && variableName) {
-					return this.disambiguateGetValue({ variableName }).then(({ deviceIds, variableName }) => {
-						return this._getValue(deviceIds, variableName, { time });
-					});
+				if (device === 'all'){
+					device = null;
 				}
 
-				return this._getValue(deviceId, variableName, { time });
+				if (!device || !variableName){
+					return this.disambiguateGetValue({ device, variableName });
+				}
+				return { deviceIds: [device], variableName };
+			})
+			.then(({ deviceIds, variableName }) => {
+				if (delay < settings.minimumApiDelay){
+					delay = settings.minimumApiDelay;
+					console.error(`Delay was too short, resetting to ${settings.minimumApiDelay}ms`);
+				}
+				console.error('Hit CTRL-C to stop!');
+				return this._pollForVariable(deviceIds, variableName, { delay, time });
 			})
 			.catch(err => {
-				const api = new ApiClient();
-				throw new VError(api.normalizedApiError(err), 'Error while reading value');
+				const api = new LegacyApiClient();
+				throw new VError(api.normalizedApiError(err), 'Error while monitoring variable');
 			});
 	}
 
-	getAllVariables() {
-		if (this._cachedVariableList) {
+	_pollForVariable(deviceIds, variableName, { delay, time }){
+		const retry = () => setTimeout(
+			this._pollForVariable.bind(this, deviceIds, variableName, { delay, time }),
+			delay
+		);
+
+		return this._getValue(deviceIds, variableName, { time })
+			.then(retry)
+			.catch(retry);
+	}
+
+	disambiguateGetValue({ device, variableName }){
+		//if their deviceId actually matches a device, list those variables.
+		//if their deviceId is null, get that var from the relevant devices
+
+		//this gets cached after the first request
+		return this.getAllVariablesWithCache()
+			.then((deviceList) => {
+				if (device){
+					const deviceDetail = find(deviceList, (d) => {
+						return d.id === device || d.name === device;
+					});
+
+					if (!deviceDetail){
+						// see if any devices have a variable name matching value of deviceId
+						const deviceIds = getIDs(deviceList, device);
+
+						if (deviceIds.length === 0){
+							throw new VError('No matching device');
+						}
+						return { deviceIds, variableName: device };
+					}
+
+					return prompt([{
+						type: 'list',
+						name: 'variableName',
+						message: 'Which variable did you want?',
+						choices: () => {
+							return map(deviceDetail.variables, (type, key) => {
+								return {
+									name: `${key} (${type})`,
+									value: key
+								};
+							});
+						}
+					}]).then((answers) => {
+						return { deviceIds: [device], variableName: answers.variableName };
+					});
+				}
+
+				const deviceIds = getIDs(deviceList, variableName);
+				return { deviceIds, variableName };
+			});
+
+		function getIDs(deviceList, varName){
+			return map(filter(deviceList, (c) => {
+				return has(c.variables, varName);
+			}), 'id');
+		}
+	}
+
+	getAllVariablesWithCache(){
+		if (this._cachedVariableList){
 			return Promise.resolve(this._cachedVariableList);
 		}
 
 		console.error('polling server to see what devices are online, and what variables are available');
 
-		const api = new ApiClient();
+		const api = new LegacyApiClient();
 		api.ensureToken();
 
 		return Promise.resolve()
 			.then(() => api.listDevices())
 			.then(devices => {
-				if (!devices || (devices.length === 0)) {
+				if (!devices || (devices.length === 0)){
 					console.log('No devices found.');
 					this._cachedVariableList = null;
 				} else {
 					const promises = [];
-					for (let i = 0; i < devices.length; i++) {
+					for (let i = 0; i < devices.length; i++){
 						const deviceid = devices[i].id;
-						if (devices[i].connected) {
+						if (devices[i].connected){
 							promises.push(api.getAttributes(deviceid));
 						} else {
 							promises.push(Promise.resolve(devices[i]));
@@ -167,76 +238,6 @@ module.exports = class VariableCommand {
 					});
 				}
 			});
-	}
-
-	listVariables() {
-		return this.getAllVariables()
-			.then((devices) => {
-				let lines = [];
-
-				for (let i = 0; i < devices.length; i++) {
-					const device = devices[i];
-					const available = [];
-
-					if (device.variables) {
-						for (const key in device.variables) {
-							const type = device.variables[key];
-							available.push('  ' + key + ' (' + type + ')');
-						}
-					}
-
-					let status = device.name + ' (' + device.id + ') has ' + available.length + ' variables ';
-					if (available.length === 0) {
-						status += ' (or is offline) ';
-					}
-
-					lines.push(status);
-					lines = lines.concat(available);
-				}
-				console.log(lines.join('\n'));
-			})
-			.catch(err => {
-				const api = new ApiClient();
-				throw new VError(api.normalizedApiError(err), 'Error while listing variables');
-			});
-	}
-
-	monitorVariables(deviceId, variableName, { delay = settings.minimumApiDelay, time } = {}) {
-		return Promise.resolve()
-			.then(() => {
-				if (deviceId === 'all') {
-					deviceId = null;
-				}
-
-				if (!deviceId || !variableName) {
-					return this.disambiguateGetValue({ deviceId, variableName });
-				}
-
-				return { deviceIds: [deviceId], variableName: variableName };
-			})
-			.then(({ deviceIds, variableName }) => {
-				if (delay < settings.minimumApiDelay) {
-					delay = settings.minimumApiDelay;
-					console.error(`Delay was too short, resetting to ${settings.minimumApiDelay}ms`);
-				}
-				console.error('Hit CTRL-C to stop!');
-				return this._pollForVariable(deviceIds, variableName, { delay, time });
-			})
-			.catch(err => {
-				const api = new ApiClient();
-				throw new VError(api.normalizedApiError(err), 'Error while monitoring variable');
-			});
-	}
-
-	_pollForVariable(deviceIds, variableName, { delay, time }){
-		const retry = () => setTimeout(
-			this._pollForVariable.bind(this, deviceIds, variableName, { delay, time }),
-			delay
-		);
-
-		return this._getValue(deviceIds, variableName, { time })
-			.then(retry)
-			.catch(retry);
 	}
 };
 

--- a/src/cmd/variable.test.js
+++ b/src/cmd/variable.test.js
@@ -13,11 +13,11 @@ describe('Variable Command', () => {
 	describe('Monitoring a variable', () => {
 		it('Monitors a variable', withConsoleStubs(sandbox, async () => {
 			const cmd = new VariableCommand();
-			const deviceID = '000000000000000xdeadbeef';
+			const device = '000000000000000xdeadbeef';
 			const variableName = 'test';
 
 			sandbox.stub(cmd, '_pollForVariable').resolves();
-			await cmd.monitorVariables(deviceID, variableName);
+			await cmd.monitorVariables({ params: { device, variableName } });
 
 			expect(process.stdout.write).to.have.callCount(0);
 			expect(process.stderr.write).to.have.callCount(1);
@@ -29,7 +29,7 @@ describe('Variable Command', () => {
 
 			const args = cmd._pollForVariable.firstCall.args;
 
-			expect(args[0]).to.eql([deviceID]);
+			expect(args[0]).to.eql([device]);
 			expect(args[1]).to.eql(variableName);
 			expect(args[2]).to.have.property('delay').that.is.a('number');
 			expect(args[2]).to.have.property('time', undefined);
@@ -37,25 +37,25 @@ describe('Variable Command', () => {
 
 		it('Prompts for variable name when it is not provided', withConsoleStubs(sandbox, async () => {
 			const cmd = new VariableCommand();
-			const deviceID = '000000000000000xdeadbeef';
+			const device = '000000000000000xdeadbeef';
 			let args;
 
 			sandbox.stub(cmd, '_pollForVariable').resolves();
 			sandbox.stub(cmd, 'disambiguateGetValue').resolves({
-				deviceIds: [deviceID],
+				deviceIds: [device],
 				variableName: 'prompted'
 			});
-			await cmd.monitorVariables(deviceID);
+			await cmd.monitorVariables({ params: { device } });
 
 			expect(cmd.disambiguateGetValue).to.have.property('callCount', 1);
 			args = cmd.disambiguateGetValue.firstCall.args;
-			expect(args[0]).to.have.property('deviceId', deviceID);
+			expect(args[0]).to.have.property('device', device);
 			expect(args[0]).to.have.property('variableName', undefined);
 			expect(args).to.have.lengthOf(1);
 
 			expect(cmd._pollForVariable).to.have.property('callCount', 1);
 			args = cmd._pollForVariable.firstCall.args;
-			expect(args[0]).to.eql([deviceID]);
+			expect(args[0]).to.eql([device]);
 			expect(args[1]).to.eql('prompted');
 			expect(args[2]).to.have.property('delay').that.is.a('number');
 			expect(args[2]).to.have.property('time', undefined);
@@ -64,14 +64,14 @@ describe('Variable Command', () => {
 
 		it('Throws when error occurs before polling', async () => {
 			const cmd = new VariableCommand();
-			const deviceID = '000000000000000xdeadbeef';
+			const device = '000000000000000xdeadbeef';
 			let error;
 
 			sandbox.stub(cmd, '_pollForVariable').resolves();
 			sandbox.stub(cmd, 'disambiguateGetValue').rejects(new Error('whoops!'));
 
 			try {
-				await cmd.monitorVariables(deviceID);
+				await cmd.monitorVariables({ params: { device } });
 			} catch (e){
 				error = e;
 			}

--- a/src/lib/ui/index.js
+++ b/src/lib/ui/index.js
@@ -26,7 +26,7 @@ module.exports = class UI {
 		stderr.write(data + EOL);
 	}
 
-	logDeviceDetail(devices){
+	logDeviceDetail(devices, { varsOnly = false, fnsOnly = false } = {}){
 		const { EOL, chalk } = this;
 		const deviceList = Array.isArray(devices) ? devices : [devices];
 		const lines = [];
@@ -52,8 +52,14 @@ module.exports = class UI {
 
 			const status = `${name} [${device.id}] (${deviceType}) is ${connectedState}`;
 			lines.push(status);
-			formatVariables(device.variables, lines);
-			formatFunctions(device.functions, lines);
+
+			if (!fnsOnly){
+				formatVariables(device.variables, lines);
+			}
+
+			if (!varsOnly){
+				formatFunctions(device.functions, lines);
+			}
 		}
 
 		this.write(lines.join(EOL));

--- a/src/lib/ui/index.js
+++ b/src/lib/ui/index.js
@@ -34,7 +34,7 @@ module.exports = class UI {
 		for (let i = 0; i < deviceList.length; i++){
 			const device = deviceList[i];
 			const deviceType = platformsById[device.product_id] || `Product ${device.product_id}`;
-			const connected = device.connected;
+			const connected = device.connected || device.online;
 			const connectedState = connected ? 'online' : 'offline';
 			let name;
 

--- a/src/lib/ui/index.test.js
+++ b/src/lib/ui/index.test.js
@@ -102,7 +102,7 @@ describe('UI', () => {
 			ui.logDeviceDetail(device);
 
 			expect(stdout.content).to.equal([
-				'prod-test-01 [e00fce0000dba0f00f000d0d] (Product 12345) is offline',
+				'prod-test-01 [e00fce0000dba0f00f000d0d] (Product 12345) is online',
 				'  Variables:',
 				'    name (string)',
 				'    version (int32)',
@@ -131,7 +131,7 @@ describe('UI', () => {
 			ui.logDeviceDetail(device);
 
 			expect(stdout.content).to.equal([
-				'prod-test-01 [e00fce0000dba0f00f000d0d] (Product 12345) is offline',
+				'prod-test-01 [e00fce0000dba0f00f000d0d] (Product 12345) is online',
 				''
 			].join(ui.EOL));
 		});
@@ -207,7 +207,7 @@ describe('UI', () => {
 			ui.logDeviceDetail(devices);
 
 			expect(stdout.content).to.equal([
-				'prod-test-01 [e00fce0000dba0f00f000d0d] (Product 12345) is offline',
+				'prod-test-01 [e00fce0000dba0f00f000d0d] (Product 12345) is online',
 				'  Variables:',
 				'    name (string)',
 				'    version (int32)',
@@ -248,7 +248,7 @@ describe('UI', () => {
 			ui.logDeviceDetail(devices);
 
 			expect(stdout.content).to.equal([
-				'prod-test-01 [e00fce0000dba0f00f000d0d] (Product 12345) is offline',
+				'prod-test-01 [e00fce0000dba0f00f000d0d] (Product 12345) is online',
 				'prod-test-02 [e00fce0000000ce0de0000dd] (Product 12345) is offline',
 				''
 			].join(ui.EOL));
@@ -430,7 +430,7 @@ describe('UI', () => {
 				last_ip_address: '192.0.2.3',
 				firmware_version: 1,
 				last_handshake_at: '2020-01-24T14:47:03.150Z',
-				online: false,
+				online: true,
 				name: 'prod-test-01',
 				platform_id: 12,
 				notes: 'here are some notes for testing',
@@ -476,7 +476,7 @@ describe('UI', () => {
 				last_ip_address: '192.0.2.3',
 				last_heard: '2020-01-24T14:47:03.150Z',
 				product_id: 12345,
-				connected: false,
+				connected: true,
 				platform_id: 12,
 				cellular: false,
 				notes: 'here are some notes for testing',

--- a/src/lib/ui/index.test.js
+++ b/src/lib/ui/index.test.js
@@ -68,6 +68,35 @@ describe('UI', () => {
 			].join(ui.EOL));
 		});
 
+		it('Logs details for a single device excluding cloud variables', () => {
+			const [device] = getDetailedDeviceList();
+			ui.logDeviceDetail(device, { fnsOnly: true });
+
+			expect(stdout.content).to.equal([
+				'test-photon [000000000e00000000000001] (Photon) is offline',
+				'  Functions:',
+				'    int check (String args) ',
+				'    int stop (String args) ',
+				'    int start (String args) ',
+				'    int toggle (String args) ',
+				''
+			].join(ui.EOL));
+		});
+
+		it('Logs details for a single device excluding cloud functions', () => {
+			const [device] = getDetailedDeviceList();
+			ui.logDeviceDetail(device, { varsOnly: true });
+
+			expect(stdout.content).to.equal([
+				'test-photon [000000000e00000000000001] (Photon) is offline',
+				'  Variables:',
+				'    name (string)',
+				'    version (int32)',
+				'    blinking (int32)',
+				''
+			].join(ui.EOL));
+		});
+
 		it('Logs details for a single product device', () => {
 			const [device] = getDetailedProductDeviceList();
 			ui.logDeviceDetail(device);
@@ -130,6 +159,45 @@ describe('UI', () => {
 				'  Functions:',
 				'    int start (String args) ',
 				'    int stop (String args) ',
+				''
+			].join(ui.EOL));
+		});
+
+		it('Logs details for multiple devices excluding cloud variables', () => {
+			const devices = getDetailedDeviceList();
+			ui.logDeviceDetail(devices, { fnsOnly: true });
+
+			expect(stdout.content).to.equal([
+				'test-photon [000000000e00000000000001] (Photon) is offline',
+				'  Functions:',
+				'    int check (String args) ',
+				'    int stop (String args) ',
+				'    int start (String args) ',
+				'    int toggle (String args) ',
+				'test-boron [e00fce0000f0c0a00c00e00a] (Boron) is online',
+				'  Functions:',
+				'    int start (String args) ',
+				'    int stop (String args) ',
+				'test-argon [e00fce00000e0df000f0000c] (Argon) is online',
+				'  Functions:',
+				'    int start (String args) ',
+				'    int stop (String args) ',
+				''
+			].join(ui.EOL));
+		});
+
+		it('Logs details for multiple devices excluding cloud functions', () => {
+			const devices = getDetailedDeviceList();
+			ui.logDeviceDetail(devices, { varsOnly: true });
+
+			expect(stdout.content).to.equal([
+				'test-photon [000000000e00000000000001] (Photon) is offline',
+				'  Variables:',
+				'    name (string)',
+				'    version (int32)',
+				'    blinking (int32)',
+				'test-boron [e00fce0000f0c0a00c00e00a] (Boron) is online',
+				'test-argon [e00fce00000e0df000f0000c] (Argon) is online',
 				''
 			].join(ui.EOL));
 		});

--- a/test/e2e/get.e2e.js
+++ b/test/e2e/get.e2e.js
@@ -1,9 +1,11 @@
+const capitalize = require('lodash/capitalize');
 const { expect } = require('../setup');
 const { delay } = require('../lib/mocha-utils');
 const cli = require('../lib/cli');
 const {
 	DEVICE_ID,
-	DEVICE_NAME
+	DEVICE_NAME,
+	DEVICE_PLATFORM_NAME
 } = require('../lib/env');
 
 
@@ -51,9 +53,10 @@ describe('Get Commands [@device]', () => {
 	});
 
 	it('Lists all available variables', async () => {
+		const platform = capitalize(DEVICE_PLATFORM_NAME);
 		const { stdout, stderr, exitCode } = await cli.run('get');
 
-		expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
+		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
 		expect(stdout).to.include('version (int32)');
 		expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
 		expect(exitCode).to.equal(0);

--- a/test/e2e/product.e2e.js
+++ b/test/e2e/product.e2e.js
@@ -212,8 +212,7 @@ describe('Product Commands', () => {
 			const args = ['product', 'device', 'list', PRODUCT_01_ID];
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
-			expect(stdout).to.include('HTTP error 400');
-			expect(stdout).to.include('The access token was not found');
+			expect(stdout).to.include('Error listing product devices: The access token was not found');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(1);
 		});
@@ -230,8 +229,7 @@ describe('Product Commands', () => {
 			expect(json.meta).to.have.all.keys('version');
 			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.error).to.have.property('message').that.is.a('string');
-			expect(json.error.message).include('HTTP error 400');
-			expect(json.error.message).include('The access token was not found');
+			expect(json.error.message).include('Error listing product devices: The access token was not found');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(1);
 		});
@@ -242,8 +240,7 @@ describe('Product Commands', () => {
 			const args = ['product', 'device', 'list', PRODUCT_01_ID, PRODUCT_01_DEVICE_01_ID];
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
-			expect(stdout).to.include('HTTP error 400');
-			expect(stdout).to.include('The access token was not found');
+			expect(stdout).to.include('Error showing product device detail: The access token was not found');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(1);
 		});
@@ -260,8 +257,7 @@ describe('Product Commands', () => {
 			expect(json.meta).to.have.all.keys('version');
 			expect(json.meta.version).to.equal('1.0.0');
 			expect(json.error).to.have.property('message').that.is.a('string');
-			expect(json.error.message).include('HTTP error 400');
-			expect(json.error.message).include('The access token was not found');
+			expect(json.error.message).include('Error showing product device detail: The access token was not found');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(1);
 		});

--- a/test/e2e/variable.e2e.js
+++ b/test/e2e/variable.e2e.js
@@ -59,76 +59,82 @@ describe('Variable Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Lists all available variables', async () => {
-		const platform = capitalize(DEVICE_PLATFORM_NAME);
-		const { stdout, stderr, exitCode } = await cli.run(['variable', 'list']);
+	describe('Variable List Subcommand', () => {
+		it('Lists all available variables', async () => {
+			const platform = capitalize(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(['variable', 'list']);
 
-		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-		expect(stdout).to.include('name (string)');
-		expect(stdout).to.include('version (int32)');
-		expect(stdout).to.include('blinking (int32)');
-		expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stdout).to.include('name (string)');
+			expect(stdout).to.include('version (int32)');
+			expect(stdout).to.include('blinking (int32)');
+			expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists all available variables (alt)', async () => {
+			const platform = capitalize(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(['variable', 'get']);
+
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stdout).to.include('name (string)');
+			expect(stdout).to.include('version (int32)');
+			expect(stdout).to.include('blinking (int32)');
+			expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists variables available on device and prompts to pick', async () => {
+			const subprocess = cli.run(['variable', 'get', DEVICE_ID]);
+
+			await delay(1000);
+			subprocess.stdin.end('\n');
+
+			const { stdout, stderr, exitCode } = await subprocess;
+
+			expect(stdout).to.include('Which variable did you want? (Use arrow keys)');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Lists all available variables (alt)', async () => {
-		const platform = capitalize(DEVICE_PLATFORM_NAME);
-		const { stdout, stderr, exitCode } = await cli.run(['variable', 'get']);
+	describe('Variable Get Subcommand', () => {
+		it('Gets a variable by name', async () => {
+			const args = ['get', DEVICE_ID, 'version'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-		expect(stdout).to.include('name (string)');
-		expect(stdout).to.include('version (int32)');
-		expect(stdout).to.include('blinking (int32)');
-		expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.equal('42');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Gets a variable by name with timestamp', async () => {
+			const args = ['variable', 'get', DEVICE_ID, 'version', '--time'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const [timestamp, version] = stdout.split(', ');
+
+			expect(timestamp.split(':')).to.have.lengthOf(4);
+			expect(version).to.equal('42');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Lists variables available on device and prompts to pick', async () => {
-		const subprocess = cli.run(['variable', 'get', DEVICE_ID]);
+	describe('Variable Get Subcommand', () => {
+		it('Monitors a variable', async () => {
+			const args = ['variable', 'monitor', DEVICE_ID, 'version', '--delay', 1000];
+			const subprocess = cli.run(args);
 
-		await delay(1000);
-		subprocess.stdin.end('\n');
+			await delay(5000);
+			subprocess.cancel(); // CTRL-C
 
-		const { stdout, stderr, exitCode } = await subprocess;
+			const { all, isCanceled } = await subprocess;
+			const [msg, ...results] = all.split('\n');
 
-		expect(stdout).to.include('Which variable did you want? (Use arrow keys)');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Gets a variable by name', async () => {
-		const args = ['get', DEVICE_ID, 'version'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('42');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Gets a variable by name with timestamp', async () => {
-		const args = ['variable', 'get', DEVICE_ID, 'version', '--time'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const [timestamp, version] = stdout.split(', ');
-
-		expect(timestamp.split(':')).to.have.lengthOf(4);
-		expect(version).to.equal('42');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Monitors a variable', async () => {
-		const args = ['variable', 'monitor', DEVICE_ID, 'version', '--delay', 1000];
-		const subprocess = cli.run(args);
-
-		await delay(5000);
-		subprocess.cancel(); // CTRL-C
-
-		const { all, isCanceled } = await subprocess;
-		const [msg, ...results] = all.split('\n');
-
-		expect(msg).to.equal('Hit CTRL-C to stop!');
-		expect(results).to.have.lengthOf.above(2);
-		expect(isCanceled).to.equal(true);
+			expect(msg).to.equal('Hit CTRL-C to stop!');
+			expect(results).to.have.lengthOf.above(2);
+			expect(isCanceled).to.equal(true);
+		});
 	});
 });
 

--- a/test/e2e/variable.e2e.js
+++ b/test/e2e/variable.e2e.js
@@ -1,9 +1,11 @@
+const capitalize = require('lodash/capitalize');
 const { expect } = require('../setup');
 const { delay } = require('../lib/mocha-utils');
 const cli = require('../lib/cli');
 const {
 	DEVICE_ID,
-	DEVICE_NAME
+	DEVICE_NAME,
+	DEVICE_PLATFORM_NAME
 } = require('../lib/env');
 
 
@@ -58,9 +60,10 @@ describe('Variable Commands [@device]', () => {
 	});
 
 	it('Lists all available variables', async () => {
+		const platform = capitalize(DEVICE_PLATFORM_NAME);
 		const { stdout, stderr, exitCode } = await cli.run(['variable', 'list']);
 
-		expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
+		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
 		expect(stdout).to.include('name (string)');
 		expect(stdout).to.include('version (int32)');
 		expect(stdout).to.include('blinking (int32)');
@@ -69,9 +72,10 @@ describe('Variable Commands [@device]', () => {
 	});
 
 	it('Lists all available variables (alt)', async () => {
+		const platform = capitalize(DEVICE_PLATFORM_NAME);
 		const { stdout, stderr, exitCode } = await cli.run(['variable', 'get']);
 
-		expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
+		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
 		expect(stdout).to.include('name (string)');
 		expect(stdout).to.include('version (int32)');
 		expect(stdout).to.include('blinking (int32)');


### PR DESCRIPTION

## Description

Adds support for optional `--product <id>` flag to the `particle variable get` command to fetch a variable from a product device ([ch](https://app.clubhouse.io/particle/story/45004/enable-reading-a-cloud-variable-from-a-product-device))

## How to Test

_Note: requires you to have a Particle product with one or more devices_

Run `particle variable get --help` and explore the command and options.

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

