### PR TITLE
feature/ch42725/usb-dfu-confirm

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2033,9 +2033,9 @@
       }
     },
     "@babel/runtime-corejs2": {
-      "version": "7.7.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.6.tgz",
-      "integrity": "sha512-QYp/8xdH8iMin3pH5gtT/rUuttVfIcOhWBC3wh9Eh/qs4jEe39+3DpCDLgWXhMQgiCTOH8mrLSvQ0OHOCcox9g==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.8.4.tgz",
+      "integrity": "sha512-7jU2FgNqNHX6yTuU/Dr/vH5/O8eVL9U85MG5aDw1LzGfCvvhXC1shdXfVzCQDsoY967yrAKeLujRv7l8BU+dZA==",
       "optional": true,
       "requires": {
         "core-js": "^2.6.5",
@@ -2430,15 +2430,15 @@
       }
     },
     "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.1.tgz",
+      "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==",
       "optional": true
     },
     "@types/node": {
-      "version": "10.17.9",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.9.tgz",
-      "integrity": "sha512-+6VygF9LbG7Gaqeog2G7u1+RUcmo0q1rI+2ZxdIg2fAUngk5Vz9fOCHXdloNUOHEPd1EuuOpL5O0CdgN9Fx5UQ==",
+      "version": "10.17.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.17.tgz",
+      "integrity": "sha512-gpNnRnZP3VWzzj5k3qrpRC6Rk3H/uclhAVo1aIvwzK5p5cOrs9yEyQ8H/HBsBY0u5rrWxXEiVPQ0dEB6pkjE8Q==",
       "optional": true
     },
     "acorn": {
@@ -8687,9 +8687,9 @@
       }
     },
     "particle-usb": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-0.5.2.tgz",
-      "integrity": "sha512-Tj7ntei6O0WrCeHe7WHGaMql5kffEpb3eG0lpbJEVPTx5xwljqwB7ZHTCxzmTtrmP0ioJ88yyOs3MAfXXtjhAw==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-0.5.4.tgz",
+      "integrity": "sha512-d05F6QkJfZQyn/Lyzmc9rf7qrMgPn4nzp1PfAHxKSABRZU/9i8MW2vVHBUIoRe0ixe5g+rr2eyzxY0l3qgvywA==",
       "optional": true,
       "requires": {
         "@babel/runtime-corejs2": "^7.3.4",
@@ -10923,9 +10923,9 @@
           }
         },
         "chownr": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-          "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw==",
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
           "optional": true
         },
         "decompress-response": {
@@ -10953,9 +10953,9 @@
           }
         },
         "mimic-response": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.0.0.tgz",
