### PR TITLE
Simplify udev rules

### DIFF
--- a/assets/50-particle.rules
+++ b/assets/50-particle.rules
@@ -14,12 +14,8 @@
 #
 # Core
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="607[df]", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
-# Photon/P1/Electron
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b04", ATTRS{idProduct}=="[cd]00[68a]", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
-# Argon/Boron/Xenon
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b04", ATTRS{idProduct}=="[cd]00[cde]", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
-# Argon/Boron/Xenon (SoM)
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b04", ATTRS{idProduct}=="[cd]01[678]", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
+# Gen 2 (Photon/P1/Electron), Gen 3 (Argon/Boron/Xenon, SoM)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="2b04", ATTRS{idProduct}=="[cd]0??", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
 # Particle Programmer Shield v1.0
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6010", GROUP="plugdev", MODE="0666", ENV{ID_MM_DEVICE_IGNORE}="1"
 # Particle Debugger


### PR DESCRIPTION
Current udev rules need to be modified for each platform. They are missing B5 SoM support right now. Until we change the pattern, we can assume that any device that matches our USB vendor ID and has a product ID starting with c0 or d0 will have the same behavior.

Validated this file on my Ubuntu machine with a B5 SoM.