### PR TITLE
feature/products-device-call-fn

### DIFF
--- a/src/cli/function.js
+++ b/src/cli/function.js
@@ -2,9 +2,9 @@ module.exports = ({ commandProcessor, root }) => {
 	const func = commandProcessor.createCategory(root, 'function', 'Call functions on your device');
 
 	commandProcessor.createCommand(func, 'list', 'Show functions provided by your device(s)', {
-		handler: (args) => {
+		handler: () => {
 			const FunctionCommand = require('../cmd/function');
-			return new FunctionCommand(args).listFunctions();
+			return new FunctionCommand().listFunctions();
 		}
 	});
 
@@ -12,7 +12,7 @@ module.exports = ({ commandProcessor, root }) => {
 		params: '<device> <function> [argument]',
 		handler: (args) => {
 			const FunctionCommand = require('../cmd/function');
-			return new FunctionCommand().callFunction(args.params.device, args.params['function'], args.params.argument);
+			return new FunctionCommand().callFunction(args);
 
 		},
 		examples: {

--- a/src/cli/function.js
+++ b/src/cli/function.js
@@ -10,6 +10,11 @@ module.exports = ({ commandProcessor, root }) => {
 
 	commandProcessor.createCommand(func, 'call', 'Call a particular function on a device', {
 		params: '<device> <function> [argument]',
+		options: {
+			'product': {
+				description: 'Target a device within the given Product ID or Slug'
+			}
+		},
 		handler: (args) => {
 			const FunctionCommand = require('../cmd/function');
 			return new FunctionCommand().callFunction(args);
@@ -17,7 +22,8 @@ module.exports = ({ commandProcessor, root }) => {
 		},
 		examples: {
 			'$0 $command coffee brew': 'Call the brew function on the coffee device',
-			'$0 $command board digitalWrite D7=HIGH': 'Call the digitalWrite function with argument D7=HIGH on the board device'
+			'$0 $command board digitalWrite D7=HIGH': 'Call the digitalWrite function with argument D7=HIGH on the board device',
+			'$0 $command coffee brew --product 12345': 'Call the brew function on the coffee device within product 12345'
 		}
 	});
 

--- a/src/cli/function.test.js
+++ b/src/cli/function.test.js
@@ -1,0 +1,119 @@
+const os = require('os');
+const { expect } = require('../../test/setup');
+const commandProcessor = require('../app/command-processor');
+const func = require('./function');
+
+
+describe('Function Command-Line Interface', () => {
+	const termWidth = null; // don't right-align option type labels so testing is easier
+	let root;
+
+	beforeEach(() => {
+		root = commandProcessor.createAppCategory();
+		func({ root, commandProcessor });
+	});
+
+	describe('Top-Level `function` Namespace', () => {
+		it('Handles `function` command', () => {
+			const argv = commandProcessor.parse(root, ['function']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.equal(undefined);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['function', '--help']);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Call functions on your device',
+					'Usage: particle function <command>',
+					'Help:  particle help function <command>',
+					'',
+					'Commands:',
+					'  list  Show functions provided by your device(s)',
+					'  call  Call a particular function on a device',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `function list` Namespace', () => {
+		it('Handles `list` command', () => {
+			const argv = commandProcessor.parse(root, ['function', 'list']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Includes help', () => {
+			commandProcessor.parse(root, ['function', 'list', '--help']);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Show functions provided by your device(s)',
+					'Usage: particle function list [options]',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `function call` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['function', 'call', 'my-device', 'my-fn']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', function: 'my-fn', argument: undefined });
+			expect(argv.product).to.equal(undefined);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['function', 'call', 'my-device', 'my-fn', 'my-fn-arg']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', function: 'my-fn', argument: 'my-fn-arg' });
+			expect(argv.product).to.equal(undefined);
+		});
+
+		it('Parses options', () => {
+			const argv = commandProcessor.parse(root, ['function', 'call', 'my-device', 'my-fn', 'my-fn-arg', '--product', '12345']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', function: 'my-fn', argument: 'my-fn-arg' });
+			expect(argv.product).to.equal('12345');
+		});
+
+		it('Errors when required `device` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['function', 'call']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'device\' is required.');
+			expect(argv.clierror).to.have.property('data', 'device');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Errors when required `function` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['function', 'call', 'my-device']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'function\' is required.');
+			expect(argv.clierror).to.have.property('data', 'function');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({ device: 'my-device' });
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['function', 'call', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Call a particular function on a device',
+					'Usage: particle function call [options] <device> <function> [argument]',
+					'',
+					'Options:',
+					'  --product  Target a device within the given Product ID or Slug  [string]',
+					'',
+					'Examples:',
+					'  particle function call coffee brew                  Call the brew function on the coffee device',
+					'  particle function call board digitalWrite D7=HIGH   Call the digitalWrite function with argument D7=HIGH on the board device',
+					'  particle function call coffee brew --product 12345  Call the brew function on the coffee device within product 12345',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+});
+

--- a/src/cli/variable.js
+++ b/src/cli/variable.js
@@ -19,7 +19,7 @@ module.exports = ({ commandProcessor, root }) => {
 		params: '[device] [variableName]',
 		options: Object.assign({}, timeOption, {
 			'product': {
-				description: 'product id or slug'
+				description: 'Target a device within the given Product ID or Slug'
 			}
 		}),
 		handler: (args) => {
@@ -28,7 +28,8 @@ module.exports = ({ commandProcessor, root }) => {
 		},
 		examples: {
 			'$0 $command basement temperature': 'Read the temperature variable from the device basement',
-			'$0 $command all temperature': 'Read the temperature variable from all my devices',
+			'$0 $command basement temperature --product 12345': 'Read the temperature variable from the device basement within product 12345',
+			'$0 $command all temperature': 'Read the temperature variable from all my devices'
 		}
 	});
 

--- a/src/cli/variable.test.js
+++ b/src/cli/variable.test.js
@@ -88,11 +88,12 @@ describe('Variable Command-Line Interface', () => {
 					'',
 					'Options:',
 					'  --time     Show the time when the variable was received  [boolean]',
-					'  --product  product id or slug  [string]',
+					'  --product  Target a device within the given Product ID or Slug  [string]',
 					'',
 					'Examples:',
-					'  particle variable get basement temperature  Read the temperature variable from the device basement',
-					'  particle variable get all temperature       Read the temperature variable from all my devices',
+					'  particle variable get basement temperature                  Read the temperature variable from the device basement',
+					'  particle variable get basement temperature --product 12345  Read the temperature variable from the device basement within product 12345',
+					'  particle variable get all temperature                       Read the temperature variable from all my devices',
 					''
 				].join(os.EOL));
 			});

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -113,6 +113,18 @@ module.exports = class ParticleApi {
 		);
 	}
 
+	callFunction(deviceId, name, argument, product){
+		return this._wrap(
+			this.api.callFunction({
+				name,
+				argument,
+				deviceId,
+				product,
+				auth: this.accessToken
+			})
+		);
+	}
+
 	downloadFirmwareBinary(binaryId, downloadPath){
 		return new Promise((resolve, reject) => {
 			const req = this.api.downloadFirmwareBinary({ binaryId, auth: this.accessToken });

--- a/src/cmd/function.js
+++ b/src/cmd/function.js
@@ -1,7 +1,9 @@
+const os = require('os');
 const VError = require('verror');
+const ParticleAPI = require('./api');
 const LegacyApiClient = require('../lib/api-client');
-const ensureError = require('../lib/utilities').ensureError;
 const spinnerMixin = require('../lib/spinner-mixin');
+const settings = require('../../settings');
 const UI = require('../lib/ui');
 
 const { normalizedApiError } = LegacyApiClient;
@@ -31,21 +33,43 @@ module.exports = class FunctionCommand {
 			});
 	}
 
-	callFunction({ params: { device, function: fn, argument: arg } }){
-		const api = new LegacyApiClient();
-		api.ensureToken();
+	callFunction({ product, params: { device, function: fn, argument: arg } }){
+		let msg = `Calling function ${fn} from device ${device}`;
 
-		return api.callFunction(device, fn, arg)
-			.then(result => {
-				if (result && result.hasOwnProperty('return_value')){
-					console.log(result.return_value);
-				} else {
-					throw api.normalizedApiError(result);
+		if (product){
+			msg += ` in product ${product}`;
+		}
+
+		const fetchVar = createAPI().callFunction(device, fn, arg, product);
+		return this.showBusySpinnerUntilResolved(msg, fetchVar)
+			.then(res => {
+				if (!res || !res.hasOwnProperty('return_value')){
+					throw res;
 				}
+				this.ui.stdout.write(`${res.return_value}${os.EOL}`);
 			})
-			.catch(err => {
-				throw new VError(ensureError(err), 'Function call failed');
+			.catch(error => {
+				let message = `Error calling function: \`${fn}\``;
+
+				if (error && error.statusCode === 404){
+					message = `Function call failed: Function \`${fn}\` not found`;
+				}
+				throw createAPIErrorResult({ error, message });
 			});
 	}
 };
+
+// UTILS //////////////////////////////////////////////////////////////////////
+function createAPI(){
+	return new ParticleAPI(settings.apiUrl, {
+		accessToken: settings.access_token
+	});
+}
+
+function createAPIErrorResult({ error: e, message, json }){
+	const error = new VError(normalizedApiError(e), message);
+	error.asJSON = json;
+	return error;
+}
+
 

--- a/src/cmd/function.js
+++ b/src/cmd/function.js
@@ -1,52 +1,51 @@
 const VError = require('verror');
-const ApiClient = require('../lib/api-client');
+const LegacyApiClient = require('../lib/api-client');
 const ensureError = require('../lib/utilities').ensureError;
+const spinnerMixin = require('../lib/spinner-mixin');
+const UI = require('../lib/ui');
+
+const { normalizedApiError } = LegacyApiClient;
 
 
 module.exports = class FunctionCommand {
-	listFunctions() {
-		const api = new ApiClient();
-		api.ensureToken();
-
-		return api.getAllAttributes().then(devices => {
-			let lines = [];
-			for (let i = 0; i < devices.length; i++) {
-
-				const device = devices[i];
-				const available = [];
-				if (device.functions) {
-
-					for (let idx = 0; idx < device.functions.length; idx++) {
-						const name = device.functions[idx];
-						available.push('  int ' + name + '(String args) ');
-					}
-				}
-
-				let status = device.name + ' (' + device.id + ') has ' + available.length + ' functions ';
-				if (available.length === 0) {
-					status += ' (or is offline) ';
-				}
-
-				lines.push(status);
-				lines = lines.concat(available);
-			}
-			console.log(lines.join('\n'));
-		});
+	constructor({
+		stdin = process.stdin,
+		stdout = process.stdout,
+		stderr = process.stderr
+	} = {}){
+		this.stdin = stdin;
+		this.stdout = stdout;
+		this.stderr = stderr;
+		this.ui = new UI({ stdin, stdout, stderr });
+		spinnerMixin(this);
 	}
 
-	callFunction(deviceId, functionName, funcParam) {
-		const api = new ApiClient();
+	listFunctions(){
+		const api = new LegacyApiClient();
 		api.ensureToken();
 
-		return api.callFunction(deviceId, functionName, funcParam).then(result => {
-			if (result && result.hasOwnProperty('return_value')) {
-				console.log(result.return_value);
-			} else {
-				throw api.normalizedApiError(result);
-			}
-		}).catch(err => {
-			throw new VError(ensureError(err), 'Function call failed');
-		});
+		return api.getAllAttributes()
+			.then(devices => this.ui.logDeviceDetail(devices, { fnsOnly: true }))
+			.catch(err => {
+				throw new VError(normalizedApiError(err), 'Error while listing variables');
+			});
+	}
+
+	callFunction({ params: { device, function: fn, argument: arg } }){
+		const api = new LegacyApiClient();
+		api.ensureToken();
+
+		return api.callFunction(device, fn, arg)
+			.then(result => {
+				if (result && result.hasOwnProperty('return_value')){
+					console.log(result.return_value);
+				} else {
+					throw api.normalizedApiError(result);
+				}
+			})
+			.catch(err => {
+				throw new VError(ensureError(err), 'Function call failed');
+			});
 	}
 };
 

--- a/src/cmd/function.test.js
+++ b/src/cmd/function.test.js
@@ -20,12 +20,12 @@ const FunctionCommand = proxyquire('./function', {
 
 describe('Function Command', () => {
 	const sandbox = sinon.createSandbox();
-	let deviceId, functionName, functionParam;
+	let device, fn, arg;
 
 	beforeEach(() => {
-		deviceId = 'test-device';
-		functionName = 'fn';
-		functionParam = 'param';
+		device = 'test-device';
+		fn = 'fn';
+		arg = 'param';
 	});
 
 	afterEach(() => {
@@ -34,35 +34,37 @@ describe('Function Command', () => {
 
 	describe('when the function succeeds', () => {
 		it('prints the return value', withConsoleStubs(sandbox, () => {
-			const { func, api } = stubForFunction(new FunctionCommand(), stubs);
+			const { cmd, api } = stubForFunction(new FunctionCommand(), stubs);
 			api.callFunction.resolves({ ok: true, return_value: 42 });
 
-			return func.callFunction(deviceId, functionName, functionParam)
+			return cmd.callFunction({ params: { device, function: fn, argument: arg } })
 				.then(() => expectSuccessMessage(42));
 		}));
 
 		it('prints the return value of 0', withConsoleStubs(sandbox, () => {
-			const { func, api } = stubForFunction(new FunctionCommand(), stubs);
+			const { cmd, api } = stubForFunction(new FunctionCommand(), stubs);
 			api.callFunction.resolves({ ok: true, return_value: 0 });
 
-			return func.callFunction(deviceId, functionName, functionParam)
+			return cmd.callFunction({ params: { device, function: fn, argument: arg } })
 				.then(() => expectSuccessMessage(0));
 		}));
 	});
 
 	describe('when the function does not exist', () => {
 		it('rejects with an error',() => {
-			const { func, api } = stubForFunction(new FunctionCommand(), stubs);
+			const { cmd, api } = stubForFunction(new FunctionCommand(), stubs);
 			api.callFunction.resolves({
 				ok: false,
-				error: `Function ${functionName} not found`
+				error: `Function ${fn} not found`
 			});
 
-			return func.callFunction(deviceId, functionName, functionParam).then(() => {
-				throw new Error('expected promise to be rejected');
-			}).catch(error => {
-				expect(error).to.have.property('message', `Function call failed: Function ${functionName} not found`);
-			});
+			return cmd.callFunction({ params: { device, function: fn, argument: arg } })
+				.then(() => {
+					throw new Error('expected promise to be rejected');
+				})
+				.catch(error => {
+					expect(error).to.have.property('message', `Function call failed: Function ${fn} not found`);
+				});
 		});
 	});
 
@@ -72,11 +74,11 @@ describe('Function Command', () => {
 			.to.match(new RegExp(`${value}\\n$`));
 	}
 
-	function stubForFunction(func, stubs){
+	function stubForFunction(cmd, stubs){
 		const { api } = stubs;
 		sandbox.stub(api, 'ensureToken');
 		sandbox.stub(api, 'callFunction');
-		return { func, api };
+		return { cmd, api };
 	}
 });
 

--- a/src/cmd/function.test.js
+++ b/src/cmd/function.test.js
@@ -1,28 +1,32 @@
-const proxyquire = require('proxyquire');
+const os = require('os');
+const stream = require('stream');
+const ParticleAPI = require('./api');
 const { expect, sinon } = require('../../test/setup');
-const { withConsoleStubs } = require('../../test/lib/mocha-utils');
-
-const stubs = {
-	api: {
-		ensureToken: () => {},
-		callFunction: () => {},
-		normalizedApiError: (resp) => new Error(resp.error),
-	},
-	ApiClient: function ApiClient(){
-		return stubs.api;
-	}
-};
-
-const FunctionCommand = proxyquire('./function', {
-	'../lib/api-client': stubs.ApiClient
-});
+const FunctionCommand = require('./function');
 
 
 describe('Function Command', () => {
 	const sandbox = sinon.createSandbox();
-	let device, fn, arg;
+	let command, stdin, stdout, stderr, device, fn, arg, product;
 
 	beforeEach(() => {
+		sandbox.stub(ParticleAPI.prototype, 'callFunction');
+
+		stdin = new stream.Readable();
+		stdout = new stream.Writable({
+			write: function write(chunk, encoding, callback){
+				this.content = (this.content || '') + chunk;
+				callback();
+			}
+		});
+		stderr = new stream.Writable({
+			write: function write(chunk, encoding, callback){
+				this.errorContent = (this.errorContent || '') + chunk;
+				callback();
+			}
+		});
+
+		command = new FunctionCommand({ stdin, stdout, stderr });
 		device = 'test-device';
 		fn = 'fn';
 		arg = 'param';
@@ -33,52 +37,44 @@ describe('Function Command', () => {
 	});
 
 	describe('when the function succeeds', () => {
-		it('prints the return value', withConsoleStubs(sandbox, () => {
-			const { cmd, api } = stubForFunction(new FunctionCommand(), stubs);
-			api.callFunction.resolves({ ok: true, return_value: 42 });
-
-			return cmd.callFunction({ params: { device, function: fn, argument: arg } })
-				.then(() => expectSuccessMessage(42));
-		}));
-
-		it('prints the return value of 0', withConsoleStubs(sandbox, () => {
-			const { cmd, api } = stubForFunction(new FunctionCommand(), stubs);
-			api.callFunction.resolves({ ok: true, return_value: 0 });
-
-			return cmd.callFunction({ params: { device, function: fn, argument: arg } })
-				.then(() => expectSuccessMessage(0));
-		}));
-	});
-
-	describe('when the function does not exist', () => {
-		it('rejects with an error',() => {
-			const { cmd, api } = stubForFunction(new FunctionCommand(), stubs);
-			api.callFunction.resolves({
-				ok: false,
-				error: `Function ${fn} not found`
-			});
-
-			return cmd.callFunction({ params: { device, function: fn, argument: arg } })
+		it('prints the return value', () => {
+			ParticleAPI.prototype.callFunction.resolves({ ok: true, return_value: 42 });
+			return command.callFunction({ params: { device, function: fn, argument: arg } })
 				.then(() => {
-					throw new Error('expected promise to be rejected');
-				})
-				.catch(error => {
-					expect(error).to.have.property('message', `Function call failed: Function ${fn} not found`);
+					expect(stdout.content).to.eql(`42${os.EOL}`);
+					expect(product).to.equal(undefined);
+					expect(ParticleAPI.prototype.callFunction)
+						.to.have.property('callCount', 1);
+					expect(ParticleAPI.prototype.callFunction.firstCall.args)
+						.to.eql([device, fn, arg, product]);
+				});
+		});
+
+		it('prints the return value of 0', () => {
+			ParticleAPI.prototype.callFunction.resolves({ ok: true, return_value: 0 });
+			return command.callFunction({ params: { device, function: fn, argument: arg } })
+				.then(() => {
+					expect(stdout.content).to.eql(`0${os.EOL}`);
+					expect(product).to.equal(undefined);
+					expect(ParticleAPI.prototype.callFunction)
+						.to.have.property('callCount', 1);
+					expect(ParticleAPI.prototype.callFunction.firstCall.args)
+						.to.eql([device, fn, arg, product]);
 				});
 		});
 	});
 
-	function expectSuccessMessage(value){
-		expect(process.stdout.write).to.have.property('callCount', 1);
-		expect(process.stdout.write.firstCall.args[0])
-			.to.match(new RegExp(`${value}\\n$`));
-	}
-
-	function stubForFunction(cmd, stubs){
-		const { api } = stubs;
-		sandbox.stub(api, 'ensureToken');
-		sandbox.stub(api, 'callFunction');
-		return { cmd, api };
-	}
+	describe('when the function does not exist', () => {
+		it('rejects with an error',() => {
+			ParticleAPI.prototype.callFunction.resolves({ ok: false, error: `Function ${fn} not found` });
+			return command.callFunction({ params: { device, function: fn, argument: arg } })
+				.then(() => {
+					throw new Error('expected promise to be rejected');
+				})
+				.catch(error => {
+					expect(error).to.have.property('message', `Error calling function: \`${fn}\`: Function fn not found`);
+				});
+		});
+	});
 });
 

--- a/test/e2e/call.e2e.js
+++ b/test/e2e/call.e2e.js
@@ -57,7 +57,7 @@ describe('Call Commands [@device]', () => {
 		const args = ['call', DEVICE_NAME, 'check'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal('200');
+		expect(stdout.slice(-3)).to.equal('200');
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
 	});
@@ -66,7 +66,7 @@ describe('Call Commands [@device]', () => {
 		const args = ['call', DEVICE_NAME, 'WATNOPE'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal('Function call failed: Function WATNOPE not found');
+		expect(stdout).to.include('Function call failed: Function `WATNOPE` not found');
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(1);
 	});

--- a/test/e2e/function.e2e.js
+++ b/test/e2e/function.e2e.js
@@ -4,11 +4,15 @@ const cli = require('../lib/cli');
 const {
 	DEVICE_ID,
 	DEVICE_NAME,
-	DEVICE_PLATFORM_NAME
+	DEVICE_PLATFORM_NAME,
+	PRODUCT_01_ID,
+	PRODUCT_01_DEVICE_01_ID,
+	PRODUCT_01_DEVICE_01_NAME
 } = require('../lib/env');
 
 
 describe('Function Commands [@device]', () => {
+	const fn = 'check';
 	const help = [
 		'Call functions on your device',
 		'Usage: particle function <command>',
@@ -69,19 +73,60 @@ describe('Function Commands [@device]', () => {
 	});
 
 	it('Calls a function', async () => {
-		const args = ['function', 'call', DEVICE_NAME, 'check'];
+		const args = ['function', 'call', DEVICE_NAME, fn];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal('200');
+		expect(stdout.slice(-3)).to.equal('200');
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
+	});
+
+	it('Calls a function', async () => {
+		const args = ['function', 'call', DEVICE_NAME, fn];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout.slice(-3)).to.equal('200');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	// TODO (mirande): need to ensure device is running expected firmware and online
+	// once flashing product devices is implemented - as it is, the expectation
+	// is that your product device is running the `stroby` firmware found in:
+	// test/__fixtures__/projects/stroby - see: cli.flashStrobyFirmwareOTAForTest()
+	it('Calls a function on a product device', async () => {
+		const args = ['function', 'call', PRODUCT_01_DEVICE_01_ID, fn, '--product', PRODUCT_01_ID];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout.slice(-3)).to.equal('200');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	// TODO (mirande): this seems like a bug
+	it('Fails when attempting to calls a function on a product device by name', async () => {
+		const args = ['function', 'call', PRODUCT_01_DEVICE_01_NAME, fn, '--product', PRODUCT_01_ID];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.include(`Function call failed: Function \`${fn}\` not found`);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(1);
+	});
+
+	it('Fails when attempting to target an unknown device', async () => {
+		const args = ['function', 'call', 'DOESNOTEXIST', 'WATNOPE'];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.include('Error calling function: `WATNOPE`');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(1);
 	});
 
 	it('Fails when attempting to call an unknown function', async () => {
 		const args = ['function', 'call', DEVICE_NAME, 'WATNOPE'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal('Function call failed: Function WATNOPE not found');
+		expect(stdout).to.include('Function call failed: Function `WATNOPE` not found');
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(1);
 	});

--- a/test/e2e/function.e2e.js
+++ b/test/e2e/function.e2e.js
@@ -1,8 +1,10 @@
+const capitalize = require('lodash/capitalize');
 const { expect } = require('../setup');
 const cli = require('../lib/cli');
 const {
 	DEVICE_ID,
-	DEVICE_NAME
+	DEVICE_NAME,
+	DEVICE_PLATFORM_NAME
 } = require('../lib/env');
 
 
@@ -56,11 +58,12 @@ describe('Function Commands [@device]', () => {
 	});
 
 	it('Lists available functions', async () => {
+		const platform = capitalize(DEVICE_PLATFORM_NAME);
 		const { stdout, stderr, exitCode } = await cli.run(['function', 'list']);
 
-		expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
-		expect(stdout).to.include('int toggle(String args)');
-		expect(stdout).to.include('int check(String args)');
+		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+		expect(stdout).to.include('int toggle (String args)');
+		expect(stdout).to.include('int check (String args)');
 		expect(stderr).to.include('polling server to see what devices are online, and what functions are available');
 		expect(exitCode).to.equal(0);
 	});

--- a/test/e2e/get.e2e.js
+++ b/test/e2e/get.e2e.js
@@ -20,10 +20,12 @@ describe('Get Commands [@device]', () => {
 		'',
 		'Options:',
 		'  --time  Show the time when the variable was received  [boolean]',
+		'  --product  Target a device within the given Product ID or Slug  [string]',
 		'',
 		'Examples:',
-		'  particle get basement temperature  Read the temperature variable from the device basement',
-		'  particle get all temperature       Read the temperature variable from all my devices'
+		'  particle get basement temperature                  Read the temperature variable from the device basement',
+		'  particle get basement temperature --product 12345  Read the temperature variable from the device basement within product 12345',
+		'  particle get all temperature                       Read the temperature variable from all my devices'
 	];
 
 	before(async () => {

--- a/test/e2e/variable.e2e.js
+++ b/test/e2e/variable.e2e.js
@@ -112,11 +112,12 @@ describe('Variable Commands [@device]', () => {
 			'',
 			'Options:',
 			'  --time     Show the time when the variable was received  [boolean]',
-			'  --product  product id or slug  [string]',
+			'  --product  Target a device within the given Product ID or Slug  [string]',
 			'',
 			'Examples:',
-			'  particle get basement temperature  Read the temperature variable from the device basement',
-			'  particle get all temperature       Read the temperature variable from all my devices'
+			'  particle get basement temperature                  Read the temperature variable from the device basement',
+			'  particle get basement temperature --product 12345  Read the temperature variable from the device basement within product 12345',
+			'  particle get all temperature                       Read the temperature variable from all my devices'
 		];
 
 		it('Gets a variable by name', async () => {

--- a/test/lib/cli.js
+++ b/test/lib/cli.js
@@ -128,12 +128,6 @@ module.exports.removeDeviceFromMeshNetwork = () => {
 	return run(['mesh', 'remove', DEVICE_ID, '--yes'], { reject: true });
 };
 
-module.exports.getNameVariable = async () => {
-	const { run } = module.exports;
-	const { stdout } = await run(['get', DEVICE_NAME, 'name'], { reject: true });
-	return stdout;
-};
-
 module.exports.waitForVariable = async (name, value) => {
 	const { run } = module.exports;
 	await delay(2000);


### PR DESCRIPTION
## Description

Adds support for optional `--product <id>` flag to the `particle function call` command to call a function on a product device ([ch](https://app.clubhouse.io/particle/story/46267/enable-calling-a-cloud-function-from-a-product-device))

## How to Test

_Note: requires you to have a Particle product with one or more devices_

Run `particle function call --help` and explore the command and options.

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

