### PR TITLE
feature/ch48802/products-publish

### DIFF
--- a/src/cli/publish.js
+++ b/src/cli/publish.js
@@ -10,6 +10,9 @@ module.exports = ({ commandProcessor, root }) => {
 			'public': {
 				boolean: true,
 				description: 'Publish to the public stream'
+			},
+			'product': {
+				description: 'Publish to the given Product ID or Slug\'s stream'
 			}
 		},
 		handler: (args) => {
@@ -17,7 +20,8 @@ module.exports = ({ commandProcessor, root }) => {
 			return new PublishCommand().publishEvent(args);
 		},
 		examples: {
-			'$0 $command temperature 25.0': 'Publish a temperature event to your private event stream'
+			'$0 $command temp 25.0': 'Publish a temp event to your private event stream',
+			'$0 $command temp 25.0 --product 12345': 'Publish a temp event to your product 12345\'s event stream'
 		}
 	});
 };

--- a/src/cli/publish.js
+++ b/src/cli/publish.js
@@ -14,7 +14,7 @@ module.exports = ({ commandProcessor, root }) => {
 		},
 		handler: (args) => {
 			const PublishCommand = require('../cmd/publish');
-			return new PublishCommand().publishEvent(args.params.event, args.params.data, args);
+			return new PublishCommand().publishEvent(args);
 		},
 		examples: {
 			'$0 $command temperature 25.0': 'Publish a temperature event to your private event stream'

--- a/src/cli/publish.test.js
+++ b/src/cli/publish.test.js
@@ -26,11 +26,12 @@ describe('Publish Command-Line Interface', () => {
 		});
 
 		it('Parses options', () => {
-			const argv = commandProcessor.parse(root, ['publish', 'my-event', '--private', '--public']);
+			const argv = commandProcessor.parse(root, ['publish', 'my-event', '--private', '--public', '--product', '12345']);
 			expect(argv.clierror).to.equal(undefined);
 			expect(argv.params).to.eql({ event: 'my-event', data: undefined });
 			expect(argv.private).to.equal(true);
 			expect(argv.public).to.equal(true);
+			expect(argv.product).to.equal('12345');
 		});
 
 		it('Errors when required `device` argument is missing', () => {
@@ -40,6 +41,11 @@ describe('Publish Command-Line Interface', () => {
 			expect(argv.clierror).to.have.property('data', 'event');
 			expect(argv.clierror).to.have.property('isUsageError', true);
 			expect(argv.params).to.eql({});
+		});
+
+		it('Throws when option flag is malformed', () => {
+			expect(() => commandProcessor.parse(root, ['publish', 'my-event', '--product']))
+				.to.throw('Not enough arguments following: product');
 		});
 
 		it('Includes help with examples', () => {
@@ -53,9 +59,11 @@ describe('Publish Command-Line Interface', () => {
 					'Options:',
 					'  --private  Publish to the private stream  [boolean] [default: true]',
 					'  --public   Publish to the public stream  [boolean]',
+					'  --product  Publish to the given Product ID or Slug\'s stream  [string]',
 					'',
 					'Examples:',
-					'  particle publish temperature 25.0  Publish a temperature event to your private event stream',
+					'  particle publish temp 25.0                  Publish a temp event to your private event stream',
+					'  particle publish temp 25.0 --product 12345  Publish a temp event to your product 12345\'s event stream',
 					''
 				].join(os.EOL));
 			});

--- a/src/cli/publish.test.js
+++ b/src/cli/publish.test.js
@@ -1,0 +1,65 @@
+const os = require('os');
+const { expect } = require('../../test/setup');
+const commandProcessor = require('../app/command-processor');
+const publish = require('./publish');
+
+
+describe('Publish Command-Line Interface', () => {
+	let root;
+
+	beforeEach(() => {
+		root = commandProcessor.createAppCategory();
+		publish({ root, commandProcessor });
+	});
+
+	describe('Top-Level `publish` Namespace', () => {
+		it('Handles `publish` command', () => {
+			const argv = commandProcessor.parse(root, ['publish', 'my-event']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ event: 'my-event', data: undefined });
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['publish', 'my-event', 'my-data']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ event: 'my-event', data: 'my-data' });
+		});
+
+		it('Parses options', () => {
+			const argv = commandProcessor.parse(root, ['publish', 'my-event', '--private', '--public']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ event: 'my-event', data: undefined });
+			expect(argv.private).to.equal(true);
+			expect(argv.public).to.equal(true);
+		});
+
+		it('Errors when required `device` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['publish']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'event\' is required.');
+			expect(argv.clierror).to.have.property('data', 'event');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Includes help with examples', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['publish', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Publish an event to the cloud',
+					'Usage: particle publish [options] <event> [data]',
+					'',
+					'Options:',
+					'  --private  Publish to the private stream  [boolean] [default: true]',
+					'  --public   Publish to the public stream  [boolean]',
+					'',
+					'Examples:',
+					'  particle publish temperature 25.0  Publish a temperature event to your private event stream',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+});
+

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -145,8 +145,16 @@ module.exports = class ParticleApi {
 		);
 	}
 
