### PR TITLE
feature/ch47342/products-device-flash

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8220,9 +8220,9 @@
       }
     },
     "particle-api-js": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-8.2.0.tgz",
-      "integrity": "sha512-Mvdnlu/rzHfOI0vFCRf/T4habvxGMAf8wwnW+6wazLjFIwHAx8KAGs7jmbuEK1yeofAoj14ekXtQWqv+YbTWEg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-8.3.0.tgz",
+      "integrity": "sha512-xS4P6WbzoNgZcKe3E9HtcSf7ZB62IL/k3xUxK3WFQj1YJwXqkUNiIw1xJmDw4b5FLJZ3/lj0dYJ5hDW5sxd4yA==",
       "requires": {
         "babel-runtime": "^6.9.2",
         "form-data": ">2.2.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lodash": "^4.17.15",
     "moment": "^2.24.0",
     "node-wifiscanner2": "^1.2.0",
-    "particle-api-js": "^8.2.0",
+    "particle-api-js": "^8.3.0",
     "particle-commands": "0.3.0",
     "particle-library-manager": "^0.1.14",
     "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",

--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -61,7 +61,11 @@ module.exports = ({ commandProcessor, root }) => {
 
 	commandProcessor.createCommand(cloud, 'flash', 'Pass a binary, source file, or source directory to a device!', {
 		params: '<device> [files...]',
-		options: Object.assign({}, compileOptions),
+		options: Object.assign({}, compileOptions, {
+			'product': {
+				description: 'Target a device within the given Product ID or Slug'
+			}
+		}),
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
 			return new CloudCommands().flashDevice(args);
@@ -71,6 +75,7 @@ module.exports = ({ commandProcessor, root }) => {
 			'$0 $command green tinker': 'Flash the default Tinker app to device green',
 			'$0 $command red blink.ino': 'Compile blink.ino in the cloud and flash to device red',
 			'$0 $command orange firmware.bin': 'Flash the pre-compiled binary to device orange',
+			'$0 $command blue --product 12345': 'Compile the source code in the current directory in the cloud and flash to device blue within product 12345'
 		}
 	});
 

--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -95,9 +95,19 @@ module.exports = ({ commandProcessor, root }) => {
 
 	commandProcessor.createCommand(cloud, 'nyan', 'Make your device shout rainbows', {
 		params: '<device> [onOff]',
+		options: {
+			'product': {
+				description: 'Target a device within the given Product ID or Slug'
+			}
+		},
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
 			return new CloudCommands().nyanMode(args);
+		},
+		examples: {
+			'$0 $command green': 'Make the device named `blue` start signaling',
+			'$0 $command green off': 'Make the device named `blue` stop signaling',
+			'$0 $command blue --product 12345': 'Make the device named `blue` within product `12345` start signaling'
 		}
 	});
 

--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -61,12 +61,7 @@ module.exports = ({ commandProcessor, root }) => {
 
 	commandProcessor.createCommand(cloud, 'flash', 'Pass a binary, source file, or source directory to a device!', {
 		params: '<device> [files...]',
-		options: Object.assign({}, compileOptions, {
-			'yes': {
-				boolean: true,
-				description: 'Answer yes to all questions'
-			}
-		}),
+		options: Object.assign({}, compileOptions),
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
 			return new CloudCommands().flashDevice(args);

--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -11,24 +11,24 @@ module.exports = ({ commandProcessor, root }) => {
 		}
 	};
 
-	commandProcessor.createCommand(cloud, 'claim', 'Register a device with your user account with the cloud', {
-		params: '<deviceID>',
-		handler: (args) => {
-			const CloudCommands = require('../cmd/cloud');
-			return new CloudCommands().claimDevice(args.params.deviceID);
-		},
-		examples: {
-			'$0 $command 123456789': 'Claim device by id to your account'
-		}
-	});
-
 	commandProcessor.createCommand(cloud, 'list', 'Display a list of your devices, as well as their variables and functions', {
 		params: '[filter]',
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
-			return new CloudCommands().listDevices(args.params.filter);
+			return new CloudCommands().listDevices(args);
 		},
 		epilogue: 'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name'
+	});
+
+	commandProcessor.createCommand(cloud, 'claim', 'Register a device with your user account with the cloud', {
+		params: '<deviceID>',
+		handler: (args) => {
+			const CloudCommands = require('../cmd/cloud');
+			return new CloudCommands().claimDevice(args);
+		},
+		examples: {
+			'$0 $command 123456789': 'Claim device by id to your account'
+		}
 	});
 
 	commandProcessor.createCommand(cloud, 'remove', 'Release a device from your account so that another user may claim it', {
@@ -41,7 +41,7 @@ module.exports = ({ commandProcessor, root }) => {
 		},
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
-			return new CloudCommands().removeDevice(args.params.device, args);
+			return new CloudCommands().removeDevice(args);
 		},
 		examples: {
 			'$0 $command 0123456789ABCDEFGHI': 'Remove device by id from your account'
@@ -52,7 +52,7 @@ module.exports = ({ commandProcessor, root }) => {
 		params: '<device> <name>',
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
-			return new CloudCommands().renameDevice(args.params.device, args.params.name);
+			return new CloudCommands().renameDevice(args);
 		},
 		examples: {
 			'$0 $command red green': 'Rename red device to green'
@@ -69,7 +69,7 @@ module.exports = ({ commandProcessor, root }) => {
 		}),
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
-			return new CloudCommands().flashDevice(args.params.device, args.params.files, args);
+			return new CloudCommands().flashDevice(args);
 		},
 		examples: {
 			'$0 $command blue': 'Compile the source code in the current directory in the cloud and flash to device blue',
@@ -88,7 +88,7 @@ module.exports = ({ commandProcessor, root }) => {
 		}),
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
-			return new CloudCommands().compileCode(args.params.deviceType, args.params.files, args);
+			return new CloudCommands().compileCode(args);
 		},
 		examples: {
 			'$0 $command photon': 'Compile the source code in the current directory in the cloud for a Photon',
@@ -102,7 +102,7 @@ module.exports = ({ commandProcessor, root }) => {
 		params: '<device> [onOff]',
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
-			return new CloudCommands().nyanMode(args.params.device, args.params.onOff);
+			return new CloudCommands().nyanMode(args);
 		}
 	});
 

--- a/src/cli/cloud.test.js
+++ b/src/cli/cloud.test.js
@@ -194,7 +194,6 @@ describe('Cloud Command-Line Interface', () => {
 			const argv = commandProcessor.parse(root, ['cloud', 'flash', 'my-device']);
 			expect(argv.clierror).to.equal(undefined);
 			expect(argv.params).to.eql({ device: 'my-device', files: [] });
-			expect(argv.yes).to.equal(false);
 			expect(argv.followSymlinks).to.equal(false);
 			expect(argv.target).to.equal(undefined);
 		});
@@ -206,7 +205,6 @@ describe('Cloud Command-Line Interface', () => {
 			expect(argv.clierror).to.have.property('data', 'device');
 			expect(argv.clierror).to.have.property('isUsageError', true);
 			expect(argv.params).to.eql({});
-			expect(argv.yes).to.equal(false);
 			expect(argv.followSymlinks).to.equal(false);
 			expect(argv.target).to.equal(undefined);
 		});
@@ -215,16 +213,14 @@ describe('Cloud Command-Line Interface', () => {
 			const argv = commandProcessor.parse(root, ['cloud', 'flash', 'my-device', 'blink.ino']);
 			expect(argv.clierror).to.equal(undefined);
 			expect(argv.params).to.eql({ device: 'my-device', files: ['blink.ino'] });
-			expect(argv.yes).to.equal(false);
 			expect(argv.followSymlinks).to.equal(false);
 			expect(argv.target).to.equal(undefined);
 		});
 
 		it('Parses options', () => {
-			const argv = commandProcessor.parse(root, ['cloud', 'flash', 'my-device', '--yes', '--followSymlinks', '--target', '2.0.0']);
+			const argv = commandProcessor.parse(root, ['cloud', 'flash', 'my-device', '--followSymlinks', '--target', '2.0.0']);
 			expect(argv.clierror).to.equal(undefined);
 			expect(argv.params).to.eql({ device: 'my-device', files: [] });
-			expect(argv.yes).to.equal(true);
 			expect(argv.followSymlinks).to.equal(true);
 			expect(argv.target).to.equal('2.0.0');
 		});
@@ -240,7 +236,6 @@ describe('Cloud Command-Line Interface', () => {
 					'Options:',
 					'  --target          The firmware version to compile against. Defaults to latest version, or version on device for cellular.  [string]',
 					'  --followSymlinks  Follow symlinks when collecting files  [boolean]',
-					'  --yes             Answer yes to all questions  [boolean]',
 					'',
 					'Examples:',
 					'  particle cloud flash blue                 Compile the source code in the current directory in the cloud and flash to device blue',

--- a/src/cli/cloud.test.js
+++ b/src/cli/cloud.test.js
@@ -334,6 +334,13 @@ describe('Cloud Command-Line Interface', () => {
 			expect(argv.params).to.eql({ device: 'my-device', onOff: 'off' });
 		});
 
+		it('Parses options', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'nyan', 'my-device', '--product', '12345']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', onOff: undefined });
+			expect(argv.product).to.equal('12345');
+		});
+
 		it('Includes help', () => {
 			const termWidth = null; // don't right-align option type labels so testing is easier
 			commandProcessor.parse(root, ['cloud', 'nyan', '--help'], termWidth);
@@ -341,6 +348,14 @@ describe('Cloud Command-Line Interface', () => {
 				expect(helpText).to.equal([
 					'Make your device shout rainbows',
 					'Usage: particle cloud nyan [options] <device> [onOff]',
+					'',
+					'Options:',
+					'  --product  Target a device within the given Product ID or Slug  [string]',
+					'',
+					'Examples:',
+					'  particle cloud nyan green                 Make the device named `blue` start signaling',
+					'  particle cloud nyan green off             Make the device named `blue` stop signaling',
+					'  particle cloud nyan blue --product 12345  Make the device named `blue` within product `12345` start signaling',
 					''
 				].join(os.EOL));
 			});

--- a/src/cli/cloud.test.js
+++ b/src/cli/cloud.test.js
@@ -29,8 +29,8 @@ describe('Cloud Command-Line Interface', () => {
 					'Help:  particle help cloud <command>',
 					'',
 					'Commands:',
-					'  claim    Register a device with your user account with the cloud',
 					'  list     Display a list of your devices, as well as their variables and functions',
+					'  claim    Register a device with your user account with the cloud',
 					'  remove   Release a device from your account so that another user may claim it',
 					'  name     Give a device a name!',
 					'  flash    Pass a binary, source file, or source directory to a device!',
@@ -38,6 +38,34 @@ describe('Cloud Command-Line Interface', () => {
 					'  nyan     Make your device shout rainbows',
 					'  login    Login to the cloud and store an access token locally',
 					'  logout   Log out of your session and clear your saved access token',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud list` Namespace', () => {
+		it('Handles `list` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'list']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ filter: undefined });
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'list', 'photon']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ filter: 'photon' });
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'list', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Display a list of your devices, as well as their variables and functions',
+					'Usage: particle cloud list [options] [filter]',
+					'',
+					'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name',
 					''
 				].join(os.EOL));
 			});
@@ -70,34 +98,6 @@ describe('Cloud Command-Line Interface', () => {
 					'',
 					'Examples:',
 					'  particle cloud claim 123456789  Claim device by id to your account',
-					''
-				].join(os.EOL));
-			});
-		});
-	});
-
-	describe('`cloud list` Namespace', () => {
-		it('Handles `list` command', () => {
-			const argv = commandProcessor.parse(root, ['cloud', 'list']);
-			expect(argv.clierror).to.equal(undefined);
-			expect(argv.params).to.eql({ filter: undefined });
-		});
-
-		it('Parses optional arguments', () => {
-			const argv = commandProcessor.parse(root, ['cloud', 'list', 'photon']);
-			expect(argv.clierror).to.equal(undefined);
-			expect(argv.params).to.eql({ filter: 'photon' });
-		});
-
-		it('Includes help', () => {
-			const termWidth = null; // don't right-align option type labels so testing is easier
-			commandProcessor.parse(root, ['cloud', 'list', '--help'], termWidth);
-			commandProcessor.showHelp((helpText) => {
-				expect(helpText).to.equal([
-					'Display a list of your devices, as well as their variables and functions',
-					'Usage: particle cloud list [options] [filter]',
-					'',
-					'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name',
 					''
 				].join(os.EOL));
 			});

--- a/src/cli/cloud.test.js
+++ b/src/cli/cloud.test.js
@@ -1,0 +1,425 @@
+const os = require('os');
+const { expect } = require('../../test/setup');
+const commandProcessor = require('../app/command-processor');
+const cloud = require('./cloud');
+
+
+describe('Cloud Command-Line Interface', () => {
+	let root;
+
+	beforeEach(() => {
+		root = commandProcessor.createAppCategory();
+		cloud({ root, commandProcessor });
+	});
+
+	describe('Top-Level `cloud` Namespace', () => {
+		it('Handles `cloud` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.equal(undefined);
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Access Particle cloud functionality',
+					'Usage: particle cloud <command>',
+					'Help:  particle help cloud <command>',
+					'',
+					'Commands:',
+					'  claim    Register a device with your user account with the cloud',
+					'  list     Display a list of your devices, as well as their variables and functions',
+					'  remove   Release a device from your account so that another user may claim it',
+					'  name     Give a device a name!',
+					'  flash    Pass a binary, source file, or source directory to a device!',
+					'  compile  Compile a source file, or directory using the cloud compiler',
+					'  nyan     Make your device shout rainbows',
+					'  login    Login to the cloud and store an access token locally',
+					'  logout   Log out of your session and clear your saved access token',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud claim` Namespace', () => {
+		it('Handles `claim` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'claim', '1234']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ deviceID: '1234' });
+		});
+
+		it('Errors when required `deviceID` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'claim']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'deviceID\' is required.');
+			expect(argv.clierror).to.have.property('data', 'deviceID');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'claim', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Register a device with your user account with the cloud',
+					'Usage: particle cloud claim [options] <deviceID>',
+					'',
+					'Examples:',
+					'  particle cloud claim 123456789  Claim device by id to your account',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud list` Namespace', () => {
+		it('Handles `list` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'list']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ filter: undefined });
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'list', 'photon']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ filter: 'photon' });
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'list', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Display a list of your devices, as well as their variables and functions',
+					'Usage: particle cloud list [options] [filter]',
+					'',
+					'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud remove` Namespace', () => {
+		it('Handles `remove` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'remove', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device' });
+			expect(argv.yes).to.equal(false);
+		});
+
+		it('Errors when required `device` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'remove']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'device\' is required.');
+			expect(argv.clierror).to.have.property('data', 'device');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({});
+			expect(argv.yes).to.equal(false);
+		});
+
+		it('Parses options', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'remove', 'my-device', '--yes']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device' });
+			expect(argv.yes).to.equal(true);
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'remove', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Release a device from your account so that another user may claim it',
+					'Usage: particle cloud remove [options] <device>',
+					'',
+					'Options:',
+					'  --yes  Answer yes to all questions  [boolean]',
+					'',
+					'Examples:',
+					'  particle cloud remove 0123456789ABCDEFGHI  Remove device by id from your account',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud name` Namespace', () => {
+		it('Handles `name` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'name', 'my-device', 'my-device-name']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', name: 'my-device-name' });
+		});
+
+		it('Errors when required `device` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'name']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'device\' is required.');
+			expect(argv.clierror).to.have.property('data', 'device');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Errors when required `name` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'name', 'my-device']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'name\' is required.');
+			expect(argv.clierror).to.have.property('data', 'name');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({ device: 'my-device' });
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'name', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Give a device a name!',
+					'Usage: particle cloud name [options] <device> <name>',
+					'',
+					'Examples:',
+					'  particle cloud name red green  Rename red device to green',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud flash` Namespace', () => {
+		it('Handles `flash` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'flash', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', files: [] });
+			expect(argv.yes).to.equal(false);
+			expect(argv.followSymlinks).to.equal(false);
+			expect(argv.target).to.equal(undefined);
+		});
+
+		it('Errors when required `device` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'flash']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'device\' is required.');
+			expect(argv.clierror).to.have.property('data', 'device');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({});
+			expect(argv.yes).to.equal(false);
+			expect(argv.followSymlinks).to.equal(false);
+			expect(argv.target).to.equal(undefined);
+		});
+
+		it('Parses optional params', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'flash', 'my-device', 'blink.ino']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', files: ['blink.ino'] });
+			expect(argv.yes).to.equal(false);
+			expect(argv.followSymlinks).to.equal(false);
+			expect(argv.target).to.equal(undefined);
+		});
+
+		it('Parses options', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'flash', 'my-device', '--yes', '--followSymlinks', '--target', '2.0.0']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', files: [] });
+			expect(argv.yes).to.equal(true);
+			expect(argv.followSymlinks).to.equal(true);
+			expect(argv.target).to.equal('2.0.0');
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'flash', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Pass a binary, source file, or source directory to a device!',
+					'Usage: particle cloud flash [options] <device> [files...]',
+					'',
+					'Options:',
+					'  --target          The firmware version to compile against. Defaults to latest version, or version on device for cellular.  [string]',
+					'  --followSymlinks  Follow symlinks when collecting files  [boolean]',
+					'  --yes             Answer yes to all questions  [boolean]',
+					'',
+					'Examples:',
+					'  particle cloud flash blue                 Compile the source code in the current directory in the cloud and flash to device blue',
+					'  particle cloud flash green tinker         Flash the default Tinker app to device green',
+					'  particle cloud flash red blink.ino        Compile blink.ino in the cloud and flash to device red',
+					'  particle cloud flash orange firmware.bin  Flash the pre-compiled binary to device orange',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud compile` Namespace', () => {
+		it('Handles `compile` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'compile', 'argon']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ deviceType: 'argon', files: [] });
+			expect(argv.target).to.equal(undefined);
+			expect(argv.followSymlinks).to.equal(false);
+			expect(argv.saveTo).to.equal(undefined);
+		});
+
+		it('Errors when required `device` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'compile']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'deviceType\' is required.');
+			expect(argv.clierror).to.have.property('data', 'deviceType');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({});
+			expect(argv.target).to.equal(undefined);
+			expect(argv.followSymlinks).to.equal(false);
+			expect(argv.saveTo).to.equal(undefined);
+		});
+
+		it('Parses optional params', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'compile', 'argon', 'blink.ino']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ deviceType: 'argon', files: ['blink.ino'] });
+			expect(argv.target).to.equal(undefined);
+			expect(argv.followSymlinks).to.equal(false);
+			expect(argv.saveTo).to.equal(undefined);
+		});
+
+		it('Parses options', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'compile', 'argon', 'blink.ino', '--followSymlinks', '--target', '2.0.0', '--saveTo', './path/to/my.bin']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ deviceType: 'argon', files: ['blink.ino'] });
+			expect(argv.target).to.equal('2.0.0');
+			expect(argv.followSymlinks).to.equal(true);
+			expect(argv.saveTo).to.equal('./path/to/my.bin');
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'compile', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Compile a source file, or directory using the cloud compiler',
+					'Usage: particle cloud compile [options] <deviceType> [files...]',
+					'',
+					'Options:',
+					'  --target          The firmware version to compile against. Defaults to latest version, or version on device for cellular.  [string]',
+					'  --followSymlinks  Follow symlinks when collecting files  [boolean]',
+					'  --saveTo          Filename for the compiled binary  [string]',
+					'',
+					'Examples:',
+					'  particle cloud compile photon                                  Compile the source code in the current directory in the cloud for a Photon',
+					'  particle cloud compile electron project --saveTo electron.bin  Compile the source code in the project directory in the cloud for a Electron and save it to electron.bin',
+					'',
+					'Param deviceType can be: core, photon, p1, electron, argon, asom, boron, bsom, xenon, xsom, etc',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud nyan` Namespace', () => {
+		it('Handles `nyan` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'nyan', 'my-device']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', onOff: undefined });
+		});
+
+		it('Errors when required `device` argument is missing', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'nyan']);
+			expect(argv.clierror).to.be.an.instanceof(Error);
+			expect(argv.clierror).to.have.property('message', 'Parameter \'device\' is required.');
+			expect(argv.clierror).to.have.property('data', 'device');
+			expect(argv.clierror).to.have.property('isUsageError', true);
+			expect(argv.params).to.eql({});
+		});
+
+		it('Parses optional params', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'nyan', 'my-device', 'off']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ device: 'my-device', onOff: 'off' });
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'nyan', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Make your device shout rainbows',
+					'Usage: particle cloud nyan [options] <device> [onOff]',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud login` Namespace', () => {
+		it('Handles `login` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'login']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({});
+			expect(argv.username).to.equal(undefined);
+			expect(argv.password).to.equal(undefined);
+			expect(argv.token).to.equal(undefined);
+			expect(argv.otp).to.equal(undefined);
+		});
+
+		it('Parses options', () => {
+			const cmd = ['cloud', 'login', '--username', 'user@example.com', '--password', 'fake-password', '--token', 'fake-token', '--otp', '01234'];
+			const argv = commandProcessor.parse(root, cmd);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({});
+			expect(argv.username).to.equal('user@example.com');
+			expect(argv.password).to.equal('fake-password');
+			expect(argv.token).to.equal('fake-token');
+			expect(argv.otp).to.equal('01234');
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'login', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Login to the cloud and store an access token locally',
+					'Usage: particle cloud login [options]',
+					'',
+					'Options:',
+					'  -u, --username  your username  [string]',
+					'  -p, --password  your password  [string]',
+					'  -t, --token     an existing Particle access token to use  [string]',
+					'  --otp           the login code if two-step authentication is enabled  [string]',
+					'',
+					'Examples:',
+					'  particle cloud login                                              prompt for credentials and log in',
+					'  particle cloud login --username user@example.com --password test  log in with credentials provided on the command line',
+					'  particle cloud login --token <my-api-token>                       log in with an access token provided on the command line',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+
+	describe('`cloud logout` Namespace', () => {
+		it('Handles `logout` command', () => {
+			const argv = commandProcessor.parse(root, ['cloud', 'logout']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({});
+			expect(argv.username).to.equal(undefined);
+			expect(argv.password).to.equal(undefined);
+			expect(argv.token).to.equal(undefined);
+			expect(argv.otp).to.equal(undefined);
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['cloud', 'logout', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Log out of your session and clear your saved access token',
+					'Usage: particle cloud logout [options]',
+					''
+				].join(os.EOL));
+			});
+		});
+	});
+});
+

--- a/src/cli/cloud.test.js
+++ b/src/cli/cloud.test.js
@@ -218,11 +218,13 @@ describe('Cloud Command-Line Interface', () => {
 		});
 
 		it('Parses options', () => {
-			const argv = commandProcessor.parse(root, ['cloud', 'flash', 'my-device', '--followSymlinks', '--target', '2.0.0']);
+			const args = ['cloud', 'flash', 'my-device', '--followSymlinks', '--target', '2.0.0', '--product', '12345'];
+			const argv = commandProcessor.parse(root, args);
 			expect(argv.clierror).to.equal(undefined);
 			expect(argv.params).to.eql({ device: 'my-device', files: [] });
 			expect(argv.followSymlinks).to.equal(true);
 			expect(argv.target).to.equal('2.0.0');
+			expect(argv.product).to.equal('12345');
 		});
 
 		it('Includes help', () => {
@@ -236,12 +238,14 @@ describe('Cloud Command-Line Interface', () => {
 					'Options:',
 					'  --target          The firmware version to compile against. Defaults to latest version, or version on device for cellular.  [string]',
 					'  --followSymlinks  Follow symlinks when collecting files  [boolean]',
+					'  --product         Target a device within the given Product ID or Slug  [string]',
 					'',
 					'Examples:',
-					'  particle cloud flash blue                 Compile the source code in the current directory in the cloud and flash to device blue',
-					'  particle cloud flash green tinker         Flash the default Tinker app to device green',
-					'  particle cloud flash red blink.ino        Compile blink.ino in the cloud and flash to device red',
-					'  particle cloud flash orange firmware.bin  Flash the pre-compiled binary to device orange',
+					'  particle cloud flash blue                  Compile the source code in the current directory in the cloud and flash to device blue',
+					'  particle cloud flash green tinker          Flash the default Tinker app to device green',
+					'  particle cloud flash red blink.ino         Compile blink.ino in the cloud and flash to device red',
+					'  particle cloud flash orange firmware.bin   Flash the pre-compiled binary to device orange',
+					'  particle cloud flash blue --product 12345  Compile the source code in the current directory in the cloud and flash to device blue within product 12345',
 					''
 				].join(os.EOL));
 			});

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -79,6 +79,17 @@ module.exports = class ParticleApi {
 		);
 	}
 
+	markAsDevelopmentDevice(deviceId, development, product){
+		return this._wrap(
+			this.api.markAsDevelopmentDevice({
+				development,
+				deviceId,
+				product,
+				auth: this.accessToken
+			})
+		);
+	}
+
 	claimDevice(deviceId, requestTransfer){
 		return this._wrap(
 			this.api.claimDevice({
@@ -110,10 +121,11 @@ module.exports = class ParticleApi {
 		);
 	}
 
-	flashDevice(deviceId, files, targetVersion){
+	flashDevice(deviceId, files, targetVersion, product){
 		return this._wrap(
 			this.api.flashDevice({
 				deviceId,
+				product,
 				// TODO (mirande): callers should provide an object like: { [filename]: filepath }
 				files: files.map || files,
 				targetVersion,

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -1,4 +1,3 @@
-const fs = require('fs');
 const url = require('url');
 const _ = require('lodash');
 const chalk = require('chalk');
@@ -41,6 +40,14 @@ module.exports = class ParticleApi {
 			});
 	}
 
+	getUserInfo(){
+		return this._wrap(
+			this.api.getUserInfo({
+				auth: this.accessToken
+			})
+		);
+	}
+
 	listDevices(options){
 		return this._wrap(
 			this.api.listDevices(
@@ -73,7 +80,14 @@ module.exports = class ParticleApi {
 	}
 
 	claimDevice(deviceId, requestTransfer){
-		return this._wrap(this.api.claimDevice({ deviceId, requestTransfer, auth: this.accessToken }));
+		return this._wrap(
+			this.api.claimDevice({
+				// TODO (mirande): push these tweaks upstream to `particle-api-js`
+				deviceId: (deviceId || '').toLowerCase(),
+				requestTransfer: requestTransfer ? true : undefined,
+				auth: this.accessToken
+			})
+		);
 	}
 
 	removeDevice(deviceId, product){
@@ -87,7 +101,25 @@ module.exports = class ParticleApi {
 	}
 
 	renameDevice(deviceId, name){
-		return this._wrap(this.api.renameDevice({ deviceId, name, auth: this.accessToken }));
+		return this._wrap(
+			this.api.renameDevice({
+				deviceId,
+				name,
+				auth: this.accessToken
+			})
+		);
+	}
+
+	flashDevice(deviceId, files, targetVersion){
+		return this._wrap(
+			this.api.flashDevice({
+				deviceId,
+				// TODO (mirande): callers should provide an object like: { [filename]: filepath }
+				files: files.map || files,
+				targetVersion,
+				auth: this.accessToken
+			})
+		);
 	}
 
 	signalDevice(deviceId, signal){
@@ -95,11 +127,24 @@ module.exports = class ParticleApi {
 	}
 
 	listBuildTargets(onlyFeatured){
-		return this._wrap(this.api.listBuildTargets({ onlyFeatured, auth: this.accessToken }));
+		return this._wrap(
+			this.api.listBuildTargets({
+				onlyFeatured,
+				auth: this.accessToken
+			})
+		);
 	}
 
 	compileCode(files, platformId, targetVersion){
-		return this._wrap(this.api.compileCode({ files, platformId, targetVersion, auth: this.accessToken }));
+		return this._wrap(
+			this.api.compileCode({
+				platformId,
+				targetVersion,
+				// TODO (mirande): callers should provide an object like: { [filename]: filepath }
+				files: files.map || files,
+				auth: this.accessToken
+			})
+		);
 	}
 
 	getVariable(deviceId, name, product){
@@ -125,13 +170,13 @@ module.exports = class ParticleApi {
 		);
 	}
 
-	downloadFirmwareBinary(binaryId, downloadPath){
-		return new Promise((resolve, reject) => {
-			const req = this.api.downloadFirmwareBinary({ binaryId, auth: this.accessToken });
-			req.pipe(fs.createWriteStream(downloadPath))
-				.on('error', reject)
-				.on('finish', resolve);
-		});
+	downloadFirmwareBinary(binaryId){
+		return this._wrap(
+			this.api.downloadFirmwareBinary({
+				binaryId,
+				auth: this.accessToken
+			})
+		);
 	}
 
 	getEventStream(deviceId, name, product){

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -122,8 +122,15 @@ module.exports = class ParticleApi {
 		);
 	}
 
-	signalDevice(deviceId, signal){
-		return this._wrap(this.api.signalDevice({ deviceId, signal, auth: this.accessToken }));
+	signalDevice(deviceId, signal, product){
+		return this._wrap(
+			this.api.signalDevice({
+				deviceId,
+				product,
+				signal,
+				auth: this.accessToken
+			})
+		);
 	}
 
 	listBuildTargets(onlyFeatured){

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -14,7 +14,7 @@ const ParticleAPI = require('./api');
 const UI = require('../lib/ui');
 const prompts = require('../lib/prompts');
 
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const extend = require('xtend');
 const chalk = require('chalk');
@@ -151,7 +151,7 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	flashDevice({ target, followSymlinks, params: { device, files } }){
+	flashDevice({ target, followSymlinks, product, params: { device, files } }){
 		return Promise.resolve()
 			.then(() => {
 				if (files.length === 0){
@@ -160,7 +160,7 @@ module.exports = class CloudCommand {
 				}
 
 				if (!fs.existsSync(files[0])){
-					return this._flashKnownApp({ deviceId: device, filePath: files[0] });
+					return this._flashKnownApp({ product, deviceId: device, filePath: files[0] });
 				}
 
 				const targetVersion = target === 'latest' ? null : target;
@@ -193,7 +193,7 @@ module.exports = class CloudCommand {
 							this.ui.stdout.write(os.EOL);
 						}
 
-						return this._doFlash({ deviceId: device, fileMapping, targetVersion });
+						return this._doFlash({ product, deviceId: device, fileMapping, targetVersion });
 					});
 			})
 			.catch((error) => {
@@ -202,11 +202,18 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	_doFlash({ deviceId, fileMapping, targetVersion }){
+	_doFlash({ product, deviceId, fileMapping, targetVersion }){
 		return Promise.resolve()
 			.then(() => {
+				if (!product){
+					return;
+				}
+				this.ui.stdout.write(`marking device ${deviceId} as a development device${os.EOL}`);
+				return createAPI().markAsDevelopmentDevice(deviceId, true, product);
+			})
+			.then(() => {
 				this.ui.stdout.write(`attempting to flash firmware to your device ${deviceId}${os.EOL}`);
-				return createAPI().flashDevice(deviceId, fileMapping, targetVersion);
+				return createAPI().flashDevice(deviceId, fileMapping, targetVersion, product);
 			})
 			.then((resp) => {
 				if (resp.status || resp.message){
@@ -218,12 +225,22 @@ module.exports = class CloudCommand {
 					throw normalizedApiError(resp);
 				}
 			})
+			.then(() => {
+				if (!product){
+					return;
+				}
+				[
+					`device ${deviceId} is now marked as a developement device and will NOT receive automatic product firmware updates.`,
+					'to resume normal updates, please visit:',
+					`https://console.particle.io/${product}/devices/unmark-development/${deviceId}`
+				].forEach(line => this.ui.stdout.write(`${line}${os.EOL}`));
+			})
 			.catch(err => {
 				throw normalizedApiError(err);
 			});
 	}
 
