### PR TITLE
bugfix/ch52181/fix-platform-id-check

### DIFF
--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -723,7 +723,11 @@ module.exports = class ApiClient {
 				includePath: true
 			});
 		}
-		form.append('platform_id', platformId);
+
+		if (platformId != null){
+			form.append('platform_id', platformId);
+		}
+
 		if (targetVersion){
 			form.append('build_target_version', targetVersion);
 		} else {


### PR DESCRIPTION
## Description

ran into an error:

```
Flash device failed: Cannot read property 'path' of undefined
VError: Flash device failed: Cannot read property 'path' of undefined
    at /Users/me/code/particle/cli/dist/cmd/cloud.js:207:13
    at async CLI.runCommand (/Users/me/code/particle/cli/dist/app/cli.js:160:7)
    at async CLI.run (/Users/me/code/particle/cli/dist/app/cli.js:190:14)
caused by: TypeError: Cannot read property 'path' of undefined
    at FormData._getContentDisposition (/Users/me/code/particle/cli/node_modules/request/node_modules/form-data/lib/form_data.js:195:44)
    at FormData._multiPartHeader (/Users/me/code/particle/cli/node_modules/request/node_modules/form-data/lib/form_data.js:169:33)
    at FormData.append (/Users/me/code/particle/cli/node_modules/request/node_modules/form-data/lib/form_data.js:64:21)
    at ApiClient._addFilesToCompile (/Users/me/code/particle/cli/dist/lib/api-client.js:756:10)
    at /Users/me/code/particle/cli/dist/lib/api-client.js:660:12
    at new Promise (<anonymous>)
    at ApiClient.flashDevice (/Users/me/code/particle/cli/dist/lib/api-client.js:639:12)
    at /Users/me/code/particle/cli/dist/cmd/cloud.js:218:18
```

...after running the device-dependent `e2e` tests


## How to Test

1. set up your local environment to run `e2e` tests as [described here](https://github.com/particle-iot/particle-cli/blob/9d7cc57e06fbe50bd21844a3375508ca148be578/test/README.md)
2. run `npm run test:e2e`


## Related Issues / Discussions

see #568 


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