-	publishEvent(name, data, isPrivate){
-		return this.api.publishEvent({ name, data, isPrivate, auth: this.accessToken });
+	publishEvent(name, data, isPrivate, product){
+		return this._wrap(
+			this.api.publishEvent({
+				name,
+				data,
+				product,
+				isPrivate,
+				auth: this.accessToken
+			})
+		);
 	}
 
 	_wrap(promise){

--- a/src/cmd/publish.js
+++ b/src/cmd/publish.js
@@ -21,15 +21,15 @@ module.exports = class PublishCommand {
 	}
 
 	publishEvent({ private: isPrivate, public: isPublic, product, params: { event, data } }){
-		const setPrivate = isPublic ? false : isPrivate;
-		const visibility = setPrivate ? 'private' : 'public';
+		isPrivate = (isPublic && !product) ? false : isPrivate; // `isPrivate: true` by default see: src/cli/publish.js
+		const visibility = isPrivate ? 'private' : 'public';
 		let epilogue = `${visibility} event: ${event}`;
 
 		if (product){
 			epilogue += ` to product: ${product}`;
 		}
 
-		const publishEvent = createAPI().publishEvent(event, data, setPrivate, product);
+		const publishEvent = createAPI().publishEvent(event, data, isPrivate, product);
 		return this.showBusySpinnerUntilResolved(`Publishing ${epilogue}`, publishEvent)
 			.then(() => this.ui.stdout.write(`Published ${epilogue}${os.EOL}${os.EOL}`))
 			.catch(error => {

--- a/src/cmd/publish.js
+++ b/src/cmd/publish.js
@@ -1,23 +1,50 @@
+const os = require('os');
 const VError = require('verror');
-const ApiClient = require('../lib/api-client');
-const ensureError = require('../lib/utilities').ensureError;
+const settings = require('../../settings');
+const spinnerMixin = require('../lib/spinner-mixin');
+const { normalizedApiError } = require('../lib/api-client');
+const ParticleAPI = require('./api');
+const UI = require('../lib/ui');
 
 
 module.exports = class PublishCommand {
-	constructor(options) {
-		this.options = options;
+	constructor({
+		stdin = process.stdin,
+		stdout = process.stdout,
+		stderr = process.stderr
+	} = {}){
+		this.stdin = stdin;
+		this.stdout = stdout;
+		this.stderr = stderr;
+		this.ui = new UI({ stdin, stdout, stderr });
+		spinnerMixin(this);
 	}
 
-	publishEvent(eventName, data, { 'public': publicFlag, 'private': privateFlag }) {
-		// Cannot use usual destructuring since public and private are reserved keywords
-		const setPrivate = publicFlag ? false : privateFlag;
-
-		const api = new ApiClient();
-		api.ensureToken();
-
-		return api.publishEvent(eventName, data, setPrivate).catch((err) => {
-			throw new VError(ensureError(err), 'Could not publish event');
-		});
+	publishEvent({ private: isPrivate, public: isPublic, params: { event, data } }){
+		const setPrivate = isPublic ? false : isPrivate;
+		const visibility = setPrivate ? 'private' : 'public';
+		const epilogue = `${visibility} event: ${event}`;
+		const publishEvent = createAPI().publishEvent(event, data, setPrivate);
+		return this.showBusySpinnerUntilResolved(`Publishing ${epilogue}`, publishEvent)
+			.then(() => this.ui.stdout.write(`Published ${epilogue}${os.EOL}${os.EOL}`))
+			.catch(error => {
+				const message = 'Error publishing event';
+				throw createAPIErrorResult({ error, message });
+			});
 	}
 };
+
+
+// UTILS //////////////////////////////////////////////////////////////////////
+function createAPI(){
+	return new ParticleAPI(settings.apiUrl, {
+		accessToken: settings.access_token
+	});
+}
+
+function createAPIErrorResult({ error: e, message, json }){
+	const error = new VError(normalizedApiError(e), message);
+	error.asJSON = json;
+	return error;
+}
 

--- a/src/cmd/publish.js
+++ b/src/cmd/publish.js
@@ -20,11 +20,16 @@ module.exports = class PublishCommand {
 		spinnerMixin(this);
 	}
 
-	publishEvent({ private: isPrivate, public: isPublic, params: { event, data } }){
+	publishEvent({ private: isPrivate, public: isPublic, product, params: { event, data } }){
 		const setPrivate = isPublic ? false : isPrivate;
 		const visibility = setPrivate ? 'private' : 'public';
-		const epilogue = `${visibility} event: ${event}`;
-		const publishEvent = createAPI().publishEvent(event, data, setPrivate);
+		let epilogue = `${visibility} event: ${event}`;
+
+		if (product){
+			epilogue += ` to product: ${product}`;
+		}
+
+		const publishEvent = createAPI().publishEvent(event, data, setPrivate, product);
 		return this.showBusySpinnerUntilResolved(`Publishing ${epilogue}`, publishEvent)
 			.then(() => this.ui.stdout.write(`Published ${epilogue}${os.EOL}${os.EOL}`))
 			.catch(error => {

--- a/test/e2e/publish.e2e.js
+++ b/test/e2e/publish.e2e.js
@@ -1,9 +1,10 @@
+const os = require('os');
 const { expect } = require('../setup');
 const cli = require('../lib/cli');
 
 
 describe('Publish Commands', () => {
-	const eventName = 'teste2eevent';
+	const eventName = 'test-e2e-event';
 	const help = [
 		'Publish an event to the cloud',
 		'Usage: particle publish [options] <event> [data]',
@@ -33,7 +34,7 @@ describe('Publish Commands', () => {
 		const { stdout, stderr, exitCode } = await cli.run(['help', 'publish']);
 
 		expect(stdout).to.equal('');
-		expect(stderr.split('\n')).to.include.members(help);
+		expect(stderr.split(os.EOL)).to.include.members(help);
 		expect(exitCode).to.equal(0);
 	});
 
@@ -41,7 +42,7 @@ describe('Publish Commands', () => {
 		const { stdout, stderr, exitCode } = await cli.run('publish');
 
 		expect(stdout).to.equal('Parameter \'event\' is required.');
-		expect(stderr.split('\n')).to.include.members(help);
+		expect(stderr.split(os.EOL)).to.include.members(help);
 		expect(exitCode).to.equal(1);
 	});
 
@@ -49,7 +50,7 @@ describe('Publish Commands', () => {
 		const { stdout, stderr, exitCode } = await cli.run(['publish', '--help']);
 
 		expect(stdout).to.equal('');
-		expect(stderr.split('\n')).to.include.members(help);
+		expect(stderr.split(os.EOL)).to.include.members(help);
 		expect(exitCode).to.equal(0);
 	});
 
@@ -57,7 +58,7 @@ describe('Publish Commands', () => {
 		const args = ['publish', eventName];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal(`Published private event: ${eventName}${'\n'}`);
+		expect(stdout).to.include(`Published private event: ${eventName}${os.EOL}`);
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
 	});
@@ -66,7 +67,7 @@ describe('Publish Commands', () => {
 		const args = ['publish', eventName, '--private'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal(`Published private event: ${eventName}${'\n'}`);
+		expect(stdout).to.include(`Published private event: ${eventName}${os.EOL}`);
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
 	});
@@ -75,9 +76,18 @@ describe('Publish Commands', () => {
 		const args = ['publish', eventName, '--public'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal(`Published public event: ${eventName}${'\n'}`);
+		expect(stdout).to.include(`Published public event: ${eventName}${os.EOL}`);
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
+	});
+
+	it('Fails when user is signed-out', async () => {
+		await cli.logout();
+		const { stdout, stderr, exitCode } = await cli.run(['publish', eventName]);
+
+		expect(stdout).to.include('Error publishing event: HTTP error 400 from https://api.particle.io/v1/devices/events - The access token was not found');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(1);
 	});
 });
 

--- a/test/e2e/publish.e2e.js
+++ b/test/e2e/publish.e2e.js
@@ -1,6 +1,7 @@
 const os = require('os');
 const { expect } = require('../setup');
 const cli = require('../lib/cli');
+const { PRODUCT_01_ID } = require('../lib/env');
 
 
 describe('Publish Commands', () => {
@@ -16,9 +17,11 @@ describe('Publish Commands', () => {
 		'Options:',
 		'  --private  Publish to the private stream  [boolean] [default: true]',
 		'  --public   Publish to the public stream  [boolean]',
+		'  --product  Publish to the given Product ID or Slug\'s stream  [string]',
 		'',
 		'Examples:',
-		'  particle publish temperature 25.0  Publish a temperature event to your private event stream'
+		'  particle publish temp 25.0                  Publish a temp event to your private event stream',
+		'  particle publish temp 25.0 --product 12345  Publish a temp event to your product 12345\'s event stream',
 	];
 
 	before(async () => {
@@ -81,11 +84,38 @@ describe('Publish Commands', () => {
 		expect(exitCode).to.equal(0);
 	});
 
+	it('Publishes a product event', async () => {
+		const args = ['publish', eventName, '--product', PRODUCT_01_ID];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.include(`Published private event: ${eventName} to product: ${PRODUCT_01_ID}${os.EOL}`);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Publishes a private product event', async () => {
+		const args = ['publish', eventName, '--product', PRODUCT_01_ID, '--private'];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.include(`Published private event: ${eventName} to product: ${PRODUCT_01_ID}${os.EOL}`);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Publishes a public product event', async () => {
+		const args = ['publish', eventName, '--product', PRODUCT_01_ID, '--public'];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.include(`Published public event: ${eventName} to product: ${PRODUCT_01_ID}${os.EOL}`);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
 	it('Fails when user is signed-out', async () => {
 		await cli.logout();
 		const { stdout, stderr, exitCode } = await cli.run(['publish', eventName]);
 
-		expect(stdout).to.include('Error publishing event: HTTP error 400 from https://api.particle.io/v1/devices/events - The access token was not found');
+		expect(stdout).to.include('Error publishing event: The access token was not found');
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(1);
 	});

--- a/test/e2e/publish.e2e.js
+++ b/test/e2e/publish.e2e.js
@@ -102,11 +102,11 @@ describe('Publish Commands', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Publishes a public product event', async () => {
+	it('Ignores `--public` flag when publishing a product event', async () => {
 		const args = ['publish', eventName, '--product', PRODUCT_01_ID, '--public'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.include(`Published public event: ${eventName} to product: ${PRODUCT_01_ID}${os.EOL}`);
+		expect(stdout).to.include(`Published private event: ${eventName} to product: ${PRODUCT_01_ID}${os.EOL}`);
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
 	});


### PR DESCRIPTION
## Description

Adds support for optional `--product <id>` flag to the `particle publish` command to send events to a product's event stream ([ch](https://app.clubhouse.io/particle/story/48802/enable-publishing-events-to-product-devices))

## How to Test

_Note: requires you to have a Particle product with one or more devices_

Run `particle publish --help` and explore the command and options.

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [ ] CI is passing