-          "integrity": "sha512-8ilDoEapqA4uQ3TwS0jakGONKXVJqpy+RpM+3b7pLdOjghCrEiGp9SRkFbUHAmZW9vdnrENWHjaweIoTIJExSQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+          "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
           "optional": true
         },
         "prebuild-install": {
@@ -11004,9 +11004,9 @@
           }
         },
         "readable-stream": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "optional": true,
           "requires": {
             "inherits": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "sinon-chai": "^3.3.0"
   },
   "optionalDependencies": {
-    "particle-usb": "^0.5.2",
+    "particle-usb": "^0.5.4",
     "serialport": "^8.0.5"
   },
   "engines": {

--- a/src/app/command-processor.js
+++ b/src/app/command-processor.js
@@ -613,9 +613,9 @@ function createCommand(category, name, description, options){
  * Options/booleans are attributes of the object. The property `clicommand` contains the command corresponding
  * to the requested command. `clierror` contains any error encountered durng parsing.
  */
-function parse(command, args){
+function parse(command, args, width = Yargs.terminalWidth()){
 	Yargs.reset();
-	Yargs.wrap(Yargs.terminalWidth());
+	Yargs.wrap(width);
 	return command.parse(args, Yargs);
 }
 

--- a/src/cli/usb.test.js
+++ b/src/cli/usb.test.js
@@ -1,0 +1,340 @@
+const os = require('os');
+const { expect } = require('../../test/setup');
+const commandProcessor = require('../app/command-processor');
+const usb = require('./usb');
+
+
+describe('USB Command-Line Interface', () => {
+	const termWidth = null; // don't right-align option type labels so testing is easier
+	let root;
+
+	beforeEach(() => {
+		root = commandProcessor.createAppCategory();
+		usb({ root, commandProcessor });
+	});
+
+	describe('Top-Level `usb` Namespace', () => {
+		it('Handles `usb` command', () => {
+			const argv = commandProcessor.parse(root, ['usb']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.equal(undefined);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['usb', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Control USB devices',
+					'Usage: particle usb <command>',
+					'Help:  particle help usb <command>',
+					'',
+					'Commands:',
+					'  list             List the devices connected to the host computer',
+					'  start-listening  Put a device into the listening mode',
+					'  listen           alias for start-listening',
+					'  stop-listening   Make a device exit the listening mode',
+					'  safe-mode        Put a device into the safe mode',
+					'  dfu              Put a device into the DFU mode',
+					'  reset            Reset a device',
+					'  setup-done       Set the setup done flag',
+					'  configure        Update the system USB configuration',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `usb list` Namespace', () => {
+		it('Handles `list` command', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'list']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Includes help', () => {
+			commandProcessor.parse(root, ['usb', 'list', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'List the devices connected to the host computer',
+					'Usage: particle usb list [options]',
+					'',
+					'Options:',
+					'  --exclude-dfu  Do not list devices which are in DFU mode  [boolean]',
+					'  --ids-only     Print only device IDs  [boolean]',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `usb start-listening` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'start-listening']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'start-listening', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: ['my-device'] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses options flags', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'start-listening', '--all']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(true);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['usb', 'start-listening', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Put a device into the listening mode',
+					'Usage: particle usb start-listening [options] [devices...]',
+					'',
+					'Options:',
+					'  --all  Send the command to all devices connected to the host computer  [boolean]',
+					'',
+					'Examples:',
+					'  particle usb start-listening my_device  Put a device named "my_device" into the listening mode',
+					'  particle usb start-listening --all      Put all devices connected to the host computer into the listening mode',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `usb stop-listening` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'stop-listening']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'stop-listening', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: ['my-device'] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses options flags', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'stop-listening', '--all']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(true);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['usb', 'stop-listening', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Make a device exit the listening mode',
+					'Usage: particle usb stop-listening [options] [devices...]',
+					'',
+					'Options:',
+					'  --all  Send the command to all devices connected to the host computer  [boolean]',
+					'',
+					'Examples:',
+					'  particle usb stop-listening my_device  Make a device named "my_device" exit the listening mode',
+					'  particle usb stop-listening --all      Make all devices connected to the host computer exit the listening mode',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `usb safe-mode` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'safe-mode']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'safe-mode', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: ['my-device'] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses options flags', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'safe-mode', '--all']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(true);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['usb', 'safe-mode', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Put a device into the safe mode',
+					'Usage: particle usb safe-mode [options] [devices...]',
+					'',
+					'Options:',
+					'  --all  Send the command to all devices connected to the host computer  [boolean]',
+					'',
+					'Examples:',
+					'  particle usb safe-mode my_device  Put a device named "my_device" into the safe mode',
+					'  particle usb safe-mode --all      Put all devices connected to the host computer into the safe mode',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `usb dfu` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'dfu']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'dfu', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: ['my-device'] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses options flags', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'dfu', '--all']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(true);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['usb', 'dfu', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Put a device into the DFU mode',
+					'Usage: particle usb dfu [options] [devices...]',
+					'',
+					'Options:',
+					'  --all  Send the command to all devices connected to the host computer  [boolean]',
+					'',
+					'Examples:',
+					'  particle usb dfu my_device  Put a device named "my_device" into the DFU mode',
+					'  particle usb dfu --all      Put all devices connected to the host computer into the DFU mode',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `usb reset` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'reset']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'reset', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: ['my-device'] });
+			expect(argv.all).to.equal(false);
+		});
+
+		it('Parses options flags', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'reset', '--all']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(true);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['usb', 'reset', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Reset a device',
+					'Usage: particle usb reset [options] [devices...]',
+					'',
+					'Options:',
+					'  --all  Send the command to all devices connected to the host computer  [boolean]',
+					'',
+					'Examples:',
+					'  particle usb reset my_device  Reset a device named "my_device"',
+					'  particle usb reset --all      Reset all devices connected to the host computer',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `usb setup-done` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'setup-done']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(false);
+			expect(argv.reset).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'setup-done', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: ['my-device'] });
+			expect(argv.all).to.equal(false);
+			expect(argv.reset).to.equal(false);
+		});
+
+		it('Parses options flags', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'setup-done', '--all', '--reset']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ devices: [] });
+			expect(argv.all).to.equal(true);
+			expect(argv.reset).to.equal(true);
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['usb', 'setup-done', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Set the setup done flag',
+					'Usage: particle usb setup-done [options] [devices...]',
+					'',
+					'Options:',
+					'  --reset  Clear the setup done flag  [boolean]',
+					'  --all    Send the command to all devices connected to the host computer  [boolean]',
+					'',
+					'Examples:',
+					'  particle usb setup-done my_device          Set the setup done flag on the device "my_device"',
+					'  particle usb setup-done --reset my_device  Clear the setup done flag on the device "my_device"',
+					'  particle usb setup-done --all              Set the setup done flag on all devices connected to the host computer',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('Handles `usb configure` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['usb', 'configure']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Includes help with examples', () => {
+			commandProcessor.parse(root, ['usb', 'configure', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Update the system USB configuration',
+					'Usage: particle usb configure [options]',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+});
+

--- a/src/cmd/device-util.js
+++ b/src/cmd/device-util.js
@@ -1,5 +1,3 @@
-const { spin } = require('../app/ui');
-
 /**
  * Check if the string can represent a valid device ID.
  *
@@ -35,7 +33,7 @@ module.exports.formatDeviceInfo = ({ id, type, name = null }) => {
  * @param {Promise<Object>}
  */
 module.exports.getDevice = ({ id, api, auth, displayName = null, dontThrow = false }) => {
-	const getDeviceInfo = api.getDevice({ deviceId: id, auth })
+	return api.getDevice({ deviceId: id, auth })
 		.then(res => res.body)
 		.catch(error => {
 			if (error.statusCode === 403 || error.statusCode === 404) {
@@ -46,7 +44,5 @@ module.exports.getDevice = ({ id, api, auth, displayName = null, dontThrow = fal
 			}
 			throw error;
 		});
-
-	return spin(getDeviceInfo, 'Getting device information...');
 };
 

--- a/src/cmd/mesh.js
+++ b/src/cmd/mesh.js
@@ -432,7 +432,9 @@ module.exports = class MeshCommand {
 	}
 
 	_getDevice(deviceId, dontThrow = false) {
-		return getDevice({ id: deviceId, api: this._api, auth: this._auth, dontThrow });
+		const msg = 'Getting device information...';
+		const operation = getDevice({ id: deviceId, api: this._api, auth: this._auth, dontThrow });
+		return spin(operation, msg);
 	}
 
 	_getNetwork(networkId) {

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -94,7 +94,7 @@ describe('USB Commands [@device]', () => {
 		expect(subproc.exitCode).to.equal(1);
 	});
 
-	it('Sets and clears the setup done flag', async function test() {
+	it('Sets and clears the setup done flag', async () => {
 		await cli.run(['usb', 'setup-done', '--reset']);
 		await delay(2000);
 
@@ -111,5 +111,32 @@ describe('USB Commands [@device]', () => {
 		expect(subproc.stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
 		expect(subproc.stderr).to.equal('');
 		expect(subproc.exitCode).to.equal(0);
+	});
+
+	it('Enters DFU mode with confirmation', async () => {
+		await cli.run(['usb', 'dfu', DEVICE_ID]);
+
+		const platform = capitalize(DEVICE_PLATFORM_NAME);
+		const { stdout, stderr, exitCode } = await cli.run(['usb', 'list']);
+		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, DFU)`);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+
+		await cli.run(['usb', 'reset']);
+		await delay(2000);
+
+		const subproc = await cli.run(['usb', 'list']);
+		expect(subproc.stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+		expect(subproc.stderr).to.equal('');
+		expect(subproc.exitCode).to.equal(0);
+	});
+
+	it('Fails to enter DFU mode when device is unrecognized', async () => {
+		const device = 'DOESNOTEXIST';
+		const { stdout, stderr, exitCode } = await cli.run(['usb', 'dfu', device]);
+
+		expect(stdout).to.equal(`Device not found: ${device}`);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(1);
 	});
 });


### PR DESCRIPTION
## Description

Currently, the `particle usb dfu` command is asynchronous - the command exits before the targeted device(s) are _known_ to be in DFU mode. This makes it hard to compose with other dependent commands like flashing ([example](https://github.com/particle-iot/workbench/blob/2c4fc50773c989effdb93b770e484f0a8b9fd034/packages/particle-toolchains/src/buildscripts/Makefile#L25-L28))

~~This PR adds an optional `--confirm` flag that when invoked causes the `particle usb dfu` command to wait until all targeted devices are confirmed to be in DFU mode.~~

edit: we updated the behavior in `particle-usb` to better align with `.enterListeningMode()`, etc

## How to Test

Using a user application which intentionally makes the device slow / unresponsive to usb commands:

```cpp
// ------------------------
// Simulate "busy" user app
// ------------------------

String name = "busy";
String version = "1.0.0";
unsigned long lastRun = 0;
int timeout = 1;

void setup(){
  Particle.variable("name", &name, STRING);
  Particle.variable("version", &version, STRING);
  Particle.function("timeout", setTimeout);
}

void loop(){
  while(millis() - lastRun < (timeout * 1000));
  lastRun = millis();
  Serial.printlnf("Ran at: %s [timeout: %isec]", Time.timeStr().c_str(), timeout);
}

int setTimeout(String sec){
  timeout = sec.toInt();
  Serial.printlnf("Set Timeout: %i", timeout);
  return timeout;
}
```

1. run `particle function call <device> timeout 10`
2. run `particle usb dfu <device>`
3. observe command exit timing and then reset your device

experiment with longer / shorter timeouts - e.g. `particle function call <device> timeout 30` and try targeting different collections of devices using the `--all` flag, additional named devices, and the default (`particle usb dfu`).


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [ ] CI is passing