-	_flashKnownApp({ deviceId, filePath }){
+	_flashKnownApp({ product, deviceId, filePath }){
 		if (!settings.knownApps[filePath]){
 			throw new VError(`I couldn't find that file: ${filePath}`);
 		}
@@ -265,7 +282,7 @@ module.exports = class CloudCommand {
 					});
 			})
 			.then((fileMapping) => {
-				return this._doFlash({ deviceId, fileMapping });
+				return this._doFlash({ product, deviceId, fileMapping });
 			});
 	}
 
@@ -375,7 +392,7 @@ module.exports = class CloudCommand {
 					return createAPI().downloadFirmwareBinary(resp.binary_id)
 						.then(data => {
 							this.ui.stdout.write(`saving to: ${filename}${os.EOL}`);
-							return fs.promises.writeFile(filename, data);
+							return fs.writeFile(filename, data);
 						})
 						.then(() => {
 							return resp.sizeInfo;

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -632,16 +632,6 @@ module.exports = class CloudCommand {
 			onOff = false;
 		}
 
-		if ((device === '') || (device === 'all')){
-			device = null;
-		} else if (device === 'on'){
-			device = null;
-			onOff = true;
-		} else if (device === 'off'){
-			device = null;
-			onOff = false;
-		}
-
 		return Promise.resolve()
 			.then(() => {
 				if (device){

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const _ = require('lodash');
 const VError = require('verror');
 const prompt = require('inquirer').prompt;
@@ -41,148 +42,185 @@ const PLATFORMS = extend(utilities.knownPlatforms(), {
 	'bb': 270
 });
 
-class CloudCommand {
-	constructor() {
+
+module.exports = class CloudCommand {
+	constructor({
+		stdin = process.stdin,
+		stdout = process.stdout,
+		stderr = process.stderr
+	} = {}){
+		this.stdin = stdin;
+		this.stdout = stdout;
+		this.stderr = stderr;
+		this.ui = new UI({ stdin, stdout, stderr });
 		spinnerMixin(this);
-		this.ui = new UI();
 	}
 
-	claimDevice(deviceId) {
-		const api = new ApiClient();
-		api.ensureToken();
-
-		console.log('Claiming device ' + deviceId);
-		return api.claimDevice(deviceId).then(() => {
-			console.log('Successfully claimed device ' + deviceId);
-		}, (err) => {
-			if (err && typeof err[0] === 'string' && err[0].indexOf('That belongs to someone else.') >= 0) {
-				return prompt([{
-					type: 'confirm',
-					name: 'transfer',
-					message: 'That device belongs to someone else. Would you like to request a transfer?',
-					default: true
-				}]).then((ans) => {
-					if (ans.transfer) {
-						return api.claimDevice(deviceId, true).then(() => {
-							console.log('Transfer requested. You will receive an email if your transfer is approved or denied.');
-						});
-					}
-					throw new Error('You cannot claim a device owned by someone else');
-				});
-			}
-
-			throw ensureError(err);
-		}).catch((err) => {
-			throw new VError(ensureError(err), 'Failed to claim device');
-		});
-	}
-
-	removeDevice(deviceId, { yes }) {
-		const api = new ApiClient();
-		api.ensureToken();
-
-		return Promise.resolve().then(() => {
-			if (yes) {
-				return true;
-			}
-			return prompt([{
-				type: 'confirm',
-				name: 'remove',
-				message: 'Are you sure you want to release ownership of this device?',
-				default: true
-			}]).then(ans => ans.remove);
-		}).then(doit => {
-			if (!doit) {
-				throw new Error('Not confirmed');
-			}
-			return api.removeDevice(deviceId);
-		}).then(() => {
-			console.log('Okay!');
-		}).catch((err) => {
-			throw new VError(ensureError(err), "Didn't remove the device");
-		});
-	}
-
-	renameDevice(deviceId, name) {
-		const api = new ApiClient();
-		api.ensureToken();
-
-		console.log('Renaming device ' + deviceId);
-
-		return Promise.resolve().then(() => {
-			return api.renameDevice(deviceId, name);
-		}).catch(err => {
-			if (err.info && err.info.indexOf('I didn\'t recognize that device name or ID') >= 0) {
-				throw new Error('Device not found');
-			}
-			throw err;
-		}).then(() => {
-			console.log('Successfully renamed device ' + deviceId + ' to: ' + name);
-		}).catch(err => {
-			throw new VError(ensureError(err), `Failed to rename ${deviceId}`);
-		});
-	}
-
-	flashDevice(deviceId, files, { target, followSymlinks }) {
-		return Promise.resolve().then(() => {
-			if (files.length === 0) {
-				// default to current directory
-				files.push('.');
-			}
-
-			const api = new ApiClient();
-			api.ensureToken();
-
-			if (!fs.existsSync(files[0])) {
-				return this._flashKnownApp({ api, deviceId, filePath: files[0] });
-			}
-
-			const targetVersion = target === 'latest' ? null : target;
-
-			if (targetVersion) {
-				console.log('Targeting version: ', targetVersion);
-				console.log();
-			}
-
-			return Promise.resolve().then(() => {
-				const fileMapping = this._handleMultiFileArgs(files, { followSymlinks });
-				api._populateFileMapping(fileMapping);
-				return fileMapping;
-			}).then((fileMapping) => {
-				if (Object.keys(fileMapping.map).length === 0) {
-					throw new Error('no files included');
+	listDevices({ params: { filter } }) {
+		return this.getAllDeviceAttributes(filter)
+			.then((devices) => {
+				if (!devices) {
+					return;
 				}
-
-				if (settings.showIncludedSourceFiles) {
-					const list = _.values(fileMapping.map);
-					console.log('Including:');
-					for (let i = 0, n = list.length; i < n; i++) {
-						console.log('    ' + list[i]);
-					}
-				}
-
-				return this._doFlash({ api, deviceId, fileMapping, targetVersion });
+				this.ui.logDeviceDetail(devices);
+			})
+			.catch((err) => {
+				throw new VError(ensureError(err), 'Failed to list device');
 			});
-		}).catch((err) => {
-			throw new VError(ensureError(err), 'Flash device failed');
-		});
+	}
+
+	claimDevice({ params: { deviceID } }){
+		const api = new ApiClient();
+		api.ensureToken();
+
+		this.ui.stdout.write(`Claiming device ${deviceID}${os.EOL}`);
+
+		return api.claimDevice(deviceID)
+			.then(() => this.ui.stdout.write(`Successfully claimed device ${deviceID}${os.EOL}`))
+			.catch((err) => {
+				if (err && typeof err[0] === 'string' && err[0].includes('That belongs to someone else.')) {
+					const question = {
+						type: 'confirm',
+						name: 'transfer',
+						message: 'That device belongs to someone else. Would you like to request a transfer?',
+						default: true
+					};
+
+					return prompt(question)
+						.then(({ transfer }) => {
+							if (transfer) {
+								return api.claimDevice(deviceID, true)
+									.then(() => this.ui.stdout.write(`Transfer requested. You will receive an email if your transfer is approved or denied.${os.EOL}`));
+							}
+							throw new Error('You cannot claim a device owned by someone else');
+						});
+				}
+
+				throw ensureError(err);
+			})
+			.catch((err) => {
+				throw new VError(ensureError(err), 'Failed to claim device');
+			});
+	}
+
+	removeDevice({ yes, params: { device } }) {
+		const api = new ApiClient();
+		api.ensureToken();
+
+		return Promise.resolve()
+			.then(() => {
+				if (yes) {
+					return true;
+				}
+				const question = {
+					type: 'confirm',
+					name: 'remove',
+					message: 'Are you sure you want to release ownership of this device?',
+					default: true
+				};
+				return prompt(question).then(({ remove }) => remove);
+			})
+			.then(remove => {
+				if (!remove) {
+					throw new Error('Not confirmed');
+				}
+				return api.removeDevice(device);
+			})
+			.then(() => this.ui.stdout.write(`Okay!${os.EOL}`))
+			.catch((err) => {
+				throw new VError(ensureError(err), "Didn't remove the device");
+			});
+	}
+
+	renameDevice({ params: { device, name } }) {
+		const api = new ApiClient();
+		api.ensureToken();
+
+		this.ui.stdout.write(`Renaming device ${device}${os.EOL}`);
+
+		return Promise.resolve()
+			.then(() => api.renameDevice(device, name))
+			.catch(err => {
+				if (err.info && err.info.includes('I didn\'t recognize that device name or ID')) {
+					throw new Error('Device not found');
+				}
+				throw err;
+			})
+			.then(() => this.ui.stdout.write(`Successfully renamed device ${device} to: ${name}${os.EOL}`))
+			.catch(err => {
+				throw new VError(ensureError(err), `Failed to rename ${device}`);
+			});
+	}
+
+	flashDevice({ target, followSymlinks, yes, params: { device, files } }) {
+		return Promise.resolve()
+			.then(() => {
+				if (files.length === 0) {
+					// default to current directory
+					files.push('.');
+				}
+
+				const api = new ApiClient();
+				api.ensureToken();
+
+				if (!fs.existsSync(files[0])) {
+					return this._flashKnownApp({ api, deviceId: device, filePath: files[0] });
+				}
+
+				const targetVersion = target === 'latest' ? null : target;
+
+				if (targetVersion) {
+					this.ui.stdout.write(`Targeting version: ${targetVersion}${os.EOL}`);
+					this.ui.stdout.write(os.EOL);
+				}
+
+				return Promise.resolve()
+					.then(() => {
+						const fileMapping = this._handleMultiFileArgs(files, { followSymlinks });
+						api._populateFileMapping(fileMapping);
+						return fileMapping;
+					})
+					.then((fileMapping) => {
+						if (Object.keys(fileMapping.map).length === 0) {
+							throw new Error('no files included');
+						}
+
+						if (settings.showIncludedSourceFiles) {
+							const list = _.values(fileMapping.map);
+
+							this.ui.stdout.write(`Including:${os.EOL}`);
+
+							for (let i = 0, n = list.length; i < n; i++) {
+								this.ui.stdout.write(`    ${list[i]}${os.EOL}`);
+							}
+						}
+
+						return this._doFlash({ api, deviceId: device, fileMapping, targetVersion });
+					});
+			})
+			.catch((err) => {
+				throw new VError(ensureError(err), 'Flash device failed');
+			});
 	}
 
 	_doFlash({ api, deviceId, fileMapping, targetVersion }) {
-		return Promise.resolve().then(() => {
-			return api.flashDevice(deviceId, fileMapping, targetVersion);
-		}).then((resp) => {
-			if (resp.status || resp.message) {
-				console.log('Flash device OK: ', resp.status || resp.message);
-			} else if (resp.output === 'Compiler timed out or encountered an error') {
-				console.log('\n' + (resp.errors && resp.errors[0]));
-				throw new Error('Compiler encountered an error');
-			} else {
-				throw api.normalizedApiError(resp);
-			}
-		}).catch(err => {
-			throw api.normalizedApiError(err);
-		});
+		return Promise.resolve()
+			.then(() => {
+				return api.flashDevice(deviceId, fileMapping, targetVersion);
+			})
+			.then((resp) => {
+				if (resp.status || resp.message) {
+					this.ui.stdout.write(`Flash device OK: ${resp.status || resp.message}${os.EOL}`);
+				} else if (resp.output === 'Compiler timed out or encountered an error') {
+					this.ui.stdout.write(`${os.EOL}${(resp.errors && resp.errors[0])}${os.EOL}`);
+					throw new Error('Compiler encountered an error');
+				} else {
+					throw api.normalizedApiError(resp);
+				}
+			})
+			.catch(err => {
+				throw api.normalizedApiError(err);
+			});
 	}
 
 	_flashKnownApp({ api, deviceId, filePath }) {
@@ -190,43 +228,45 @@ class CloudCommand {
 			throw new VError(`I couldn't find that file: ${filePath}`);
 		}
 
-		return api.getAttributes(deviceId).then((attrs) => {
-			const spec = _.find(specs, { productId: attrs.product_id });
-			if (spec) {
-				if (spec.knownApps[filePath]) {
-					return api._populateFileMapping( { list: [spec.knownApps[filePath]] } );
+		return api.getAttributes(deviceId)
+			.then((attrs) => {
+				const spec = _.find(specs, { productId: attrs.product_id });
+
+				if (spec) {
+					if (spec.knownApps[filePath]) {
+						return api._populateFileMapping({ list: [spec.knownApps[filePath]] });
+					}
+
+					if (spec.productName) {
+						throw new VError(`I don't have a ${filePath} binary for ${spec.productName}.`);
+					}
 				}
 
-				if (spec.productName) {
-					throw new VError(`I don't have a ${filePath} binary for ${spec.productName}.`);
-				}
-			}
+				// TODO (mirande): fix this
+				// TODO: this shouldn't be necessary. Just look at the attrs.platform_id instead of
+				// product_id above
+				const question = {
+					name: 'type',
+					type: 'list',
+					message: 'Which type of device?',
+					choices: ['Photon', 'Core', 'P1', 'Electron']
+				};
 
-			// TODO: this shouldn't be necessary. Just look at the attrs.platform_id instead of
-			// product_id above
-			return prompt([{
-				name: 'type',
-				type: 'list',
-				message: 'Which type of device?',
-				choices: [
-					'Photon',
-					'Core',
-					'P1',
-					'Electron'
-				]
-			}]).then((ans) => {
-				const spec = _.find(specs, { productName: ans.type });
-				const binary = spec && spec.knownApps[filePath];
+				return prompt(question)
+					.then(({ type }) => {
+						const spec = _.find(specs, { productName: type });
+						const binary = spec && spec.knownApps[filePath];
 
-				if (!binary) {
-					throw new VError(`I don't have a ${filePath} binary for ${ans.type}.`);
-				}
+						if (!binary) {
+							throw new VError(`I don't have a ${filePath} binary for ${type}.`);
+						}
 
-				return { map: { binary: binary } };
+						return { map: { binary: binary } };
+					});
+			})
+			.then((fileMapping) => {
+				return this._doFlash({ api, deviceId, fileMapping });
 			});
-		}).then((fileMapping) => {
-			return this._doFlash({ api, deviceId, fileMapping });
-		});
 	}
 
 	_getDownloadPath(deviceType, saveTo) {
@@ -237,112 +277,121 @@ class CloudCommand {
 		return deviceType + '_firmware_' + Date.now() + '.bin';
 	}
 
-	compileCode(deviceType, files, { target, saveTo, followSymlinks }) {
+	compileCode({ target, followSymlinks, yes, saveTo, params: { deviceType, files } }) {
 		let api;
 		let platformId;
 		let targetVersion;
 
-		return Promise.resolve().then(() => {
-			if (files.length === 0) {
-				files.push('.'); // default to current directory
-			}
+		return Promise.resolve()
+			.then(() => {
+				if (files.length === 0) {
+					files.push('.'); // default to current directory
+				}
 
-			if (deviceType in PLATFORMS) {
-				platformId = PLATFORMS[deviceType];
-			} else {
-				throw new Error([
-					'Target device ' + deviceType + ' is not valid',
-					'	eg. particle compile core xxx',
-					'	eg. particle compile photon xxx'
-				].join('\n'));
-			}
+				if (deviceType in PLATFORMS) {
+					platformId = PLATFORMS[deviceType];
+				} else {
+					throw new Error([
+						`Target device ${deviceType} is not valid`,
+						'	eg. particle compile core xxx',
+						'	eg. particle compile photon xxx'
+					].join('\n'));
+				}
 
-			api = new ApiClient();
-			api.ensureToken();
+				api = new ApiClient();
+				api.ensureToken();
 
-			console.log('\nCompiling code for ' + deviceType);
+				this.ui.stdout.write(`${os.EOL}Compiling code for ${deviceType}${os.EOL}`);
 
-			if (target) {
-				if (target === 'latest') {
+				if (target) {
+					if (target === 'latest') {
+						return;
+					}
+
+					return api.getBuildTargets()
+						.catch(err => {
+							throw api.normalizedApiError(err);
+						})
+						.then((data) => {
+							const validTargets = data.targets.filter((t) => t.platforms.includes(platformId));
+							const validTarget = validTargets.filter((t) => t.version === target);
+
+							if (!validTarget.length) {
+								throw new VError(['Invalid build target version.', 'Valid targets:'].concat(_.map(validTargets, 'version')).join('\n'));
+							}
+
+							targetVersion = validTarget[0].version;
+							this.ui.stdout.write(`Targeting version: ${targetVersion}${os.EOL}`);
+						});
+				}
+			})
+			.then(() => {
+				const filePath = files[0];
+
+				this.ui.stdout.write(os.EOL);
+
+				if (!fs.existsSync(filePath)) {
+					throw new VError(`I couldn't find that: ${filePath}`);
+				}
+
+				return this._handleMultiFileArgs(files, { followSymlinks });
+			})
+			.then((fileMapping) => {
+				if (!fileMapping) {
 					return;
 				}
 
-				return api.getBuildTargets().catch(err => {
-					throw api.normalizedApiError(err);
-				}).then((data) => {
-					const validTargets = data.targets.filter((t) => {
-						return t.platforms.indexOf(platformId) >= 0;
-					});
-					const validTarget = validTargets.filter((t) => {
-						return t.version === target;
-					});
-					if (!validTarget.length) {
-						throw new VError(['Invalid build target version.', 'Valid targets:'].concat(_.map(validTargets, 'version')).join('\n'));
-					}
+				const list = _.values(fileMapping.map);
 
-					targetVersion = validTarget[0].version;
-					console.log('Targeting version:', targetVersion);
-				});
-			}
-		}).then(() => {
-			console.log();
-
-			const filePath = files[0];
-			if (!fs.existsSync(filePath)) {
-				throw new VError(`I couldn't find that: ${filePath}`);
-			}
-
-			return this._handleMultiFileArgs(files, { followSymlinks });
-		}).then((fileMapping) => {
-			if (!fileMapping) {
-				return;
-			}
-
-			const list = _.values(fileMapping.map);
-			if (list.length === 0) {
-				throw new VError('No source to compile!');
-			}
-
-			if (settings.showIncludedSourceFiles) {
-				console.log('Including:');
-				for (let i = 0, n = list.length; i < n; i++) {
-					console.log('    ' + list[i]);
+				if (list.length === 0) {
+					throw new VError('No source to compile!');
 				}
-			}
 
-			const filename = this._getDownloadPath(deviceType, saveTo);
-			return this._compileAndDownload(api, fileMapping, platformId, filename, targetVersion);
-		}).catch((err) => {
-			throw new VError(ensureError(err), 'Compile failed');
-		});
+				if (settings.showIncludedSourceFiles) {
+					this.ui.stdout.write(`Including:${os.EOL}`);
+					for (let i = 0, n = list.length; i < n; i++) {
+						this.ui.stdout.write(`    ${list[i]}${os.EOL}`);
+					}
+				}
+
+				const filename = this._getDownloadPath(deviceType, saveTo);
+				return this._compileAndDownload(api, fileMapping, platformId, filename, targetVersion);
+			})
+			.catch((err) => {
+				throw new VError(ensureError(err), 'Compile failed');
+			});
 	}
 
 	_compileAndDownload(api, fileMapping, platformId, filename, targetVersion) {
-		return Promise.resolve().then(() => {
-			// compile
-			return api.compileCode(fileMapping, platformId, targetVersion);
-		}).then(resp => {
-			//download
-			if (resp && resp.binary_url) {
-				return api.downloadBinary(resp.binary_url, filename).then(() => {
-					return resp.sizeInfo;
-				});
-			} else if (resp && resp.output === 'Compiler timed out or encountered an error') {
-				console.log('\n' + (resp && resp.errors && resp.errors[0]));
-				throw new Error('Compiler encountered an error');
-			} else {
-				throw api.normalizedApiError(resp);
-			}
-		}).catch(err => {
-			throw api.normalizedApiError(err);
-		}).then((sizeInfo) => {
-			if (sizeInfo) {
-				console.log('Memory use: ');
-				console.log(sizeInfo);
-			}
-			console.log('Compile succeeded.');
-			console.log('Saved firmware to:', path.resolve(filename));
-		});
+		return Promise.resolve()
+			.then(() => {
+				// compile
+				return api.compileCode(fileMapping, platformId, targetVersion);
+			})
+			.then(resp => {
+				//download
+				if (resp && resp.binary_url) {
+					return api.downloadBinary(resp.binary_url, filename).then(() => {
+						return resp.sizeInfo;
+					});
+				} else if (resp && resp.output === 'Compiler timed out or encountered an error') {
+					this.ui.stdout.write(`${os.EOL}${(resp && resp.errors && resp.errors[0])}${os.EOL}`);
+					throw new Error('Compiler encountered an error');
+				} else {
+					throw api.normalizedApiError(resp);
+				}
+			})
+			.catch(err => {
+				throw api.normalizedApiError(err);
+			})
+			.then((sizeInfo) => {
+				if (sizeInfo) {
+					this.ui.stdout.write(`Memory use:${os.EOL}`);
+					this.ui.stdout.write(`${sizeInfo}${os.EOL}`);
+				}
+				this.ui.stdout.write(`Compile succeeded.${os.EOL}`);
+				this.ui.stdout.write(`Saved firmware to: ${path.resolve(filename)}${os.EOL}`);
+			});
 	}
 
 	login({ username, password, token, otp } = {}) {
@@ -367,10 +416,7 @@ class CloudCommand {
 
 				if (token) {
 					return this.stopSpinAfterPromise(api.getUser(token).then((response) => {
-						return {
-							token,
-							username: response.username
-						};
+						return { token, username: response.username };
 					}));
 				}
 				return this.stopSpinAfterPromise(api.login(settings.clientId, username, password))
@@ -380,13 +426,13 @@ class CloudCommand {
 							return this.enterOtp({ otp, mfaToken: error.mfa_token, shouldRetry });
 						}
 						throw error;
-					}).then(body => ({ token: body.access_token, username }));
+					})
+					.then(body => ({ token: body.access_token, username }));
 			})
 			.then(credentials => {
 				const { token, username } = credentials;
 
-				console.log(arrow, 'Successfully completed login!');
-
+				this.ui.stdout.write(`${arrow} Successfully completed login!${os.EOL}`);
 				settings.override(null, 'access_token', token);
 
 				if (username) {
@@ -399,8 +445,8 @@ class CloudCommand {
 				return token;
 			})
 			.catch(error => {
-				console.log(alert, `There was an error logging you in! ${shouldRetry ? "Let's try again." : ''}`);
-				console.error(alert, error.message || error.error_description);
+				this.ui.stdout.write(`${alert} There was an error logging you in! ${shouldRetry ? "Let's try again." : ''}${os.EOL}`);
+				this.ui.stderr.write(`${alert} ${error.message || error.error_description}${os.EOL}`);
 				this.tries = (this.tries || 0) + 1;
 
 				if (shouldRetry && this.tries < 3){
@@ -411,66 +457,67 @@ class CloudCommand {
 	}
 
 	enterOtp({ otp, mfaToken, shouldRetry = true }) {
-		return Promise.resolve().then(() => {
-			if (!this.tries) {
-				console.log('Use your authenticator app on your mobile device to get a login code.');
-				console.log('Lost access to your phone? Visit https://login.particle.io/account-info');
-			}
+		return Promise.resolve()
+			.then(() => {
+				if (!this.tries) {
+					this.ui.stdout.write(`Use your authenticator app on your mobile device to get a login code.${os.EOL}`);
+					this.ui.stdout.write(`Lost access to your phone? Visit https://login.particle.io/account-info${os.EOL}`);
+				}
 
-			if (otp) {
-				return otp;
-			}
-			return prompts.getOtp();
-		}).then(_otp => {
-			otp = _otp;
-			this.newSpin('Sending login code...').start();
+				if (otp) {
+					return otp;
+				}
+				return prompts.getOtp();
+			})
+			.then(_otp => {
+				otp = _otp;
+				this.newSpin('Sending login code...').start();
+				const api = new ApiClient();
+				return this.stopSpinAfterPromise(api.sendOtp(settings.clientId, mfaToken, otp));
+			})
+			.catch(error => {
+				this.ui.stdout.write(`${alert} This login code didn't work. ${shouldRetry ? "Let's try again." : ''}${os.EOL}`);
+				this.ui.stderr.write(`${alert} ${error.message || error.error_description}${os.EOL}`);
+				this.tries = (this.tries || 0) + 1;
 
-			const api = new ApiClient();
-			return this.stopSpinAfterPromise(api.sendOtp(settings.clientId, mfaToken, otp));
-		}).catch(error => {
-			console.log(alert, `This login code didn't work. ${shouldRetry ? "Let's try again." : ''}`);
-			console.error(alert, error.message || error.error_description);
-			this.tries = (this.tries || 0) + 1;
-
-			if (shouldRetry && this.tries < 3){
-				return this.enterOtp({ mfaToken, shouldRetry });
-			}
-			throw new VError('Recover your account at https://login.particle.io/account-info');
-		});
+				if (shouldRetry && this.tries < 3){
+					return this.enterOtp({ mfaToken, shouldRetry });
+				}
+				throw new VError('Recover your account at https://login.particle.io/account-info');
+			});
 	}
 
 	doLogout(keep, password) {
 		const api = new ApiClient();
 
-		return Promise.resolve().then(() => {
-			if (!keep) {
-				return api.removeAccessToken(settings.username, password, settings.access_token);
-			} else {
-				console.log(arrow, 'Leaving your token intact.');
-			}
-		}).then(() => {
-			console.log(
-				arrow,
-				util.format('You have been logged out from %s.',
-					chalk.bold.cyan(settings.username))
-			);
-			settings.override(null, 'username', null);
-			settings.override(null, 'access_token', null);
-		}).catch(err => {
-			throw new VError(ensureError(err), 'There was an error revoking the token');
-		});
+		return Promise.resolve()
+			.then(() => {
+				if (!keep) {
+					return api.removeAccessToken(settings.username, password, settings.access_token);
+				}
+				this.ui.stdout.write(`${arrow} Leaving your token intact.${os.EOL}`);
+			})
+			.then(() => {
+				this.ui.stdout.write(`${arrow} You have been logged out from ${chalk.bold.cyan(settings.username)}${os.EOL}`);
+				settings.override(null, 'username', null);
+				settings.override(null, 'access_token', null);
+			})
+			.catch(err => {
+				throw new VError(ensureError(err), 'There was an error revoking the token');
+			});
 	}
 
 	logout(noPrompt) {
 		if (!settings.access_token) {
-			console.log('You were already logged out.');
+			this.ui.stdout.write(`You were already logged out.${os.EOL}`);
 			return;
 		}
+
 		if (noPrompt) {
 			return this.doLogout(true);
 		}
 
-		return prompt([
+		const questions = [
 			{
 				type: 'confirm',
 				name: 'keep',
@@ -485,9 +532,10 @@ class CloudCommand {
 					return !ans.keep;
 				}
 			}
-		]).then((ans) => {
-			return this.doLogout(ans.keep, ans.password);
-		});
+		];
+
+		return prompt(questions)
+			.then(({ password, keep }) => this.doLogout(keep, password));
 	}
 
 
@@ -500,65 +548,59 @@ class CloudCommand {
 		if (filter){
 			const platforms = utilities.knownPlatforms();
 			if (filter === 'online') {
-				filterFunc = (d) => {
-					return d.connected;
-				};
+				filterFunc = (d) => d.connected;
 			} else if (filter === 'offline') {
-				filterFunc = (d) => {
-					return !d.connected;
-				};
+				filterFunc = (d) => !d.connected;
 			} else if (Object.keys(platforms).indexOf(filter) >= 0) {
-				filterFunc = (d) => {
-					return d.product_id === platforms[filter];
-				};
+				filterFunc = (d) => d.product_id === platforms[filter];
 			} else {
-				filterFunc = (d) => {
-					return d.id === filter || d.name === filter;
-				};
+				filterFunc = (d) => d.id === filter || d.name === filter;
 			}
 		}
 
-		return Promise.resolve().then(() => {
-			return api.listDevices();
-		}).then(devices => {
-			if (!devices || (devices.length === 0) || (typeof devices === 'string')) {
-				console.log('No devices found.');
-			} else {
-				this.newSpin('Retrieving device functions and variables...').start();
-				const promises = [];
-				devices.forEach((device) => {
-					if (!device.id || (filter && !filterFunc(device))) {
-						// Don't request attributes from unnecessary devices...
-						return;
-					}
-
-					if (device.connected) {
-						promises.push(api.getAttributes(device.id).then((attrs) => {
-							return extend(device, attrs);
-						}));
-					} else {
-						promises.push(Promise.resolve(device));
-					}
-				});
-
-				return this.stopSpinAfterPromise(Promise.all(promises).then(fullDevices => {
-					//sort alphabetically
-					fullDevices = fullDevices.sort((a, b) => {
-						if (a.connected && !b.connected) {
-							return 1;
+		return Promise.resolve()
+			.then(() => {
+				return api.listDevices();
+			})
+			.then(devices => {
+				if (!devices || (devices.length === 0) || (typeof devices === 'string')) {
+					this.ui.stdout.write(`No devices found.${os.EOL}`);
+				} else {
+					this.newSpin('Retrieving device functions and variables...').start();
+					const promises = [];
+					devices.forEach((device) => {
+						if (!device.id || (filter && !filterFunc(device))) {
+							// Don't request attributes from unnecessary devices...
+							return;
 						}
 
-						return (a.name || '').localeCompare(b.name);
+						if (device.connected) {
+							promises.push(api.getAttributes(device.id).then((attrs) => {
+								return extend(device, attrs);
+							}));
+						} else {
+							promises.push(Promise.resolve(device));
+						}
 					});
-					return fullDevices;
-				}));
-			}
-		}).catch(err => {
-			throw api.normalizedApiError(err);
-		});
+
+					return this.stopSpinAfterPromise(Promise.all(promises).then(fullDevices => {
+						//sort alphabetically
+						fullDevices = fullDevices.sort((a, b) => {
+							if (a.connected && !b.connected) {
+								return 1;
+							}
+
+							return (a.name || '').localeCompare(b.name);
+						});
+						return fullDevices;
+					}));
+				}
+			}).catch(err => {
+				throw api.normalizedApiError(err);
+			});
 	}
 
-	nyanMode(deviceId, onOff) {
+	nyanMode({ params: { device, onOff } }) {
 		const api = new ApiClient();
 		api.ensureToken();
 
@@ -568,55 +610,43 @@ class CloudCommand {
 			onOff = false;
 		}
 
-		if ((deviceId === '') || (deviceId === 'all')) {
-			deviceId = null;
-		} else if (deviceId === 'on') {
-			deviceId = null;
+		if ((device === '') || (device === 'all')) {
+			device = null;
+		} else if (device === 'on') {
+			device = null;
 			onOff = true;
-		} else if (deviceId === 'off') {
-			deviceId = null;
+		} else if (device === 'off') {
+			device = null;
 			onOff = false;
 		}
 
-		if (deviceId) {
-			return api.signalDevice(deviceId, onOff).catch((err) => {
-				throw api.normalizedApiError(err);
-			});
+		if (device) {
+			return api.signalDevice(device, onOff)
+				.catch((err) => {
+					throw api.normalizedApiError(err);
+				});
 		} else {
-			return Promise.resolve(() => {
-				return api.listDevices();
-			}).then(devices => {
-				if (!devices || (devices.length === 0)) {
-					console.log('No devices found.');
-					return;
-				} else {
-					const promises = [];
-					devices.forEach((device) => {
-						if (!device.connected) {
-							promises.push(Promise.resolve(device));
-							return;
-						}
-						promises.push(api.signalDevice(device.id, onOff));
-					});
-					return Promise.all(promises);
-				}
-			}).catch(err => {
-				throw api.normalizedApiError(err);
-			});
+			return Promise.resolve(() => api.listDevices())
+				.then(devices => {
+					if (!devices || (devices.length === 0)) {
+						this.ui.stdout.write(`No devices found.${os.EOL}`);
+						return;
+					} else {
+						const promises = [];
+						devices.forEach((device) => {
+							if (!device.connected) {
+								promises.push(Promise.resolve(device));
+								return;
+							}
+							promises.push(api.signalDevice(device.id, onOff));
+						});
+						return Promise.all(promises);
+					}
+				})
+				.catch(err => {
+					throw api.normalizedApiError(err);
+				});
 		}
-	}
-
-	listDevices(filter) {
-		return this.getAllDeviceAttributes(filter)
-			.then((devices) => {
-				if (!devices) {
-					return;
-				}
-				this.ui.logDeviceDetail(devices);
-			})
-			.catch((err) => {
-				throw new VError(ensureError(err), 'Failed to list device');
-			});
 	}
 
 	/**
@@ -764,6 +794,5 @@ class CloudCommand {
 			}
 		});
 	}
-}
+};
 
-module.exports = CloudCommand;

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -606,9 +606,8 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	nyanMode({ params: { device, onOff } }){
-		const api = new ApiClient();
-		api.ensureToken();
+	nyanMode({ product, params: { device, onOff } }){
+		const api = createAPI();
 
 		if (!onOff || (onOff === '') || (onOff === 'on')){
 			onOff = true;
@@ -626,33 +625,35 @@ module.exports = class CloudCommand {
 			onOff = false;
 		}
 
-		if (device){
-			return api.signalDevice(device, onOff)
-				.catch((err) => {
-					throw api.normalizedApiError(err);
-				});
-		} else {
-			return Promise.resolve(() => api.listDevices())
-				.then(devices => {
-					if (!devices || (devices.length === 0)){
-						this.ui.stdout.write(`No devices found.${os.EOL}`);
-						return;
-					} else {
-						const promises = [];
-						devices.forEach((device) => {
-							if (!device.connected){
-								promises.push(Promise.resolve(device));
+		return Promise.resolve()
+			.then(() => {
+				if (device){
+					return api.signalDevice(device, onOff, product);
+				} else {
+					return Promise.resolve()
+						.then(() => api.listDevices())
+						.then(devices => {
+							if (!devices || (devices.length === 0)){
+								this.ui.stdout.write(`No devices found.${os.EOL}`);
 								return;
+							} else {
+								const promises = [];
+								devices.forEach((device) => {
+									if (!device.connected){
+										promises.push(Promise.resolve(device));
+										return;
+									}
+									promises.push(api.signalDevice(device.id, onOff, product));
+								});
+								return Promise.all(promises);
 							}
-							promises.push(api.signalDevice(device.id, onOff));
 						});
-						return Promise.all(promises);
-					}
-				})
-				.catch(err => {
-					throw api.normalizedApiError(err);
-				});
-		}
+				}
+			})
+			.catch((error) => {
+				const message = 'Signaling failed';
+				throw createAPIErrorResult({ error, message });
+			});
 	}
 
 	/**

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -5,10 +5,12 @@ const prompt = require('inquirer').prompt;
 
 const settings = require('../../settings');
 const specs = require('../lib/deviceSpecs');
-const ApiClient = require('../lib/api-client');
+const ApiClient = require('../lib/api-client'); // TODO (mirande): remove in favor of `ParticleAPI`
+const { normalizedApiError } = require('../lib/api-client');
 const utilities = require('../lib/utilities');
 const spinnerMixin = require('../lib/spinner-mixin');
 const ensureError = require('../lib/utilities').ensureError;
+const ParticleAPI = require('./api');
 const UI = require('../lib/ui');
 const prompts = require('../lib/prompts');
 
@@ -55,10 +57,10 @@ module.exports = class CloudCommand {
 		spinnerMixin(this);
 	}
 
-	listDevices({ params: { filter } }) {
+	listDevices({ params: { filter } }){
 		return this.getAllDeviceAttributes(filter)
 			.then((devices) => {
-				if (!devices) {
+				if (!devices){
 					return;
 				}
 				this.ui.logDeviceDetail(devices);
@@ -69,15 +71,16 @@ module.exports = class CloudCommand {
 	}
 
 	claimDevice({ params: { deviceID } }){
-		const api = new ApiClient();
-		api.ensureToken();
+		const api = createAPI();
 
 		this.ui.stdout.write(`Claiming device ${deviceID}${os.EOL}`);
 
 		return api.claimDevice(deviceID)
 			.then(() => this.ui.stdout.write(`Successfully claimed device ${deviceID}${os.EOL}`))
 			.catch((err) => {
-				if (err && typeof err[0] === 'string' && err[0].includes('That belongs to someone else.')) {
+				const error = formatAPIErrorMessage(err);
+
+				if (error.canRequestTransfer){
 					const question = {
 						type: 'confirm',
 						name: 'transfer',
@@ -87,7 +90,7 @@ module.exports = class CloudCommand {
 
 					return prompt(question)
 						.then(({ transfer }) => {
-							if (transfer) {
+							if (transfer){
 								return api.claimDevice(deviceID, true)
 									.then(() => this.ui.stdout.write(`Transfer requested. You will receive an email if your transfer is approved or denied.${os.EOL}`));
 							}
@@ -95,20 +98,18 @@ module.exports = class CloudCommand {
 						});
 				}
 
-				throw ensureError(err);
+				throw error;
 			})
-			.catch((err) => {
-				throw new VError(ensureError(err), 'Failed to claim device');
+			.catch((error) => {
+				const message = 'Failed to claim device';
+				throw createAPIErrorResult({ error, message });
 			});
 	}
 
-	removeDevice({ yes, params: { device } }) {
-		const api = new ApiClient();
-		api.ensureToken();
-
+	removeDevice({ yes, params: { device } }){
 		return Promise.resolve()
 			.then(() => {
-				if (yes) {
+				if (yes){
 					return true;
 				}
 				const question = {
@@ -120,55 +121,51 @@ module.exports = class CloudCommand {
 				return prompt(question).then(({ remove }) => remove);
 			})
 			.then(remove => {
-				if (!remove) {
+				if (!remove){
 					throw new Error('Not confirmed');
 				}
-				return api.removeDevice(device);
+				this.ui.stdout.write(`releasing device ${device}${os.EOL}`);
+				return createAPI().removeDevice(device);
 			})
 			.then(() => this.ui.stdout.write(`Okay!${os.EOL}`))
-			.catch((err) => {
-				throw new VError(ensureError(err), "Didn't remove the device");
+			.catch((error) => {
+				const message = 'Didn\'t remove the device';
+				throw createAPIErrorResult({ error, message });
 			});
 	}
 
-	renameDevice({ params: { device, name } }) {
-		const api = new ApiClient();
-		api.ensureToken();
-
+	renameDevice({ params: { device, name } }){
 		this.ui.stdout.write(`Renaming device ${device}${os.EOL}`);
-
 		return Promise.resolve()
-			.then(() => api.renameDevice(device, name))
+			.then(() => createAPI().renameDevice(device, name))
 			.catch(err => {
-				if (err.info && err.info.includes('I didn\'t recognize that device name or ID')) {
+				if (err.info && err.info.includes('I didn\'t recognize that device name or ID')){
 					throw new Error('Device not found');
 				}
 				throw err;
 			})
 			.then(() => this.ui.stdout.write(`Successfully renamed device ${device} to: ${name}${os.EOL}`))
-			.catch(err => {
-				throw new VError(ensureError(err), `Failed to rename ${device}`);
+			.catch((error) => {
+				const message = `Failed to rename ${device}`;
+				throw createAPIErrorResult({ error, message });
 			});
 	}
 
-	flashDevice({ target, followSymlinks, params: { device, files } }) {
+	flashDevice({ target, followSymlinks, params: { device, files } }){
 		return Promise.resolve()
 			.then(() => {
-				if (files.length === 0) {
+				if (files.length === 0){
 					// default to current directory
 					files.push('.');
 				}
 
-				const api = new ApiClient();
-				api.ensureToken();
-
-				if (!fs.existsSync(files[0])) {
-					return this._flashKnownApp({ api, deviceId: device, filePath: files[0] });
+				if (!fs.existsSync(files[0])){
+					return this._flashKnownApp({ deviceId: device, filePath: files[0] });
 				}
 
 				const targetVersion = target === 'latest' ? null : target;
 
-				if (targetVersion) {
+				if (targetVersion){
 					this.ui.stdout.write(`Targeting version: ${targetVersion}${os.EOL}`);
 					this.ui.stdout.write(os.EOL);
 				}
@@ -176,67 +173,71 @@ module.exports = class CloudCommand {
 				return Promise.resolve()
 					.then(() => {
 						const fileMapping = this._handleMultiFileArgs(files, { followSymlinks });
-						api._populateFileMapping(fileMapping);
+						populateFileMapping(fileMapping);
 						return fileMapping;
 					})
 					.then((fileMapping) => {
-						if (Object.keys(fileMapping.map).length === 0) {
+						if (Object.keys(fileMapping.map).length === 0){
 							throw new Error('no files included');
 						}
 
-						if (settings.showIncludedSourceFiles) {
+						if (settings.showIncludedSourceFiles){
 							const list = _.values(fileMapping.map);
 
 							this.ui.stdout.write(`Including:${os.EOL}`);
 
-							for (let i = 0, n = list.length; i < n; i++) {
+							for (let i = 0, n = list.length; i < n; i++){
 								this.ui.stdout.write(`    ${list[i]}${os.EOL}`);
 							}
+
+							this.ui.stdout.write(os.EOL);
 						}
 
-						return this._doFlash({ api, deviceId: device, fileMapping, targetVersion });
+						return this._doFlash({ deviceId: device, fileMapping, targetVersion });
 					});
 			})
-			.catch((err) => {
-				throw new VError(ensureError(err), 'Flash device failed');
+			.catch((error) => {
+				const message = `Failed to flash ${device}`;
+				throw createAPIErrorResult({ error, message });
 			});
 	}
 
-	_doFlash({ api, deviceId, fileMapping, targetVersion }) {
+	_doFlash({ deviceId, fileMapping, targetVersion }){
 		return Promise.resolve()
 			.then(() => {
-				return api.flashDevice(deviceId, fileMapping, targetVersion);
+				this.ui.stdout.write(`attempting to flash firmware to your device ${deviceId}${os.EOL}`);
+				return createAPI().flashDevice(deviceId, fileMapping, targetVersion);
 			})
 			.then((resp) => {
-				if (resp.status || resp.message) {
+				if (resp.status || resp.message){
 					this.ui.stdout.write(`Flash device OK: ${resp.status || resp.message}${os.EOL}`);
-				} else if (resp.output === 'Compiler timed out or encountered an error') {
+				} else if (resp.output === 'Compiler timed out or encountered an error'){
 					this.ui.stdout.write(`${os.EOL}${(resp.errors && resp.errors[0])}${os.EOL}`);
 					throw new Error('Compiler encountered an error');
 				} else {
-					throw api.normalizedApiError(resp);
+					throw normalizedApiError(resp);
 				}
 			})
 			.catch(err => {
-				throw api.normalizedApiError(err);
+				throw normalizedApiError(err);
 			});
 	}
 
-	_flashKnownApp({ api, deviceId, filePath }) {
-		if (!settings.knownApps[filePath]) {
+	_flashKnownApp({ deviceId, filePath }){
+		if (!settings.knownApps[filePath]){
 			throw new VError(`I couldn't find that file: ${filePath}`);
 		}
 
-		return api.getAttributes(deviceId)
+		return createAPI().getDeviceAttributes(deviceId)
 			.then((attrs) => {
 				const spec = _.find(specs, { productId: attrs.product_id });
 
-				if (spec) {
-					if (spec.knownApps[filePath]) {
-						return api._populateFileMapping({ list: [spec.knownApps[filePath]] });
+				if (spec){
+					if (spec.knownApps[filePath]){
+						return populateFileMapping({ list: [spec.knownApps[filePath]] });
 					}
 
-					if (spec.productName) {
+					if (spec.productName){
 						throw new VError(`I don't have a ${filePath} binary for ${spec.productName}.`);
 					}
 				}
@@ -256,7 +257,7 @@ module.exports = class CloudCommand {
 						const spec = _.find(specs, { productName: type });
 						const binary = spec && spec.knownApps[filePath];
 
-						if (!binary) {
+						if (!binary){
 							throw new VError(`I don't have a ${filePath} binary for ${type}.`);
 						}
 
@@ -264,30 +265,30 @@ module.exports = class CloudCommand {
 					});
 			})
 			.then((fileMapping) => {
-				return this._doFlash({ api, deviceId, fileMapping });
+				return this._doFlash({ deviceId, fileMapping });
 			});
 	}
 
-	_getDownloadPath(deviceType, saveTo) {
-		if (saveTo) {
+	_getDownloadPath(deviceType, saveTo){
+		if (saveTo){
 			return saveTo;
 		}
 
 		return deviceType + '_firmware_' + Date.now() + '.bin';
 	}
 
-	compileCode({ target, followSymlinks, saveTo, params: { deviceType, files } }) {
-		let api;
+	compileCode({ target, followSymlinks, saveTo, params: { deviceType, files } }){
 		let platformId;
 		let targetVersion;
 
 		return Promise.resolve()
+			.then(() => ensureAPIToken())
 			.then(() => {
-				if (files.length === 0) {
+				if (files.length === 0){
 					files.push('.'); // default to current directory
 				}
 
-				if (deviceType in PLATFORMS) {
+				if (deviceType in PLATFORMS){
 					platformId = PLATFORMS[deviceType];
 				} else {
 					throw new Error([
@@ -297,25 +298,22 @@ module.exports = class CloudCommand {
 					].join('\n'));
 				}
 
-				api = new ApiClient();
-				api.ensureToken();
-
 				this.ui.stdout.write(`${os.EOL}Compiling code for ${deviceType}${os.EOL}`);
 
-				if (target) {
-					if (target === 'latest') {
+				if (target){
+					if (target === 'latest'){
 						return;
 					}
 
-					return api.getBuildTargets()
+					return createAPI().listBuildTargets(true /* onlyFeatured */)
 						.catch(err => {
-							throw api.normalizedApiError(err);
+							throw normalizedApiError(err);
 						})
 						.then((data) => {
 							const validTargets = data.targets.filter((t) => t.platforms.includes(platformId));
 							const validTarget = validTargets.filter((t) => t.version === target);
 
-							if (!validTarget.length) {
+							if (!validTarget.length){
 								throw new VError(['Invalid build target version.', 'Valid targets:'].concat(_.map(validTargets, 'version')).join('\n'));
 							}
 
@@ -329,62 +327,71 @@ module.exports = class CloudCommand {
 
 				this.ui.stdout.write(os.EOL);
 
-				if (!fs.existsSync(filePath)) {
+				if (!fs.existsSync(filePath)){
 					throw new VError(`I couldn't find that: ${filePath}`);
 				}
 
 				return this._handleMultiFileArgs(files, { followSymlinks });
 			})
 			.then((fileMapping) => {
-				if (!fileMapping) {
+				if (!fileMapping){
 					return;
 				}
 
 				const list = _.values(fileMapping.map);
 
-				if (list.length === 0) {
+				if (list.length === 0){
 					throw new VError('No source to compile!');
 				}
 
-				if (settings.showIncludedSourceFiles) {
+				if (settings.showIncludedSourceFiles){
 					this.ui.stdout.write(`Including:${os.EOL}`);
-					for (let i = 0, n = list.length; i < n; i++) {
+
+					for (let i = 0, n = list.length; i < n; i++){
 						this.ui.stdout.write(`    ${list[i]}${os.EOL}`);
 					}
+
+					this.ui.stdout.write(os.EOL);
 				}
 
 				const filename = this._getDownloadPath(deviceType, saveTo);
-				return this._compileAndDownload(api, fileMapping, platformId, filename, targetVersion);
+				return this._compileAndDownload(fileMapping, platformId, filename, targetVersion);
 			})
-			.catch((err) => {
-				throw new VError(ensureError(err), 'Compile failed');
+			.catch((error) => {
+				const message = 'Compile failed';
+				throw createAPIErrorResult({ error, message });
 			});
 	}
 
-	_compileAndDownload(api, fileMapping, platformId, filename, targetVersion) {
+	_compileAndDownload(fileMapping, platformId, filename, targetVersion){
 		return Promise.resolve()
 			.then(() => {
-				// compile
-				return api.compileCode(fileMapping, platformId, targetVersion);
+				this.ui.stdout.write(`attempting to compile firmware${os.EOL}`);
+				return createAPI().compileCode(fileMapping, platformId, targetVersion);
 			})
 			.then(resp => {
-				//download
-				if (resp && resp.binary_url) {
-					return api.downloadBinary(resp.binary_url, filename).then(() => {
-						return resp.sizeInfo;
-					});
-				} else if (resp && resp.output === 'Compiler timed out or encountered an error') {
+				if (resp && resp.binary_url && resp.binary_id){
+					this.ui.stdout.write(`downloading binary from: ${resp.binary_url}${os.EOL}`);
+					return createAPI().downloadFirmwareBinary(resp.binary_id)
+						.then(data => {
+							this.ui.stdout.write(`saving to: ${filename}${os.EOL}`);
+							return fs.promises.writeFile(filename, data);
+						})
+						.then(() => {
+							return resp.sizeInfo;
+						});
+				} else if (resp && resp.output === 'Compiler timed out or encountered an error'){
 					this.ui.stdout.write(`${os.EOL}${(resp && resp.errors && resp.errors[0])}${os.EOL}`);
 					throw new Error('Compiler encountered an error');
 				} else {
-					throw api.normalizedApiError(resp);
+					throw normalizedApiError(resp);
 				}
 			})
 			.catch(err => {
-				throw api.normalizedApiError(err);
+				throw normalizedApiError(err);
 			})
 			.then((sizeInfo) => {
-				if (sizeInfo) {
+				if (sizeInfo){
 					this.ui.stdout.write(`Memory use:${os.EOL}`);
 					this.ui.stdout.write(`${sizeInfo}${os.EOL}`);
 				}
@@ -393,7 +400,7 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	login({ username, password, token, otp } = {}) {
+	login({ username, password, token, otp } = {}){
 		const shouldRetry = !((username && password) || token && !this.tries);
 
 		return Promise.resolve()
@@ -413,14 +420,14 @@ module.exports = class CloudCommand {
 				this.newSpin('Sending login details...').start();
 				this._usernameProvided = username;
 
-				if (token) {
+				if (token){
 					return this.stopSpinAfterPromise(api.getUser(token).then((response) => {
 						return { token, username: response.username };
 					}));
 				}
 				return this.stopSpinAfterPromise(api.login(settings.clientId, username, password))
 					.catch((error) => {
-						if (error.error === 'mfa_required') {
+						if (error.error === 'mfa_required'){
 							this.tries = 0;
 							return this.enterOtp({ otp, mfaToken: error.mfa_token, shouldRetry });
 						}
@@ -434,7 +441,7 @@ module.exports = class CloudCommand {
 				this.ui.stdout.write(`${arrow} Successfully completed login!${os.EOL}`);
 				settings.override(null, 'access_token', token);
 
-				if (username) {
+				if (username){
 					settings.override(null, 'username', username);
 				}
 
@@ -455,15 +462,15 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	enterOtp({ otp, mfaToken, shouldRetry = true }) {
+	enterOtp({ otp, mfaToken, shouldRetry = true }){
 		return Promise.resolve()
 			.then(() => {
-				if (!this.tries) {
+				if (!this.tries){
 					this.ui.stdout.write(`Use your authenticator app on your mobile device to get a login code.${os.EOL}`);
 					this.ui.stdout.write(`Lost access to your phone? Visit https://login.particle.io/account-info${os.EOL}`);
 				}
 
-				if (otp) {
+				if (otp){
 					return otp;
 				}
 				return prompts.getOtp();
@@ -486,12 +493,12 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	doLogout(keep, password) {
+	doLogout(keep, password){
 		const api = new ApiClient();
 
 		return Promise.resolve()
 			.then(() => {
-				if (!keep) {
+				if (!keep){
 					return api.removeAccessToken(settings.username, password, settings.access_token);
 				}
 				this.ui.stdout.write(`${arrow} Leaving your token intact.${os.EOL}`);
@@ -506,13 +513,13 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	logout(noPrompt) {
-		if (!settings.access_token) {
+	logout(noPrompt){
+		if (!settings.access_token){
 			this.ui.stdout.write(`You were already logged out.${os.EOL}`);
 			return;
 		}
 
-		if (noPrompt) {
+		if (noPrompt){
 			return this.doLogout(true);
 		}
 
@@ -538,7 +545,7 @@ module.exports = class CloudCommand {
 	}
 
 
-	getAllDeviceAttributes(filter) {
+	getAllDeviceAttributes(filter){
 		const api = new ApiClient();
 		api.ensureToken();
 
@@ -546,11 +553,11 @@ module.exports = class CloudCommand {
 
 		if (filter){
 			const platforms = utilities.knownPlatforms();
-			if (filter === 'online') {
+			if (filter === 'online'){
 				filterFunc = (d) => d.connected;
-			} else if (filter === 'offline') {
+			} else if (filter === 'offline'){
 				filterFunc = (d) => !d.connected;
-			} else if (Object.keys(platforms).indexOf(filter) >= 0) {
+			} else if (Object.keys(platforms).indexOf(filter) >= 0){
 				filterFunc = (d) => d.product_id === platforms[filter];
 			} else {
 				filterFunc = (d) => d.id === filter || d.name === filter;
@@ -562,18 +569,18 @@ module.exports = class CloudCommand {
 				return api.listDevices();
 			})
 			.then(devices => {
-				if (!devices || (devices.length === 0) || (typeof devices === 'string')) {
+				if (!devices || (devices.length === 0) || (typeof devices === 'string')){
 					this.ui.stdout.write(`No devices found.${os.EOL}`);
 				} else {
 					this.newSpin('Retrieving device functions and variables...').start();
 					const promises = [];
 					devices.forEach((device) => {
-						if (!device.id || (filter && !filterFunc(device))) {
+						if (!device.id || (filter && !filterFunc(device))){
 							// Don't request attributes from unnecessary devices...
 							return;
 						}
 
-						if (device.connected) {
+						if (device.connected){
 							promises.push(api.getAttributes(device.id).then((attrs) => {
 								return extend(device, attrs);
 							}));
@@ -585,7 +592,7 @@ module.exports = class CloudCommand {
 					return this.stopSpinAfterPromise(Promise.all(promises).then(fullDevices => {
 						//sort alphabetically
 						fullDevices = fullDevices.sort((a, b) => {
-							if (a.connected && !b.connected) {
+							if (a.connected && !b.connected){
 								return 1;
 							}
 
@@ -599,27 +606,27 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	nyanMode({ params: { device, onOff } }) {
+	nyanMode({ params: { device, onOff } }){
 		const api = new ApiClient();
 		api.ensureToken();
 
-		if (!onOff || (onOff === '') || (onOff === 'on')) {
+		if (!onOff || (onOff === '') || (onOff === 'on')){
 			onOff = true;
-		} else if (onOff === 'off') {
+		} else if (onOff === 'off'){
 			onOff = false;
 		}
 
-		if ((device === '') || (device === 'all')) {
+		if ((device === '') || (device === 'all')){
 			device = null;
-		} else if (device === 'on') {
+		} else if (device === 'on'){
 			device = null;
 			onOff = true;
-		} else if (device === 'off') {
+		} else if (device === 'off'){
 			device = null;
 			onOff = false;
 		}
 
-		if (device) {
+		if (device){
 			return api.signalDevice(device, onOff)
 				.catch((err) => {
 					throw api.normalizedApiError(err);
@@ -627,13 +634,13 @@ module.exports = class CloudCommand {
 		} else {
 			return Promise.resolve(() => api.listDevices())
 				.then(devices => {
-					if (!devices || (devices.length === 0)) {
+					if (!devices || (devices.length === 0)){
 						this.ui.stdout.write(`No devices found.${os.EOL}`);
 						return;
 					} else {
 						const promises = [];
 						devices.forEach((device) => {
-							if (!device.connected) {
+							if (!device.connected){
 								promises.push(Promise.resolve(device));
 								return;
 							}
@@ -666,12 +673,12 @@ module.exports = class CloudCommand {
 			map: {}
 		};
 
-		for (let i = 0; i < filenames.length; i++) {
+		for (let i = 0; i < filenames.length; i++){
 			const filename = filenames[i];
 			const ext = utilities.getFilenameExt(filename).toLowerCase();
 			const alwaysIncludeThisFile = ((ext === '.bin') && (i === 0) && (filenames.length === 1));
 
-			if (filename.indexOf('--') === 0) {
+			if (filename.indexOf('--') === 0){
 				// go over the argument
 				i++;
 				continue;
@@ -680,21 +687,21 @@ module.exports = class CloudCommand {
 			let filestats;
 			try {
 				filestats = fs.statSync(filename);
-			} catch (ex) {
+			} catch (ex){
 				console.error("I couldn't find the file " + filename);
 				return null;
 			}
 
-			if (filestats.isDirectory()) {
+			if (filestats.isDirectory()){
 				this._processDirIncludes(fileMapping, filename, { followSymlinks });
 				continue;
 			}
 
-			if (!alwaysIncludeThisFile && settings.notSourceExtensions.includes(ext)) {
+			if (!alwaysIncludeThisFile && settings.notSourceExtensions.includes(ext)){
 				continue;
 			}
 
-			if (!alwaysIncludeThisFile && filestats.size > settings.MAX_FILE_SIZE) {
+			if (!alwaysIncludeThisFile && filestats.size > settings.MAX_FILE_SIZE){
 				console.log('Skipping ' + filename + " it's too big! " + filestats.size);
 				continue;
 			}
@@ -737,7 +744,7 @@ module.exports = class CloudCommand {
 			'project.properties'
 		];
 
-		if (fs.existsSync(includesFile)) {
+		if (fs.existsSync(includesFile)){
 			//grab and process all the files in the include file.
 
 			includes = utilities.trimBlankLinesAndComments(
@@ -749,7 +756,7 @@ module.exports = class CloudCommand {
 
 		let files = utilities.globList(dirname, includes, { followSymlinks });
 
-		if (fs.existsSync(ignoreFile)) {
+		if (fs.existsSync(ignoreFile)){
 			const ignores = utilities.trimBlankLinesAndComments(
 				utilities.readAndTrimLines(ignoreFile)
 			);
@@ -766,7 +773,7 @@ module.exports = class CloudCommand {
 			// If using an include file, only base names are supported since people are using those to
 			// link across relative folders
 			let target;
-			if (hasIncludeFile) {
+			if (hasIncludeFile){
 				target = path.basename(file);
 			} else {
 				target = path.relative(dirname, file);
@@ -781,17 +788,72 @@ module.exports = class CloudCommand {
 	 * @param {Object} fileMapping Object mapping from filenames seen by the compile server to local filenames,
 	 *                             relative to a base path
 	 */
-	_handleLibraryExample(fileMapping) {
+	_handleLibraryExample(fileMapping){
 		return Promise.resolve().then(() => {
 			const list = _.values(fileMapping.map);
-			if (list.length === 1) {
+			if (list.length === 1){
 				return require('particle-library-manager').isLibraryExample(list[0]);
 			}
 		}).then(example => {
-			if (example) {
+			if (example){
 				return example.buildFiles(fileMapping);
 			}
 		});
 	}
 };
 
+
+// UTILS //////////////////////////////////////////////////////////////////////
+function createAPI(){
+	return new ParticleAPI(settings.apiUrl, {
+		accessToken: settings.access_token
+	});
+}
+
+function createAPIErrorResult({ error: e, message, json }){
+	const error = new VError(formatAPIErrorMessage(e), message);
+	error.asJSON = json;
+	return error;
+}
+
+// TODO (mirande): reconcile this w/ `normalizedApiError()` and `ensureError()`
+// utilities and pull the result into cmd/api.js
+function formatAPIErrorMessage(error){
+	error = normalizedApiError(error);
+
+	if (error.body){
+		if (typeof error.body.error === 'string'){
+			error.message = error.body.error;
+		} else if (Array.isArray(error.body.errors)){
+			if (error.body.errors.length === 1){
+				error.message = error.body.errors[0];
+			}
+		}
+	}
+
+	if (error.message.includes('That belongs to someone else.')){
+		error.canRequestTransfer = true;
+	}
+
+	return error;
+}
+
+// TODO (mirande): refactor cmd/api.js to do this check by default when appropriate
+function ensureAPIToken(){
+	if (!settings.access_token){
+		throw new Error(`You're not logged in. Please login using ${chalk.bold.cyan('particle cloud login')} before using this command`);
+	}
+}
+
+function populateFileMapping(fileMapping){
+	if (!fileMapping.map){
+		fileMapping.map = {};
+		if (fileMapping.list){
+			for (let i = 0; i < fileMapping.list.length; i++){
+				let item = fileMapping.list[i];
+				fileMapping.map[item] = item;
+			}
+		}
+	}
+	return fileMapping;
+}

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -15,7 +15,6 @@ const prompts = require('../lib/prompts');
 const fs = require('fs');
 const path = require('path');
 const extend = require('xtend');
-const util = require('util');
 const chalk = require('chalk');
 
 const arrow = chalk.green('>');
@@ -152,7 +151,7 @@ module.exports = class CloudCommand {
 			});
 	}
 
-	flashDevice({ target, followSymlinks, yes, params: { device, files } }) {
+	flashDevice({ target, followSymlinks, params: { device, files } }) {
 		return Promise.resolve()
 			.then(() => {
 				if (files.length === 0) {
@@ -277,7 +276,7 @@ module.exports = class CloudCommand {
 		return deviceType + '_firmware_' + Date.now() + '.bin';
 	}
 
-	compileCode({ target, followSymlinks, yes, saveTo, params: { deviceType, files } }) {
+	compileCode({ target, followSymlinks, saveTo, params: { deviceType, files } }) {
 		let api;
 		let platformId;
 		let targetVersion;

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -28,7 +28,7 @@ module.exports = class FlashCommand {
 		} else if (serial){
 			result = this.flashYModem({ binary, port, yes });
 		} else {
-			result = this.flashCloud({ device, files, target, yes });
+			result = this.flashCloud({ device, files, target });
 		}
 
 		return result.then(() => {
@@ -36,9 +36,9 @@ module.exports = class FlashCommand {
 		});
 	}
 
-	flashCloud({ device, files, target, yes }){
+	flashCloud({ device, files, target }){
 		const CloudCommands = require('../cmd/cloud');
-		const args = { target, yes, params: { device, files } };
+		const args = { target, params: { device, files } };
 		return new CloudCommands().flashDevice(args);
 	}
 

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -38,7 +38,8 @@ module.exports = class FlashCommand {
 
 	flashCloud({ device, files, target, yes }){
 		const CloudCommands = require('../cmd/cloud');
-		return new CloudCommands().flashDevice(device, files, { target, yes });
+		const args = { target, yes, params: { device, files } };
+		return new CloudCommands().flashDevice(args);
 	}
 
 	flashYModem({ binary, port, yes }){

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -92,7 +92,7 @@ describe('Cloud Commands [@device]', () => {
 			'',
 			'Including:',
 			`    ${PATH_PROJ_STROBY_INO}`,
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
 			`saving to: ${strobyBinPath}`,
 			'Memory use:',

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -195,6 +195,25 @@ describe('Cloud Commands [@device]', () => {
 		await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductVariable()` helper
 	});
 
+	it('Flashes a `known app` on to a product device', async () => {
+		const args = ['cloud', 'flash', PRODUCT_01_DEVICE_01_ID, 'tinker', '--product', PRODUCT_01_ID];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+		const log = [
+			`marking device ${PRODUCT_01_DEVICE_01_ID} as a development device`,
+			`attempting to flash firmware to your device ${PRODUCT_01_DEVICE_01_ID}`,
+			'Flash device OK: Update started',
+			`device ${PRODUCT_01_DEVICE_01_ID} is now marked as a developement device and will NOT receive automatic product firmware updates.`,
+			'to resume normal updates, please visit:',
+			`https://console.particle.io/${PRODUCT_01_ID}/devices/unmark-development/${PRODUCT_01_DEVICE_01_ID}`
+		];
+
+		expect(stdout.split('\n')).to.include.members(log);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+
+		await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductFunction()` helper
+	});
+
 	it('Removes device', async () => {
 		const args = ['cloud', 'remove', DEVICE_NAME, '--yes'];
 		const { stdout, stderr, exitCode } = await cli.run(args);

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -95,7 +95,7 @@ describe('Cloud Commands [@device]', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
 			`saving to: ${strobyBinPath}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${strobyBinPath}`
@@ -134,7 +134,7 @@ describe('Cloud Commands [@device]', () => {
 			'Including:',
 			`    ${PATH_PROJ_STROBY_INO}`,
 			`attempting to flash firmware to your device ${DEVICE_NAME}`,
-			'Flash device OK:  Update started'
+			'Flash device OK: Update started'
 		];
 
 		expect(stdout.split('\n')).to.include.members(log);
@@ -245,6 +245,33 @@ describe('Cloud Commands [@device]', () => {
 		expect(stdout.split('\n')).to.include.members(log);
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
+	});
+
+	it('Fails to name an unknown device', async () => {
+		const invalidDeviceID = '1234567890';
+		const args = ['cloud', 'name', invalidDeviceID, 'NOPE'];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+		const log = [
+			`Renaming device ${invalidDeviceID}`,
+			`Failed to rename ${invalidDeviceID}: Permission Denied`
+		];
+
+		expect(stdout.split('\n')).to.include.members(log);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(1);
+	});
+
+	it('Fails to name a device owned by someone else', async () => {
+		const args = ['cloud', 'name', FOREIGN_DEVICE_ID, 'NOPE'];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+		const log = [
+			`Renaming device ${FOREIGN_DEVICE_ID}`,
+			`Failed to rename ${FOREIGN_DEVICE_ID}: Permission Denied`
+		];
+
+		expect(stdout.split('\n')).to.include.members(log);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(1);
 	});
 });
 

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -9,6 +9,9 @@ const {
 	DEVICE_NAME,
 	DEVICE_PLATFORM_NAME,
 	FOREIGN_DEVICE_ID,
+	PRODUCT_01_ID,
+	PRODUCT_01_DEVICE_01_ID,
+	PRODUCT_01_DEVICE_01_NAME,
 	PATH_TMP_DIR,
 	PATH_PROJ_STROBY_INO,
 	PATH_FIXTURES_PROJECTS_DIR
@@ -43,9 +46,13 @@ describe('Cloud Commands [@device]', () => {
 		await cli.flashBlankFirmwareOTAForTest();
 	});
 
-	after(async () => {
+	afterEach(async () => {
 		await cli.claimTestDevice();
 		await cli.revertDeviceName();
+	});
+
+	after(async () => {
+		await cli.run(['cloud', 'nyan', 'all', 'off'], { reject: true });
 		await cli.logout();
 		await cli.setDefaultProfile();
 	});
@@ -159,6 +166,8 @@ describe('Cloud Commands [@device]', () => {
 		expect(stdout.split('\n')).to.include.members(log);
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
+
+		await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForDeviceToGetOnline()` helper
 	});
 
 	it('Removes device', async () => {
@@ -270,6 +279,71 @@ describe('Cloud Commands [@device]', () => {
 		];
 
 		expect(stdout.split('\n')).to.include.members(log);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(1);
+	});
+
+	it('Starts a device signaling', async () => {
+		const args = ['cloud', 'nyan', DEVICE_NAME];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.equal('');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Stops a device signaling', async () => {
+		const args = ['cloud', 'nyan', DEVICE_NAME, 'off'];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.equal('');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	// TODO (mirande): this currently includes all product devices..?
+	it('Starts all devices signaling', async () => {
+		const args = ['cloud', 'nyan', 'all'];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.equal('');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Stops all devices signaling', async () => {
+		const args = ['cloud', 'nyan', 'all', 'off'];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.equal('');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Starts a product device signaling', async () => {
+		const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_ID, '--product', PRODUCT_01_ID];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.equal('');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Stops a product device signaling', async () => {
+		const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_ID, 'off', '--product', PRODUCT_01_ID];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.equal('');
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+	});
+
+	// TODO (mirande): seems like a bug..?
+	it('Fails to start a product device signaling when called with device name', async () => {
+		const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_NAME, '--product', PRODUCT_01_ID];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+
+		expect(stdout).to.equal('Signaling failed: Device not found.');
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(1);
 	});

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -53,7 +53,10 @@ describe('Cloud Commands [@device]', () => {
 	});
 
 	after(async () => {
-		await cli.run(['cloud', 'nyan', 'all', 'off'], { reject: true });
+		await Promise.all(
+			[DEVICE_ID, PRODUCT_01_DEVICE_01_ID]
+				.map(id => cli.run(['cloud', 'nyan', id, 'off'], { reject: true }))
+		);
 		await cli.logout();
 		await cli.setDefaultProfile();
 	});
@@ -316,25 +319,6 @@ describe('Cloud Commands [@device]', () => {
 
 	it('Stops a device signaling', async () => {
 		const args = ['cloud', 'nyan', DEVICE_NAME, 'off'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	// TODO (mirande): this currently includes all product devices..?
-	it('Starts all devices signaling', async () => {
-		const args = ['cloud', 'nyan', 'all'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Stops all devices signaling', async () => {
-		const args = ['cloud', 'nyan', 'all', 'off'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
 		expect(stdout).to.equal('');

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -13,6 +13,7 @@ const {
 	PRODUCT_01_DEVICE_01_ID,
 	PRODUCT_01_DEVICE_01_NAME,
 	PATH_TMP_DIR,
+	PATH_PROJ_BLANK_INO,
 	PATH_PROJ_STROBY_INO,
 	PATH_FIXTURES_PROJECTS_DIR
 } = require('../lib/env');
@@ -168,6 +169,27 @@ describe('Cloud Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 
 		await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForDeviceToGetOnline()` helper
+	});
+
+	it('Flashes a product device', async () => {
+		const args = ['cloud', 'flash', PRODUCT_01_DEVICE_01_ID, PATH_PROJ_BLANK_INO, '--product', PRODUCT_01_ID];
+		const { stdout, stderr, exitCode } = await cli.run(args);
+		const log = [
+			'Including:',
+			`    ${PATH_PROJ_BLANK_INO}`,
+			`marking device ${PRODUCT_01_DEVICE_01_ID} as a development device`,
+			`attempting to flash firmware to your device ${PRODUCT_01_DEVICE_01_ID}`,
+			'Flash device OK: Update started',
+			`device ${PRODUCT_01_DEVICE_01_ID} is now marked as a developement device and will NOT receive automatic product firmware updates.`,
+			'to resume normal updates, please visit:',
+			`https://console.particle.io/${PRODUCT_01_ID}/devices/unmark-development/${PRODUCT_01_DEVICE_01_ID}`
+		];
+
+		expect(stdout.split('\n')).to.include.members(log);
+		expect(stderr).to.equal('');
+		expect(exitCode).to.equal(0);
+
+		await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductVariable()` helper
 	});
 
 	it('Removes device', async () => {

--- a/test/e2e/compile.e2e.js
+++ b/test/e2e/compile.e2e.js
@@ -75,7 +75,7 @@ describe('Compile Commands', () => {
 			'',
 			'Including:',
 			`    ${PATH_PROJ_STROBY_INO}`,
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
 			`saving to: ${strobyBinPath}`,
 			'Memory use:',
@@ -101,7 +101,7 @@ describe('Compile Commands', () => {
 			'',
 			'Including:',
 			`    ${PATH_PROJ_STROBY_INO}`,
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
 			`saving to: ${strobyBinPath}`,
 			'Memory use:',
@@ -135,7 +135,7 @@ describe('Compile Commands', () => {
 			'    app.ino',
 			'    helper.cpp',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -167,7 +167,7 @@ describe('Compile Commands', () => {
 			'    app.ino',
 			'    helper/helper.cpp',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -199,7 +199,7 @@ describe('Compile Commands', () => {
 			'    helper/helper.cpp',
 			'    helper/helper.h',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -231,7 +231,7 @@ describe('Compile Commands', () => {
 			'    helper.cpp',
 			'    helper.h',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -265,7 +265,7 @@ describe('Compile Commands', () => {
 			'    app.ino',
 			'    helper.cpp',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -304,7 +304,7 @@ describe('Compile Commands', () => {
 			'    src/helper/h2.cpp',
 			'    src/helper/h3.cpp',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -360,7 +360,7 @@ describe('Compile Commands', () => {
 			'    legacy-flat/app.ino',
 			'    legacy-flat/helper.cpp',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -393,7 +393,7 @@ describe('Compile Commands', () => {
 			'    src/helper/helper.cpp',
 			'    project.properties',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -428,7 +428,7 @@ describe('Compile Commands', () => {
 			'    src/test-library-publish.h',
 			'    src/uber-library-example/uber-library-example.h',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
 			'Memory use:',
@@ -453,7 +453,7 @@ describe('Compile Commands', () => {
 			'',
 			'Including:',
 			`    ${PATH_PROJ_STROBY_INO}`,
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
 			`saving to: ${strobyBinPath}`,
 			'Memory use:',
@@ -513,13 +513,14 @@ describe('Compile Commands', () => {
 			'    app.ino',
 			'    helper.cpp',
 			'',
-			'attempting to compile firmware ',
+			'attempting to compile firmware',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
-			`saving to: ${destination}`
+			`saving to: ${destination}`,
+			`Compile failed: ENOENT: no such file or directory, open '${destination}'`
 		];
 
 		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.include(`Error: ENOENT: no such file or directory, open '${destination}'`);
+		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(1);
 	});
 
@@ -530,8 +531,8 @@ describe('Compile Commands', () => {
 		const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
 
 		expect(stdout).to.include('Compiling code for photon');
+		expect(stdout).to.include('Compile failed: make -C ../modules/photon/user-part all');
 		expect(stdout).to.include('error: \'asdfjasfjdkl\' does not name a type');
-		expect(stdout).to.include('Compile failed: Compiler encountered an error');
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(1);
 	});

--- a/test/e2e/compile.e2e.js
+++ b/test/e2e/compile.e2e.js
@@ -78,7 +78,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
 			`saving to: ${strobyBinPath}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${strobyBinPath}`
@@ -104,7 +104,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
 			`saving to: ${strobyBinPath}`,
-			'Memory use: ',
+			'Memory use:',
 			'   text\t   data\t    bss\t    dec\t    hex\tfilename',
 			'   8332\t    112\t   1112\t   9556\t   2554\t/workspace/target/workspace.elf',
 			'',
@@ -138,7 +138,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -170,7 +170,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -202,7 +202,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -234,7 +234,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -268,7 +268,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -307,7 +307,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -363,7 +363,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -396,7 +396,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -431,7 +431,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			`saving to: ${destination}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${destination}`
@@ -456,7 +456,7 @@ describe('Compile Commands', () => {
 			'attempting to compile firmware ',
 			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
 			`saving to: ${strobyBinPath}`,
-			'Memory use: ',
+			'Memory use:',
 			'', // don't assert against memory stats since they may change based on current default Device OS version
 			'Compile succeeded.',
 			`Saved firmware to: ${strobyBinPath}`

--- a/test/e2e/flash.e2e.js
+++ b/test/e2e/flash.e2e.js
@@ -79,7 +79,7 @@ describe('Flash Commands [@device]', () => {
 			'    src/stroby.ino',
 			'    project.properties',
 			`attempting to flash firmware to your device ${DEVICE_NAME}`,
-			'Flash device OK:  Update started'
+			'Flash device OK: Update started'
 		];
 
 		expect(stdout.split('\n')).to.include.members(log);
@@ -116,7 +116,7 @@ describe('Flash Commands [@device]', () => {
 			'Including:',
 			`    ${PATH_PROJ_STROBY_INO}`,
 			`attempting to flash firmware to your device ${DEVICE_NAME}`,
-			'Flash device OK:  Update started'
+			'Flash device OK: Update started'
 		];
 
 		expect(stdout.split('\n')).to.include.members(log);
@@ -134,7 +134,7 @@ describe('Flash Commands [@device]', () => {
 			'Including:',
 			`    ${bin}`,
 			`attempting to flash firmware to your device ${DEVICE_NAME}`,
-			'Flash device OK:  Update started'
+			'Flash device OK: Update started'
 		];
 
 		expect(stdout.split('\n')).to.include.members(log);

--- a/test/e2e/help.e2e.js
+++ b/test/e2e/help.e2e.js
@@ -44,8 +44,8 @@ describe('Help & Unknown Command / Argument Handling', () => {
 		'  whoami      prints signed-in username'
 	];
 
-	const allCmds = ['binary inspect', 'binary', 'call', 'cloud claim',
-		'cloud list', 'cloud remove', 'cloud name', 'cloud flash',
+	const allCmds = ['binary inspect', 'binary', 'call', 'cloud list',
+		'cloud claim', 'cloud remove', 'cloud name', 'cloud flash',
 		'cloud compile', 'cloud nyan', 'cloud login', 'cloud logout',
 		'cloud', 'compile', 'config', 'device add', 'device remove',
 		'device rename', 'device doctor', 'device', 'doctor', 'flash',

--- a/test/e2e/token.e2e.js
+++ b/test/e2e/token.e2e.js
@@ -177,10 +177,11 @@ describe('Token Commands', () => {
 		const tokens = matches(stripANSI(stdout), / Token:\s{6}(.*)/g);
 
 		expect(tokens).to.have.lengthOf.at.least(3);
-		expect(stderr).to.equal('');
+		expect(stderr).to.match(/(?:Checking with the cloud\.\.\.)?/);
 		expect(exitCode).to.equal(0);
 
 		// TODO (mirande): always revoke all tokens upon completion?
+		// console.log('TOKEN COUNT:', tokens.length);
 		// await tokens.reduce((promise, t) => {
 		// 	return promise.then(() => {
 		// 		console.log('REVOKING:', t);

--- a/test/e2e/variable.e2e.js
+++ b/test/e2e/variable.e2e.js
@@ -172,7 +172,7 @@ describe('Variable Commands [@device]', () => {
 		});
 	});
 
-	describe('Variable Get Subcommand', () => {
+	describe('Variable Monitor Subcommand', () => {
 		it('Monitors a variable', async () => {
 			const args = ['variable', 'monitor', DEVICE_ID, 'version', '--delay', 1000];
 			const subprocess = cli.run(args);


### PR DESCRIPTION
## Description

Adds support for optional `--product <id>` flag to the `particle cloud flash` command to facilitate flashing a product device ([ch](https://app.clubhouse.io/particle/story/47342/enable-cloud-flashing-a-product-device))

## How to Test

_Note: requires you to have a Particle product with one or more devices_

Run `particle cloud flash --help` and explore the command and options.

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

