### PR TITLE
bugfix/ch47215/product-error-messaging

### DIFF
--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -55,7 +55,7 @@ module.exports = ({ commandProcessor, root }) => {
 			return new CloudCommands().renameDevice(args);
 		},
 		examples: {
-			'$0 $command red green': 'Rename red device to green'
+			'$0 $command red green': 'Rename device `red` to `green`'
 		}
 	});
 
@@ -71,11 +71,11 @@ module.exports = ({ commandProcessor, root }) => {
 			return new CloudCommands().flashDevice(args);
 		},
 		examples: {
-			'$0 $command blue': 'Compile the source code in the current directory in the cloud and flash to device blue',
-			'$0 $command green tinker': 'Flash the default Tinker app to device green',
-			'$0 $command red blink.ino': 'Compile blink.ino in the cloud and flash to device red',
-			'$0 $command orange firmware.bin': 'Flash the pre-compiled binary to device orange',
-			'$0 $command blue --product 12345': 'Compile the source code in the current directory in the cloud and flash to device blue within product 12345'
+			'$0 $command blue': 'Compile the source code in the current directory in the cloud and flash to device `blue`',
+			'$0 $command green tinker': 'Flash the default `tinker` app to device `green`',
+			'$0 $command red blink.ino': 'Compile `blink.ino` in the cloud and flash to device `red`',
+			'$0 $command orange firmware.bin': 'Flash a pre-compiled `firmware.bin` binary to device `orange`',
+			'$0 $command 0123456789abcdef01234567 --product 12345': 'Compile the source code in the current directory in the cloud and flash to device `0123456789abcdef01234567` within product `12345`'
 		}
 	});
 
@@ -91,8 +91,8 @@ module.exports = ({ commandProcessor, root }) => {
 			return new CloudCommands().compileCode(args);
 		},
 		examples: {
-			'$0 $command photon': 'Compile the source code in the current directory in the cloud for a Photon',
-			'$0 $command electron project --saveTo electron.bin': 'Compile the source code in the project directory in the cloud for a Electron and save it to electron.bin',
+			'$0 $command photon': 'Compile the source code in the current directory in the cloud for a `photon`',
+			'$0 $command electron project --saveTo electron.bin': 'Compile the source code in the project directory in the cloud for an `electron` and save it to a file named `electron.bin`',
 		},
 		// TODO: get the platforms from config and document in epilogue
 		epilogue: 'Param deviceType can be: core, photon, p1, electron, argon, asom, boron, bsom, xenon, xsom, etc'
@@ -117,11 +117,6 @@ module.exports = ({ commandProcessor, root }) => {
 	});
 
 	commandProcessor.createCommand(cloud, 'login', 'Login to the cloud and store an access token locally', {
-		examples: {
-			'$0 $command': 'prompt for credentials and log in',
-			'$0 $command --username user@example.com --password test': 'log in with credentials provided on the command line',
-			'$0 $command --token <my-api-token>': 'log in with an access token provided on the command line'
-		},
 		options: {
 			u: {
 				description: 'your username',
@@ -142,6 +137,11 @@ module.exports = ({ commandProcessor, root }) => {
 		handler: (args) => {
 			const CloudCommands = require('../cmd/cloud');
 			return new CloudCommands().login(args);
+		},
+		examples: {
+			'$0 $command': 'prompt for credentials and log in',
+			'$0 $command --username user@example.com --password test': 'log in with credentials provided on the command line',
+			'$0 $command --token <my-api-token>': 'log in with an access token provided on the command line'
 		}
 	});
 

--- a/src/cli/cloud.test.js
+++ b/src/cli/cloud.test.js
@@ -182,7 +182,7 @@ describe('Cloud Command-Line Interface', () => {
 					'Usage: particle cloud name [options] <device> <name>',
 					'',
 					'Examples:',
-					'  particle cloud name red green  Rename red device to green',
+					'  particle cloud name red green  Rename device `red` to `green`',
 					''
 				].join(os.EOL));
 			});
@@ -241,11 +241,11 @@ describe('Cloud Command-Line Interface', () => {
 					'  --product         Target a device within the given Product ID or Slug  [string]',
 					'',
 					'Examples:',
-					'  particle cloud flash blue                  Compile the source code in the current directory in the cloud and flash to device blue',
-					'  particle cloud flash green tinker          Flash the default Tinker app to device green',
-					'  particle cloud flash red blink.ino         Compile blink.ino in the cloud and flash to device red',
-					'  particle cloud flash orange firmware.bin   Flash the pre-compiled binary to device orange',
-					'  particle cloud flash blue --product 12345  Compile the source code in the current directory in the cloud and flash to device blue within product 12345',
+					'  particle cloud flash blue                                      Compile the source code in the current directory in the cloud and flash to device `blue`',
+					'  particle cloud flash green tinker                              Flash the default `tinker` app to device `green`',
+					'  particle cloud flash red blink.ino                             Compile `blink.ino` in the cloud and flash to device `red`',
+					'  particle cloud flash orange firmware.bin                       Flash a pre-compiled `firmware.bin` binary to device `orange`',
+					'  particle cloud flash 0123456789abcdef01234567 --product 12345  Compile the source code in the current directory in the cloud and flash to device `0123456789abcdef01234567` within product `12345`',
 					''
 				].join(os.EOL));
 			});
@@ -306,8 +306,8 @@ describe('Cloud Command-Line Interface', () => {
 					'  --saveTo          Filename for the compiled binary  [string]',
 					'',
 					'Examples:',
-					'  particle cloud compile photon                                  Compile the source code in the current directory in the cloud for a Photon',
-					'  particle cloud compile electron project --saveTo electron.bin  Compile the source code in the project directory in the cloud for a Electron and save it to electron.bin',
+					'  particle cloud compile photon                                  Compile the source code in the current directory in the cloud for a `photon`',
+					'  particle cloud compile electron project --saveTo electron.bin  Compile the source code in the project directory in the cloud for an `electron` and save it to a file named `electron.bin`',
 					'',
 					'Param deviceType can be: core, photon, p1, electron, argon, asom, boron, bsom, xenon, xsom, etc',
 					''

--- a/src/cli/function.js
+++ b/src/cli/function.js
@@ -21,9 +21,9 @@ module.exports = ({ commandProcessor, root }) => {
 
 		},
 		examples: {
-			'$0 $command coffee brew': 'Call the brew function on the coffee device',
-			'$0 $command board digitalWrite D7=HIGH': 'Call the digitalWrite function with argument D7=HIGH on the board device',
-			'$0 $command coffee brew --product 12345': 'Call the brew function on the coffee device within product 12345'
+			'$0 $command coffee brew': 'Call the `brew` function on the `coffee` device',
+			'$0 $command board digitalWrite D7=HIGH': 'Call the `digitalWrite` function with argument `D7=HIGH` on the `board` device',
+			'$0 $command 0123456789abcdef01234567 brew --product 12345': 'Call the `brew` function on the device with id `0123456789abcdef01234567` within product `12345`'
 		}
 	});
 

--- a/src/cli/function.test.js
+++ b/src/cli/function.test.js
@@ -107,9 +107,9 @@ describe('Function Command-Line Interface', () => {
 					'  --product  Target a device within the given Product ID or Slug  [string]',
 					'',
 					'Examples:',
-					'  particle function call coffee brew                  Call the brew function on the coffee device',
-					'  particle function call board digitalWrite D7=HIGH   Call the digitalWrite function with argument D7=HIGH on the board device',
-					'  particle function call coffee brew --product 12345  Call the brew function on the coffee device within product 12345',
+					'  particle function call coffee brew                                    Call the `brew` function on the `coffee` device',
+					'  particle function call board digitalWrite D7=HIGH                     Call the `digitalWrite` function with argument `D7=HIGH` on the `board` device',
+					'  particle function call 0123456789abcdef01234567 brew --product 12345  Call the `brew` function on the device with id `0123456789abcdef01234567` within product `12345`',
 					''
 				].join(os.EOL));
 			});

--- a/src/cli/product.js
+++ b/src/cli/product.js
@@ -30,9 +30,9 @@ module.exports = ({ commandProcessor, root }) => {
 			}
 		},
 		examples: {
-			'$0 $command 12345': 'Lists devices in Product 12345',
-			'$0 $command 12345 5a8ef38cb85f8720edce631a': 'Get details for device 5a8ef38cb85f8720edce631a within in product 12345',
-			'$0 $command 12345 --groups foo bar': 'Lists devices in Product which are assigned the `foo` or `bar` groups'
+			'$0 $command 12345': 'Lists devices in product `12345`',
+			'$0 $command 12345 0123456789abcdef01234567': 'Get details for device with id `0123456789abcdef01234567` within in product `12345`',
+			'$0 $command 12345 --groups foo bar': 'Lists devices in product which are assigned the `foo` or `bar` groups'
 		},
 		handler: (args) => {
 			const ProdCmd = require('../cmd/product');
@@ -49,8 +49,8 @@ module.exports = ({ commandProcessor, root }) => {
 			}
 		},
 		examples: {
-			'$0 $command 12345 5a8ef38cb85f8720edce631a': 'Add device id 5a8ef38cb85f8720edce631a into product 12345',
-			'$0 $command 12345 --file ./path/to/device_ids.txt': 'Adds a list of devices into product 12345',
+			'$0 $command 12345 0123456789abcdef01234567': 'Add device id `0123456789abcdef01234567` into product `12345`',
+			'$0 $command 12345 --file ./path/to/device_ids.txt': 'Adds a list of devices into product `12345`',
 		},
 		handler: (args) => {
 			const ProdCmd = require('../cmd/product');

--- a/src/cli/product.test.js
+++ b/src/cli/product.test.js
@@ -91,9 +91,9 @@ describe('Product Command-Line Interface', () => {
 					'  --json        Output JSON formatted data (experimental)  [boolean]',
 					'',
 					'Examples:',
-					'  particle product device list 12345                           Lists devices in Product 12345',
-					'  particle product device list 12345 5a8ef38cb85f8720edce631a  Get details for device 5a8ef38cb85f8720edce631a within in product 12345',
-					'  particle product device list 12345 --groups foo bar          Lists devices in Product which are assigned the `foo` or `bar` groups',
+					'  particle product device list 12345                           Lists devices in product `12345`',
+					'  particle product device list 12345 0123456789abcdef01234567  Get details for device with id `0123456789abcdef01234567` within in product `12345`',
+					'  particle product device list 12345 --groups foo bar          Lists devices in product which are assigned the `foo` or `bar` groups',
 					''
 				].join(os.EOL));
 			});
@@ -128,8 +128,8 @@ describe('Product Command-Line Interface', () => {
 					'  --file, -f  Path to single column .txt file with list of IDs, S/Ns, IMEIs, or ICCIDs of the devices to add  [string]',
 					'',
 					'Examples:',
-					'  particle product device add 12345 5a8ef38cb85f8720edce631a         Add device id 5a8ef38cb85f8720edce631a into product 12345',
-					'  particle product device add 12345 --file ./path/to/device_ids.txt  Adds a list of devices into product 12345',
+					'  particle product device add 12345 0123456789abcdef01234567         Add device id `0123456789abcdef01234567` into product `12345`',
+					'  particle product device add 12345 --file ./path/to/device_ids.txt  Adds a list of devices into product `12345`',
 					''
 				].join(os.EOL));
 			});

--- a/src/cli/subscribe.js
+++ b/src/cli/subscribe.js
@@ -26,11 +26,12 @@ module.exports = ({ commandProcessor, root }) => {
 		},
 		examples: {
 			'$0 $command': 'Subscribe to all event published by my devices',
-			'$0 $command update': 'Subscribe to events starting with update from my devices',
-			'$0 $command --device x': 'Subscribe to all events published by device x',
+			'$0 $command update': 'Subscribe to events starting with `update` from my devices',
+			'$0 $command --product 12345': 'Subscribe to all events published by devices within product `12345`',
+			'$0 $command --device blue': 'Subscribe to all events published by device `blue`',
 			'$0 $command --all': 'Subscribe to public events and all events published by my devices',
-			'$0 $command --until x': 'Subscribe to all events and exit when an event has data matching x',
-			'$0 $command --max x': 'Subscribe to all events and exit after seeing x events'
+			'$0 $command --until data': 'Subscribe to all events and exit when an event has data matching `data`',
+			'$0 $command --max 4': 'Subscribe to all events and exit after seeing `4` events'
 		}
 	});
 };

--- a/src/cli/subscribe.test.js
+++ b/src/cli/subscribe.test.js
@@ -60,12 +60,13 @@ describe('Subscribe Command-Line Interface', () => {
 					'  --product  Target a device within the given Product ID or Slug  [string]',
 					'',
 					'Examples:',
-					'  particle subscribe             Subscribe to all event published by my devices',
-					'  particle subscribe update      Subscribe to events starting with update from my devices',
-					'  particle subscribe --device x  Subscribe to all events published by device x',
-					'  particle subscribe --all       Subscribe to public events and all events published by my devices',
-					'  particle subscribe --until x   Subscribe to all events and exit when an event has data matching x',
-					'  particle subscribe --max x     Subscribe to all events and exit after seeing x events',
+					'  particle subscribe                  Subscribe to all event published by my devices',
+					'  particle subscribe update           Subscribe to events starting with `update` from my devices',
+					'  particle subscribe --product 12345  Subscribe to all events published by devices within product `12345`',
+					'  particle subscribe --device blue    Subscribe to all events published by device `blue`',
+					'  particle subscribe --all            Subscribe to public events and all events published by my devices',
+					'  particle subscribe --until data     Subscribe to all events and exit when an event has data matching `data`',
+					'  particle subscribe --max 4          Subscribe to all events and exit after seeing `4` events',
 					''
 				].join(os.EOL));
 			});

--- a/src/cli/variable.js
+++ b/src/cli/variable.js
@@ -27,9 +27,9 @@ module.exports = ({ commandProcessor, root }) => {
 			return new VariableCommand().getValue(args);
 		},
 		examples: {
-			'$0 $command basement temperature': 'Read the temperature variable from the device basement',
-			'$0 $command basement temperature --product 12345': 'Read the temperature variable from the device basement within product 12345',
-			'$0 $command all temperature': 'Read the temperature variable from all my devices'
+			'$0 $command basement temperature': 'Read the `temperature` variable from the device `basement`',
+			'$0 $command 0123456789abcdef01234567 temperature --product 12345': 'Read the `temperature` variable from the device with id `0123456789abcdef01234567` within product `12345`',
+			'$0 $command all temperature': 'Read the `temperature` variable from all my devices'
 		}
 	});
 

--- a/src/cli/variable.test.js
+++ b/src/cli/variable.test.js
@@ -91,9 +91,9 @@ describe('Variable Command-Line Interface', () => {
 					'  --product  Target a device within the given Product ID or Slug  [string]',
 					'',
 					'Examples:',
-					'  particle variable get basement temperature                  Read the temperature variable from the device basement',
-					'  particle variable get basement temperature --product 12345  Read the temperature variable from the device basement within product 12345',
-					'  particle variable get all temperature                       Read the temperature variable from all my devices',
+					'  particle variable get basement temperature                                  Read the `temperature` variable from the device `basement`',
+					'  particle variable get 0123456789abcdef01234567 temperature --product 12345  Read the `temperature` variable from the device with id `0123456789abcdef01234567` within product `12345`',
+					'  particle variable get all temperature                                       Read the `temperature` variable from all my devices',
 					''
 				].join(os.EOL));
 			});

--- a/src/cmd/base.js
+++ b/src/cmd/base.js
@@ -1,0 +1,35 @@
+const { errors: { usageError } } = require('../app/command-processor');
+const spinnerMixin = require('../lib/spinner-mixin');
+const UI = require('../lib/ui');
+
+const DEVICE_ID_PTN = /^[0-9a-f]{24}$/i;
+
+
+module.exports = class CLICommandBase {
+	constructor({
+		stdin = process.stdin,
+		stdout = process.stdout,
+		stderr = process.stderr
+	} = {}) {
+		this.stdin = stdin;
+		this.stdout = stdout;
+		this.stderr = stderr;
+		this.ui = new UI({ stdin, stdout, stderr });
+		spinnerMixin(this);
+	}
+
+	isDeviceId(x){
+		return DEVICE_ID_PTN.test(x);
+	}
+
+	showUsageError(msg){
+		return Promise.reject(usageError(msg));
+	}
+
+	showProductDeviceNameUsageError(device){
+		return this.showUsageError(
+			`\`device\` must be an id when \`--product\` flag is set - received: ${device}`
+		);
+	}
+};
+

--- a/src/cmd/base.test.js
+++ b/src/cmd/base.test.js
@@ -31,7 +31,7 @@ describe('CLI Command Base Class', () => {
 		expect(cmd.isDeviceId('0123456789ABCDEF01234567')).to.equal(true);
 	});
 
-	it('Show a usage error', async () => {
+	it('Shows a usage error', async () => {
 		const promise = cmd.showUsageError('test');
 
 		expect(promise).to.be.an.instanceof(Promise);
@@ -48,7 +48,7 @@ describe('CLI Command Base Class', () => {
 		expect(error).to.have.property('message', 'test');
 	});
 
-	it('Show a product device name usage error', async () => {
+	it('Shows a product device name usage error', async () => {
 		const promise = cmd.showProductDeviceNameUsageError('my-device-name');
 
 		expect(promise).to.be.an.instanceof(Promise);

--- a/src/cmd/base.test.js
+++ b/src/cmd/base.test.js
@@ -1,0 +1,68 @@
+const { expect } = require('../../test/setup');
+const CLICommandBase = require('./base');
+const UI = require('../lib/ui');
+
+
+describe('CLI Command Base Class', () => {
+	let cmd;
+
+	beforeEach(() => {
+		cmd = new CLICommandBase();
+	});
+
+	it('Initializes', () => {
+		expect(cmd).to.have.property('stdin', process.stdin);
+		expect(cmd).to.have.property('stdout', process.stdout);
+		expect(cmd).to.have.property('stderr', process.stderr);
+		expect(cmd).to.have.property('ui').that.is.an.instanceof(UI);
+		expect(cmd).to.respondTo('showUsageError');
+		expect(cmd).to.respondTo('isDeviceId');
+	});
+
+	it('Determines if input is a device id', () => {
+		expect(cmd.isDeviceId(null)).to.equal(false);
+		expect(cmd.isDeviceId(undefined)).to.equal(false);
+		expect(cmd.isDeviceId('')).to.equal(false);
+		expect(cmd.isDeviceId(666)).to.equal(false);
+		expect(cmd.isDeviceId('nope')).to.equal(false);
+		expect(cmd.isDeviceId(123456789123456789123456)).to.equal(false);
+		expect(cmd.isDeviceId('0123456789abcdef0123456')).to.equal(false);
+		expect(cmd.isDeviceId('0123456789abcdef01234567')).to.equal(true);
+		expect(cmd.isDeviceId('0123456789ABCDEF01234567')).to.equal(true);
+	});
+
+	it('Show a usage error', async () => {
+		const promise = cmd.showUsageError('test');
+
+		expect(promise).to.be.an.instanceof(Promise);
+
+		let error;
+
+		try {
+			await promise;
+		} catch (e){
+			error = e;
+		}
+
+		expect(error).to.be.an.instanceof(Error);
+		expect(error).to.have.property('message', 'test');
+	});
+
+	it('Show a product device name usage error', async () => {
+		const promise = cmd.showProductDeviceNameUsageError('my-device-name');
+
+		expect(promise).to.be.an.instanceof(Promise);
+
+		let error;
+
+		try {
+			await promise;
+		} catch (e){
+			error = e;
+		}
+
+		expect(error).to.be.an.instanceof(Error);
+		expect(error).to.have.property('message', '`device` must be an id when `--product` flag is set - received: my-device-name');
+	});
+});
+

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -8,11 +8,10 @@ const specs = require('../lib/deviceSpecs');
 const ApiClient = require('../lib/api-client'); // TODO (mirande): remove in favor of `ParticleAPI`
 const { normalizedApiError } = require('../lib/api-client');
 const utilities = require('../lib/utilities');
-const spinnerMixin = require('../lib/spinner-mixin');
 const ensureError = require('../lib/utilities').ensureError;
 const ParticleAPI = require('./api');
-const UI = require('../lib/ui');
 const prompts = require('../lib/prompts');
+const CLICommandBase = require('./base');
 
 const fs = require('fs-extra');
 const path = require('path');
@@ -44,17 +43,9 @@ const PLATFORMS = extend(utilities.knownPlatforms(), {
 });
 
 
-module.exports = class CloudCommand {
-	constructor({
-		stdin = process.stdin,
-		stdout = process.stdout,
-		stderr = process.stderr
-	} = {}){
-		this.stdin = stdin;
-		this.stdout = stdout;
-		this.stderr = stderr;
-		this.ui = new UI({ stdin, stdout, stderr });
-		spinnerMixin(this);
+module.exports = class CloudCommand extends CLICommandBase {
+	constructor(...args){
+		super(...args);
 	}
 
 	listDevices({ params: { filter } }){
@@ -152,6 +143,12 @@ module.exports = class CloudCommand {
 	}
 
 	flashDevice({ target, followSymlinks, product, params: { device, files } }){
+		if (product){
+			if (!this.isDeviceId(device)){
+				return this.showProductDeviceNameUsageError(device);
+			}
+		}
+
 		return Promise.resolve()
 			.then(() => {
 				if (files.length === 0){
@@ -605,6 +602,12 @@ module.exports = class CloudCommand {
 	}
 
 	nyanMode({ product, params: { device, onOff } }){
+		if (product){
+			if (!this.isDeviceId(device)){
+				return this.showProductDeviceNameUsageError(device);
+			}
+		}
+
 		const api = createAPI();
 
 		if (!onOff || (onOff === '') || (onOff === 'on')){

--- a/src/cmd/function.js
+++ b/src/cmd/function.js
@@ -2,24 +2,15 @@ const os = require('os');
 const VError = require('verror');
 const ParticleAPI = require('./api');
 const LegacyApiClient = require('../lib/api-client');
-const spinnerMixin = require('../lib/spinner-mixin');
 const settings = require('../../settings');
-const UI = require('../lib/ui');
+const CLICommandBase = require('./base');
 
 const { normalizedApiError } = LegacyApiClient;
 
 
-module.exports = class FunctionCommand {
-	constructor({
-		stdin = process.stdin,
-		stdout = process.stdout,
-		stderr = process.stderr
-	} = {}){
-		this.stdin = stdin;
-		this.stdout = stdout;
-		this.stderr = stderr;
-		this.ui = new UI({ stdin, stdout, stderr });
-		spinnerMixin(this);
+module.exports = class FunctionCommand extends CLICommandBase {
+	constructor(...args){
+		super(...args);
 	}
 
 	listFunctions(){
@@ -34,6 +25,12 @@ module.exports = class FunctionCommand {
 	}
 
 	callFunction({ product, params: { device, function: fn, argument: arg } }){
+		if (product){
+			if (!this.isDeviceId(device)){
+				return this.showProductDeviceNameUsageError(device);
+			}
+		}
+
 		let msg = `Calling function ${fn} from device ${device}`;
 
 		if (product){

--- a/src/cmd/product.js
+++ b/src/cmd/product.js
@@ -5,22 +5,13 @@ const settings = require('../../settings');
 const { errors: { usageError } } = require('../app/command-processor');
 const ParticleAPI = require('./api');
 const { normalizedApiError } = require('../lib/api-client');
-const spinnerMixin = require('../lib/spinner-mixin');
 const { JSONResult } = require('../lib/json-result');
-const UI = require('../lib/ui');
+const CLICommandBase = require('./base');
 
 
-module.exports = class ProductCommand {
-	constructor({
-		stdin = process.stdin,
-		stdout = process.stdout,
-		stderr = process.stderr
-	} = {}) {
-		this.stdin = stdin;
-		this.stdout = stdout;
-		this.stderr = stderr;
-		this.ui = new UI({ stdin, stdout, stderr });
-		spinnerMixin(this);
+module.exports = class ProductCommand extends CLICommandBase {
+	constructor(...args){
+		super(...args);
 	}
 
 	addDevice({ params: { product, device } }){
@@ -39,6 +30,9 @@ module.exports = class ProductCommand {
 		}
 
 		if (device){
+			if (!this.isDeviceId(device)){
+				return this.showUsageError(`\`device\` parameter must be an id - received: ${device}`);
+			}
 			return this.addDevice({ params: { product, device } });
 		}
 

--- a/src/cmd/publish.js
+++ b/src/cmd/publish.js
@@ -1,23 +1,14 @@
 const os = require('os');
 const VError = require('verror');
 const settings = require('../../settings');
-const spinnerMixin = require('../lib/spinner-mixin');
 const { normalizedApiError } = require('../lib/api-client');
 const ParticleAPI = require('./api');
-const UI = require('../lib/ui');
+const CLICommandBase = require('./base');
 
 
-module.exports = class PublishCommand {
-	constructor({
-		stdin = process.stdin,
-		stdout = process.stdout,
-		stderr = process.stderr
-	} = {}){
-		this.stdin = stdin;
-		this.stdout = stdout;
-		this.stderr = stderr;
-		this.ui = new UI({ stdin, stdout, stderr });
-		spinnerMixin(this);
+module.exports = class PublishCommand extends CLICommandBase {
+	constructor(...args){
+		super(...args);
 	}
 
 	publishEvent({ private: isPrivate, public: isPublic, product, params: { event, data } }){

--- a/src/cmd/subscribe.js
+++ b/src/cmd/subscribe.js
@@ -1,31 +1,27 @@
 const os = require('os');
 const VError = require('verror');
 const settings = require('../../settings');
-const spinnerMixin = require('../lib/spinner-mixin');
 const { normalizedApiError } = require('../lib/api-client');
-const { errors: { usageError } } = require('../app/command-processor');
+const CLICommandBase = require('./base');
 const ParticleAPI = require('./api');
-const UI = require('../lib/ui');
 
 
-module.exports = class SubscribeCommand {
-	constructor({
-		stdin = process.stdin,
-		stdout = process.stdout,
-		stderr = process.stderr
-	} = {}){
-		this.stdin = stdin;
-		this.stdout = stdout;
-		this.stderr = stderr;
-		this.ui = new UI({ stdin, stdout, stderr });
-		spinnerMixin(this);
+module.exports = class SubscribeCommand extends CLICommandBase {
+	constructor(...args){
+		super(...args);
 	}
 
 	startListening({ device, all, until, max, product, params: { event } }){
 		if (all && !event){
-			throw usageError(
+			return this.showUsageError(
 				'`event` parameter is required when `--all` flag is set'
 			);
+		}
+
+		if (product && device){
+			if (!this.isDeviceId(device)){
+				return this.showProductDeviceNameUsageError(device);
+			}
 		}
 
 		const msg = ['Subscribing to'];

--- a/src/cmd/variable.js
+++ b/src/cmd/variable.js
@@ -7,26 +7,16 @@ const find = require('lodash/find');
 const filter = require('lodash/filter');
 const prompt = require('inquirer').prompt;
 const settings = require('../../settings');
-const { errors: { usageError } } = require('../app/command-processor');
-const spinnerMixin = require('../lib/spinner-mixin');
 const LegacyApiClient = require('../lib/api-client');
 const ParticleAPI = require('./api');
-const UI = require('../lib/ui');
+const CLICommandBase = require('./base');
 
 const { normalizedApiError } = LegacyApiClient;
 
 
-module.exports = class VariableCommand {
-	constructor({
-		stdin = process.stdin,
-		stdout = process.stdout,
-		stderr = process.stderr
-	} = {}) {
-		this.stdin = stdin;
-		this.stdout = stdout;
-		this.stderr = stderr;
-		this.ui = new UI({ stdin, stdout, stderr });
-		spinnerMixin(this);
+module.exports = class VariableCommand extends CLICommandBase {
+	constructor(...args){
+		super(...args);
 	}
 
 	listVariables(){
@@ -40,13 +30,13 @@ module.exports = class VariableCommand {
 	getValue({ time, product, params: { device, variableName } }){
 		if (product){
 			if (!device){
-				throw usageError(
+				return this.showUsageError(
 					'`device` parameter is required when `--product` flag is set'
 				);
 			}
 
 			if (!variableName){
-				throw usageError(
+				return this.showUsageError(
 					`\`variableName\` parameter is required when \`--product\` flag is set. To view available variables, run: particle product device list ${product}`
 				);
 			}

--- a/src/cmd/variable.js
+++ b/src/cmd/variable.js
@@ -33,6 +33,8 @@ module.exports = class VariableCommand extends CLICommandBase {
 				return this.showUsageError(
 					'`device` parameter is required when `--product` flag is set'
 				);
+			} else if (!this.isDeviceId(device)){
+				return this.showProductDeviceNameUsageError(device);
 			}
 
 			if (!variableName){
@@ -98,7 +100,7 @@ module.exports = class VariableCommand extends CLICommandBase {
 					const result = results[i];
 
 					if (result.error){
-						console.log('Error:', result.error);
+						this.ui.stdout.write(`Error: ${result.error}${os.EOL}`);
 						hasErrors = true;
 						continue;
 					}
@@ -112,7 +114,7 @@ module.exports = class VariableCommand extends CLICommandBase {
 					}
 
 					parts.push(result.result);
-					console.log(parts.join(', '));
+					this.ui.stdout.write(`${parts.join(', ')}${os.EOL}`);
 				}
 
 				if (hasErrors){
@@ -138,9 +140,9 @@ module.exports = class VariableCommand extends CLICommandBase {
 			.then(({ deviceIds, variableName }) => {
 				if (delay < settings.minimumApiDelay){
 					delay = settings.minimumApiDelay;
-					console.error(`Delay was too short, resetting to ${settings.minimumApiDelay}ms`);
+					this.ui.stderr.write(`Delay was too short, resetting to ${settings.minimumApiDelay}ms${os.EOL}`);
 				}
-				console.error('Hit CTRL-C to stop!');
+				this.ui.stderr.write(`Hit CTRL-C to stop!${os.EOL}`);
 				return this._pollForVariable(deviceIds, variableName, { delay, time });
 			})
 			.catch(err => {
@@ -215,7 +217,7 @@ module.exports = class VariableCommand extends CLICommandBase {
 			return Promise.resolve(this._cachedVariableList);
 		}
 
-		console.error('polling server to see what devices are online, and what variables are available');
+		this.ui.stderr.write(`polling server to see what devices are online, and what variables are available${os.EOL}`);
 
 		const api = new LegacyApiClient();
 		api.ensureToken();
@@ -224,7 +226,7 @@ module.exports = class VariableCommand extends CLICommandBase {
 			.then(() => api.listDevices())
 			.then(devices => {
 				if (!devices || (devices.length === 0)){
-					console.log('No devices found.');
+					this.ui.stderr.write(`No devices found.${os.EOL}`);
 					this._cachedVariableList = null;
 				} else {
 					const promises = [];

--- a/test/e2e/call.e2e.js
+++ b/test/e2e/call.e2e.js
@@ -18,9 +18,9 @@ describe('Call Commands [@device]', () => {
 		'  --product  Target a device within the given Product ID or Slug  [string]',
 		'',
 		'Examples:',
-		'  particle call coffee brew                  Call the brew function on the coffee device',
-		'  particle call board digitalWrite D7=HIGH   Call the digitalWrite function with argument D7=HIGH on the board device',
-		'  particle call coffee brew --product 12345  Call the brew function on the coffee device within product 12345'
+		'  particle call coffee brew                                    Call the `brew` function on the `coffee` device',
+		'  particle call board digitalWrite D7=HIGH                     Call the `digitalWrite` function with argument `D7=HIGH` on the `board` device',
+		'  particle call 0123456789abcdef01234567 brew --product 12345  Call the `brew` function on the device with id `0123456789abcdef01234567` within product `12345`',
 	];
 
 	before(async () => {

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const path = require('path');
 const capitalize = require('lodash/capitalize');
 const { expect } = require('../setup');
@@ -85,292 +86,352 @@ describe('Cloud Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Lists devices', async () => {
-		const args = ['cloud', 'list'];
-		const platform = capitalize(DEVICE_PLATFORM_NAME);
-		const { stdout, stderr, exitCode } = await cli.run(args);
+	describe('Cloud List Subcommand', () => {
+		it('Lists devices', async () => {
+			const args = ['cloud', 'list'];
+			const platform = capitalize(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Compiles firmware', async () => {
-		const args = ['cloud', 'compile', 'photon', PATH_PROJ_STROBY_INO, '--saveTo', strobyBinPath];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			'Compiling code for photon',
+	describe('Cloud Compile Subcommand', () => {
+		it('Compiles firmware', async () => {
+			const args = ['cloud', 'compile', 'photon', PATH_PROJ_STROBY_INO, '--saveTo', strobyBinPath];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				'Compiling code for photon',
+				'',
+				'Including:',
+				`    ${PATH_PROJ_STROBY_INO}`,
+				'attempting to compile firmware',
+				'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
+				`saving to: ${strobyBinPath}`,
+				'Memory use:',
+				'', // don't assert against memory stats since they may change based on current default Device OS version
+				'Compile succeeded.',
+				`Saved firmware to: ${strobyBinPath}`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Compiles a project with symlinks to parent/other file locations', async () => {
+			const name = 'symlinks';
+			const platform = 'photon';
+			const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
+			const destination = path.join(PATH_TMP_DIR, `${name}-${platform}.bin`);
+			const args = ['cloud', 'compile', platform, '--saveTo', destination, '--followSymlinks'];
+			const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
+			const log = [
+				`Compiling code for ${platform}`,
+				'Including:',
+				'    shared/sub_dir/helper.h',
+				'    app.ino',
+				'    shared/sub_dir/helper.cpp',
+				'    project.properties',
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+	});
+
+	describe('Cloud Flash Subcommand', () => {
+		const help = [
+			'Pass a binary, source file, or source directory to a device!',
+			'Usage: particle cloud flash [options] <device> [files...]',
 			'',
-			'Including:',
-			`    ${PATH_PROJ_STROBY_INO}`,
-			'attempting to compile firmware',
-			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
-			`saving to: ${strobyBinPath}`,
-			'Memory use:',
-			'', // don't assert against memory stats since they may change based on current default Device OS version
-			'Compile succeeded.',
-			`Saved firmware to: ${strobyBinPath}`
+			'Global Options:',
+			'  -v, --verbose  Increases how much logging to display  [count]',
+			'  -q, --quiet    Decreases how much logging to display  [count]',
+			'',
+			'Options:',
+			'  --target          The firmware version to compile against. Defaults to latest version, or version on device for cellular.  [string]',
+			'  --followSymlinks  Follow symlinks when collecting files  [boolean]',
+			'  --product         Target a device within the given Product ID or Slug  [string]',
+			'',
+			'Examples:',
+			'  particle cloud flash blue                                      Compile the source code in the current directory in the cloud and flash to device `blue`',
+			'  particle cloud flash green tinker                              Flash the default `tinker` app to device `green`',
+			'  particle cloud flash red blink.ino                             Compile `blink.ino` in the cloud and flash to device `red`',
+			'  particle cloud flash orange firmware.bin                       Flash a pre-compiled `firmware.bin` binary to device `orange`',
+			'  particle cloud flash 0123456789abcdef01234567 --product 12345  Compile the source code in the current directory in the cloud and flash to device `0123456789abcdef01234567` within product `12345`',
 		];
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+		it('Flashes firmware', async () => {
+			const args = ['cloud', 'flash', DEVICE_NAME, PATH_PROJ_STROBY_INO];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				'Including:',
+				`    ${PATH_PROJ_STROBY_INO}`,
+				`attempting to flash firmware to your device ${DEVICE_NAME}`,
+				'Flash device OK: Update started'
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+
+			await cli.waitForVariable('name', 'stroby');
+		});
+
+		it('Flashes a project with symlinks to parent/other file locations', async () => {
+			const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
+			const args = ['cloud', 'flash', DEVICE_NAME, '--followSymlinks'];
+			const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
+			const log = [
+				'Including:',
+				'    shared/sub_dir/helper.h',
+				'    app.ino',
+				'    shared/sub_dir/helper.cpp',
+				'    project.properties',
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+
+			await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForDeviceToGetOnline()` helper
+		});
+
+		it('Flashes a product device', async () => {
+			const args = ['cloud', 'flash', PRODUCT_01_DEVICE_01_ID, PATH_PROJ_BLANK_INO, '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				'Including:',
+				`    ${PATH_PROJ_BLANK_INO}`,
+				`marking device ${PRODUCT_01_DEVICE_01_ID} as a development device`,
+				`attempting to flash firmware to your device ${PRODUCT_01_DEVICE_01_ID}`,
+				'Flash device OK: Update started',
+				`device ${PRODUCT_01_DEVICE_01_ID} is now marked as a developement device and will NOT receive automatic product firmware updates.`,
+				'to resume normal updates, please visit:',
+				`https://console.particle.io/${PRODUCT_01_ID}/devices/unmark-development/${PRODUCT_01_DEVICE_01_ID}`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+
+			await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductVariable()` helper
+		});
+
+		it('Flashes a `known app` on to a product device', async () => {
+			const args = ['cloud', 'flash', PRODUCT_01_DEVICE_01_ID, 'tinker', '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`marking device ${PRODUCT_01_DEVICE_01_ID} as a development device`,
+				`attempting to flash firmware to your device ${PRODUCT_01_DEVICE_01_ID}`,
+				'Flash device OK: Update started',
+				`device ${PRODUCT_01_DEVICE_01_ID} is now marked as a developement device and will NOT receive automatic product firmware updates.`,
+				'to resume normal updates, please visit:',
+				`https://console.particle.io/${PRODUCT_01_ID}/devices/unmark-development/${PRODUCT_01_DEVICE_01_ID}`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+
+			await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductFunction()` helper
+		});
+
+		it('Fails to flash a product device when `device` param is not an id', async () => {
+			const args = ['cloud', 'flash', PRODUCT_01_DEVICE_01_NAME, PATH_PROJ_BLANK_INO, '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.include(`\`device\` must be an id when \`--product\` flag is set - received: ${PRODUCT_01_DEVICE_01_NAME}`);
+			expect(stderr.split(os.EOL)).to.include.members(help);
+			expect(exitCode).to.equal(1);
+		});
 	});
 
-	it('Compiles a project with symlinks to parent/other file locations', async () => {
-		const name = 'symlinks';
-		const platform = 'photon';
-		const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
-		const destination = path.join(PATH_TMP_DIR, `${name}-${platform}.bin`);
-		const args = ['cloud', 'compile', platform, '--saveTo', destination, '--followSymlinks'];
-		const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
-		const log = [
-			`Compiling code for ${platform}`,
-			'Including:',
-			'    shared/sub_dir/helper.h',
-			'    app.ino',
-			'    shared/sub_dir/helper.cpp',
-			'    project.properties',
+	describe('Cloud Remove Subcommand', () => {
+		it('Removes device', async () => {
+			const args = ['cloud', 'remove', DEVICE_NAME, '--yes'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`releasing device ${DEVICE_NAME}`,
+				'Okay!'
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+	});
+
+	describe('Cloud Claim Subcommand', () => {
+		it('Claims device', async () => {
+			const id = DEVICE_ID.toLowerCase();
+			const args = ['cloud', 'claim', id];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Claiming device ${id}`,
+				`Successfully claimed device ${id}`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Claims device when device id is capitalized', async () => {
+			const id = DEVICE_ID.toUpperCase();
+			const args = ['cloud', 'claim', id];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Claiming device ${id}`,
+				`Successfully claimed device ${id}`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Fails to claim an unknown device', async () => {
+			const invalidDeviceID = '1234567890';
+			const args = ['cloud', 'claim', invalidDeviceID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Claiming device ${invalidDeviceID}`,
+				'Failed to claim device: device not found'
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
+
+		it('Fails to claim a device owned by someone else', async () => {
+			const args = ['cloud', 'claim', FOREIGN_DEVICE_ID];
+			const subprocess = cli.run(args);
+
+			await delay(1000);
+			subprocess.stdin.write('n');
+			subprocess.stdin.write('\n');
+
+			const { all, exitCode } = await subprocess;
+			const log = stripANSI(all);
+
+			expect(log).to.include(`Claiming device ${FOREIGN_DEVICE_ID}`);
+			expect(log).to.include('That device belongs to someone else. Would you like to request a transfer?');
+			expect(log).to.include('Failed to claim device: You cannot claim a device owned by someone else');
+			expect(exitCode).to.equal(1);
+		});
+	});
+
+	describe('Cloud Name Subcommand', () => {
+		it('Names a device', async () => {
+			const name = `${DEVICE_NAME}-updated`;
+			const args = ['cloud', 'name', DEVICE_ID, name];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Renaming device ${DEVICE_ID}`,
+				`Successfully renamed device ${DEVICE_ID} to: ${name}`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Fails to name an unknown device', async () => {
+			const invalidDeviceID = '1234567890';
+			const args = ['cloud', 'name', invalidDeviceID, 'NOPE'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Renaming device ${invalidDeviceID}`,
+				`Failed to rename ${invalidDeviceID}: Permission Denied`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
+
+		it('Fails to name a device owned by someone else', async () => {
+			const args = ['cloud', 'name', FOREIGN_DEVICE_ID, 'NOPE'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Renaming device ${FOREIGN_DEVICE_ID}`,
+				`Failed to rename ${FOREIGN_DEVICE_ID}: Permission Denied`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
+	});
+
+	describe('Cloud Nyan Subcommand', () => {
+		const help = [
+			'Make your device shout rainbows',
+			'Usage: particle cloud nyan [options] <device> [onOff]',
+			'',
+			'Global Options:',
+			'  -v, --verbose  Increases how much logging to display  [count]',
+			'  -q, --quiet    Decreases how much logging to display  [count]',
+			'',
+			'Options:',
+			'  --product  Target a device within the given Product ID or Slug  [string]',
+			'',
+			'Examples:',
+			'  particle cloud nyan green                 Make the device named `blue` start signaling',
+			'  particle cloud nyan green off             Make the device named `blue` stop signaling',
+			'  particle cloud nyan blue --product 12345  Make the device named `blue` within product `12345` start signaling',
 		];
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
+		it('Starts a device signaling', async () => {
+			const args = ['cloud', 'nyan', DEVICE_NAME];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-	it('Flashes firmware', async () => {
-		const args = ['cloud', 'flash', DEVICE_NAME, PATH_PROJ_STROBY_INO];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			'Including:',
-			`    ${PATH_PROJ_STROBY_INO}`,
-			`attempting to flash firmware to your device ${DEVICE_NAME}`,
-			'Flash device OK: Update started'
-		];
+			expect(stdout).to.equal('');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+		it('Stops a device signaling', async () => {
+			const args = ['cloud', 'nyan', DEVICE_NAME, 'off'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		await cli.waitForVariable('name', 'stroby');
-	});
+			expect(stdout).to.equal('');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 
-	it('Flashes a project with symlinks to parent/other file locations', async () => {
-		const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
-		const args = ['cloud', 'flash', DEVICE_NAME, '--followSymlinks'];
-		const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
-		const log = [
-			'Including:',
-			'    shared/sub_dir/helper.h',
-			'    app.ino',
-			'    shared/sub_dir/helper.cpp',
-			'    project.properties',
-		];
+		it('Starts a product device signaling', async () => {
+			const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_ID, '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.equal('');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 
-		await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForDeviceToGetOnline()` helper
-	});
+		it('Stops a product device signaling', async () => {
+			const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_ID, 'off', '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-	it('Flashes a product device', async () => {
-		const args = ['cloud', 'flash', PRODUCT_01_DEVICE_01_ID, PATH_PROJ_BLANK_INO, '--product', PRODUCT_01_ID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			'Including:',
-			`    ${PATH_PROJ_BLANK_INO}`,
-			`marking device ${PRODUCT_01_DEVICE_01_ID} as a development device`,
-			`attempting to flash firmware to your device ${PRODUCT_01_DEVICE_01_ID}`,
-			'Flash device OK: Update started',
-			`device ${PRODUCT_01_DEVICE_01_ID} is now marked as a developement device and will NOT receive automatic product firmware updates.`,
-			'to resume normal updates, please visit:',
-			`https://console.particle.io/${PRODUCT_01_ID}/devices/unmark-development/${PRODUCT_01_DEVICE_01_ID}`
-		];
+			expect(stdout).to.equal('');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+		it('Fails to start a product device signaling when `device` param is not an id', async () => {
+			const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_NAME, '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductVariable()` helper
-	});
-
-	it('Flashes a `known app` on to a product device', async () => {
-		const args = ['cloud', 'flash', PRODUCT_01_DEVICE_01_ID, 'tinker', '--product', PRODUCT_01_ID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`marking device ${PRODUCT_01_DEVICE_01_ID} as a development device`,
-			`attempting to flash firmware to your device ${PRODUCT_01_DEVICE_01_ID}`,
-			'Flash device OK: Update started',
-			`device ${PRODUCT_01_DEVICE_01_ID} is now marked as a developement device and will NOT receive automatic product firmware updates.`,
-			'to resume normal updates, please visit:',
-			`https://console.particle.io/${PRODUCT_01_ID}/devices/unmark-development/${PRODUCT_01_DEVICE_01_ID}`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-
-		await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductFunction()` helper
-	});
-
-	it('Removes device', async () => {
-		const args = ['cloud', 'remove', DEVICE_NAME, '--yes'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`releasing device ${DEVICE_NAME}`,
-			'Okay!'
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Claims device', async () => {
-		const id = DEVICE_ID.toLowerCase();
-		const args = ['cloud', 'claim', id];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Claiming device ${id}`,
-			`Successfully claimed device ${id}`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Claims device when device id is capitalized', async () => {
-		const id = DEVICE_ID.toUpperCase();
-		const args = ['cloud', 'claim', id];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Claiming device ${id}`,
-			`Successfully claimed device ${id}`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Fails to claim an unknown device', async () => {
-		const invalidDeviceID = '1234567890';
-		const args = ['cloud', 'claim', invalidDeviceID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Claiming device ${invalidDeviceID}`,
-			'Failed to claim device: device not found'
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
-	});
-
-	it('Fails to claim a device owned by someone else', async () => {
-		const args = ['cloud', 'claim', FOREIGN_DEVICE_ID];
-		const subprocess = cli.run(args);
-
-		await delay(1000);
-		subprocess.stdin.write('n');
-		subprocess.stdin.write('\n');
-
-		const { all, exitCode } = await subprocess;
-		const log = stripANSI(all);
-
-		expect(log).to.include(`Claiming device ${FOREIGN_DEVICE_ID}`);
-		expect(log).to.include('That device belongs to someone else. Would you like to request a transfer?');
-		expect(log).to.include('Failed to claim device: You cannot claim a device owned by someone else');
-		expect(exitCode).to.equal(1);
-	});
-
-	it('Names a device', async () => {
-		const name = `${DEVICE_NAME}-updated`;
-		const args = ['cloud', 'name', DEVICE_ID, name];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Renaming device ${DEVICE_ID}`,
-			`Successfully renamed device ${DEVICE_ID} to: ${name}`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Fails to name an unknown device', async () => {
-		const invalidDeviceID = '1234567890';
-		const args = ['cloud', 'name', invalidDeviceID, 'NOPE'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Renaming device ${invalidDeviceID}`,
-			`Failed to rename ${invalidDeviceID}: Permission Denied`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
-	});
-
-	it('Fails to name a device owned by someone else', async () => {
-		const args = ['cloud', 'name', FOREIGN_DEVICE_ID, 'NOPE'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Renaming device ${FOREIGN_DEVICE_ID}`,
-			`Failed to rename ${FOREIGN_DEVICE_ID}: Permission Denied`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
-	});
-
-	it('Starts a device signaling', async () => {
-		const args = ['cloud', 'nyan', DEVICE_NAME];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Stops a device signaling', async () => {
-		const args = ['cloud', 'nyan', DEVICE_NAME, 'off'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Starts a product device signaling', async () => {
-		const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_ID, '--product', PRODUCT_01_ID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Stops a product device signaling', async () => {
-		const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_ID, 'off', '--product', PRODUCT_01_ID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	// TODO (mirande): seems like a bug..?
-	it('Fails to start a product device signaling when called with device name', async () => {
-		const args = ['cloud', 'nyan', PRODUCT_01_DEVICE_01_NAME, '--product', PRODUCT_01_ID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('Signaling failed: Device not found.');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
+			expect(stdout).to.include(`\`device\` must be an id when \`--product\` flag is set - received: ${PRODUCT_01_DEVICE_01_NAME}`);
+			expect(stderr.split(os.EOL)).to.include.members(help);
+			expect(exitCode).to.equal(1);
+		});
 	});
 });
 

--- a/test/e2e/compile.e2e.js
+++ b/test/e2e/compile.e2e.js
@@ -27,10 +27,10 @@ describe('Compile Commands', () => {
 		'  --saveTo          Filename for the compiled binary  [string]',
 		'',
 		'Examples:',
-		'  particle compile photon                                  Compile the source code in the current directory in the cloud for a Photon',
-		'  particle compile electron project --saveTo electron.bin  Compile the source code in the project directory in the cloud for a Electron and save it to electron.bin',
+		'  particle compile photon                                  Compile the source code in the current directory in the cloud for a `photon`',
+		'  particle compile electron project --saveTo electron.bin  Compile the source code in the project directory in the cloud for an `electron` and save it to a file named `electron.bin`',
 		'',
-		'Param deviceType can be: core, photon, p1, electron, argon, asom, boron, bsom, xenon, xsom, etc'
+		'Param deviceType can be: core, photon, p1, electron, argon, asom, boron, bsom, xenon, xsom, etc',
 	];
 
 	before(async () => {

--- a/test/e2e/function.e2e.js
+++ b/test/e2e/function.e2e.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const capitalize = require('lodash/capitalize');
 const { expect } = require('../setup');
 const cli = require('../lib/cli');
@@ -7,12 +8,11 @@ const {
 	DEVICE_PLATFORM_NAME,
 	PRODUCT_01_ID,
 	PRODUCT_01_DEVICE_02_ID,
-	PRODUCT_01_DEVICE_01_NAME
+	PRODUCT_01_DEVICE_02_NAME
 } = require('../lib/env');
 
 
 describe('Function Commands [@device]', () => {
-	const fn = 'check';
 	const help = [
 		'Call functions on your device',
 		'Usage: particle function <command>',
@@ -61,74 +61,95 @@ describe('Function Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Lists available functions', async () => {
-		const platform = capitalize(DEVICE_PLATFORM_NAME);
-		const { stdout, stderr, exitCode } = await cli.run(['function', 'list']);
+	describe('Function List Subcommand', () => {
+		it('Lists available functions', async () => {
+			const platform = capitalize(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(['function', 'list']);
 
-		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-		expect(stdout).to.include('int toggle (String args)');
-		expect(stdout).to.include('int check (String args)');
-		expect(stderr).to.include('polling server to see what devices are online, and what functions are available');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stdout).to.include('int toggle (String args)');
+			expect(stdout).to.include('int check (String args)');
+			expect(stderr).to.include('polling server to see what devices are online, and what functions are available');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Calls a function', async () => {
-		const args = ['function', 'call', DEVICE_NAME, fn];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+	describe('Function Call Subcommand', () => {
+		const fn = 'check';
+		const help = [
+			'Call a particular function on a device',
+			'Usage: particle function call [options] <device> <function> [argument]',
+			'',
+			'Global Options:',
+			'  -v, --verbose  Increases how much logging to display  [count]',
+			'  -q, --quiet    Decreases how much logging to display  [count]',
+			'',
+			'Options:',
+			'  --product  Target a device within the given Product ID or Slug  [string]',
+			'',
+			'Examples:',
+			'  particle function call coffee brew                                    Call the `brew` function on the `coffee` device',
+			'  particle function call board digitalWrite D7=HIGH                     Call the `digitalWrite` function with argument `D7=HIGH` on the `board` device',
+			'  particle function call 0123456789abcdef01234567 brew --product 12345  Call the `brew` function on the device with id `0123456789abcdef01234567` within product `12345`',
+		];
 
-		expect(stdout.slice(-3)).to.equal('200');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
+		it('Calls a function', async () => {
+			const args = ['function', 'call', DEVICE_NAME, fn];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-	it('Calls a function', async () => {
-		const args = ['function', 'call', DEVICE_NAME, fn];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+			expect(stdout.slice(-3)).to.equal('200');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 
-		expect(stdout.slice(-3)).to.equal('200');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
+		it('Calls a function', async () => {
+			const args = ['function', 'call', DEVICE_NAME, fn];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-	// TODO (mirande): need to ensure device is running expected firmware and online
-	// once flashing product devices is implemented - as it is, the expectation
-	// is that your product device is running the `stroby` firmware found in:
-	// test/__fixtures__/projects/stroby - see: cli.flashStrobyFirmwareOTAForTest()
-	it('Calls a function on a product device', async () => {
-		const args = ['function', 'call', PRODUCT_01_DEVICE_02_ID, fn, '--product', PRODUCT_01_ID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+			expect(stdout.slice(-3)).to.equal('200');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 
-		expect(stdout.slice(-3)).to.equal('200');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
+		// TODO (mirande): need to ensure device is running expected firmware and online
+		// once flashing product devices is implemented - as it is, the expectation
+		// is that your product device is running the `stroby` firmware found in:
+		// test/__fixtures__/projects/stroby - see: cli.flashStrobyFirmwareOTAForTest()
+		it('Calls a function on a product device', async () => {
+			const args = ['function', 'call', PRODUCT_01_DEVICE_02_ID, fn, '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-	// TODO (mirande): this seems like a bug
-	it('Fails when attempting to calls a function on a product device by name', async () => {
-		const args = ['function', 'call', PRODUCT_01_DEVICE_01_NAME, fn, '--product', PRODUCT_01_ID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+			expect(stdout.slice(-3)).to.equal('200');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 
-		expect(stdout).to.include(`Function call failed: Function \`${fn}\` not found`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
-	});
+		it('Fails to call a function on a product device when `device` param is not an id', async () => {
+			const args = ['function', 'call', PRODUCT_01_DEVICE_02_NAME, fn, '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-	it('Fails when attempting to target an unknown device', async () => {
-		const args = ['function', 'call', 'DOESNOTEXIST', 'WATNOPE'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+			expect(stdout).to.include(`\`device\` must be an id when \`--product\` flag is set - received: ${PRODUCT_01_DEVICE_02_NAME}`);
+			expect(stderr.split(os.EOL)).to.include.members(help);
+			expect(exitCode).to.equal(1);
+		});
 
-		expect(stdout).to.include('Error calling function: `WATNOPE`');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
-	});
+		it('Fails when attempting to target an unknown device', async () => {
+			const args = ['function', 'call', 'DOESNOTEXIST', 'WATNOPE'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-	it('Fails when attempting to call an unknown function', async () => {
-		const args = ['function', 'call', DEVICE_NAME, 'WATNOPE'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+			expect(stdout).to.include('Error calling function: `WATNOPE`');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
 
-		expect(stdout).to.include('Function call failed: Function `WATNOPE` not found');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
+		it('Fails when attempting to call an unknown function', async () => {
+			const args = ['function', 'call', DEVICE_NAME, 'WATNOPE'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.include('Function call failed: Function `WATNOPE` not found');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
 	});
 });
 

--- a/test/e2e/get.e2e.js
+++ b/test/e2e/get.e2e.js
@@ -23,9 +23,9 @@ describe('Get Commands [@device]', () => {
 		'  --product  Target a device within the given Product ID or Slug  [string]',
 		'',
 		'Examples:',
-		'  particle get basement temperature                  Read the temperature variable from the device basement',
-		'  particle get basement temperature --product 12345  Read the temperature variable from the device basement within product 12345',
-		'  particle get all temperature                       Read the temperature variable from all my devices'
+		'  particle get basement temperature                                  Read the `temperature` variable from the device `basement`',
+		'  particle get 0123456789abcdef01234567 temperature --product 12345  Read the `temperature` variable from the device with id `0123456789abcdef01234567` within product `12345`',
+		'  particle get all temperature                                       Read the `temperature` variable from all my devices'
 	];
 
 	before(async () => {

--- a/test/e2e/product.e2e.js
+++ b/test/e2e/product.e2e.js
@@ -279,8 +279,8 @@ describe('Product Commands', () => {
 			'  --file, -f  Path to single column .txt file with list of IDs, S/Ns, IMEIs, or ICCIDs of the devices to add  [string]',
 			'',
 			'Examples:',
-			'  particle product device add 12345 5a8ef38cb85f8720edce631a         Add device id 5a8ef38cb85f8720edce631a into product 12345',
-			'  particle product device add 12345 --file ./path/to/device_ids.txt  Adds a list of devices into product 12345'
+			'  particle product device add 12345 0123456789abcdef01234567         Add device id `0123456789abcdef01234567` into product `12345`',
+			'  particle product device add 12345 --file ./path/to/device_ids.txt  Adds a list of devices into product `12345`'
 		];
 
 		before(async () => {
@@ -328,6 +328,15 @@ describe('Product Commands', () => {
 			expect(exitCode).to.equal(1);
 		});
 
+		it('Fails to add a single device when `device` param is not an id', async () => {
+			const args = ['product', 'device', 'add', PRODUCT_01_ID, PRODUCT_01_DEVICE_01_NAME];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.include(`\`device\` parameter must be an id - received: ${PRODUCT_01_DEVICE_01_NAME}`);
+			expect(stderr.split(os.EOL)).to.include.members(help);
+			expect(exitCode).to.equal(1);
+		});
+
 		it('Fails to add a single device when `product` is unknown', async () => {
 			const args = ['product', 'device', 'add', 'LOLWUTNOPE', PRODUCT_01_DEVICE_01_ID];
 			const { stdout, stderr, exitCode } = await cli.run(args);
@@ -338,12 +347,12 @@ describe('Product Commands', () => {
 		});
 
 		it('Fails to add a single device when `device` is unknown', async () => {
-			const args = ['product', 'device', 'add', PRODUCT_01_ID, 'LOLWUTNOPE'];
+			const args = ['product', 'device', 'add', PRODUCT_01_ID, '000000000000000000000001'];
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
 			// for an unknown reason the API does .toLowerCase() on the ID
 			expect(stdout).to.include('Skipped Invalid IDs:');
-			expect(stdout).to.include('  lolwutnope');
+			expect(stdout).to.include('  000000000000000000000001');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(1);
 		});

--- a/test/e2e/subscribe.e2e.js
+++ b/test/e2e/subscribe.e2e.js
@@ -68,7 +68,7 @@ describe('Subscribe Commands [@device]', () => {
 		await cli.callStrobyStart(DEVICE_NAME);
 
 		const args = ['subscribe'];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { events, received: [msg], isCanceled } = await runAndCollectEventOutput(args);
 
 		expect(msg).to.equal('Subscribing to all events from my devices');
 		expect(events).to.have.lengthOf.above(2);
@@ -86,7 +86,7 @@ describe('Subscribe Commands [@device]', () => {
 
 		const eventName = 'led';
 		const args = ['subscribe', eventName];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { events, received: [msg], isCanceled } = await runAndCollectEventOutput(args);
 
 		expect(msg).to.equal(`Subscribing to "${eventName}" from my devices`);
 		expect(events).to.have.lengthOf.above(2);
@@ -104,7 +104,8 @@ describe('Subscribe Commands [@device]', () => {
 		const eventName = DEVICE_ID.substring(0, 6);
 		const eventData = 'active';
 		const args = ['subscribe', '--all', eventName];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { received: [msg, ...data], isCanceled } = await runAndCollectEventOutput(args);
+		const events = getPublishedEventsByName(data, eventName);
 
 		expect(msg).to.equal(`Subscribing to "${eventName}" from the firehose (all devices) and my personal stream (my devices)`);
 		expect(events).to.have.lengthOf.above(2);
@@ -120,7 +121,7 @@ describe('Subscribe Commands [@device]', () => {
 		await cli.callStrobyStart(DEVICE_NAME);
 		const eventName = 't';
 		const args = ['subscribe', '--all', eventName];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { events, received: [msg], isCanceled } = await runAndCollectEventOutput(args);
 
 		expect(msg).to.equal(`Subscribing to "${eventName}" from the firehose (all devices) and my personal stream (my devices)`);
 		expect(events).to.have.lengthOf.above(2);
@@ -144,7 +145,7 @@ describe('Subscribe Commands [@device]', () => {
 		await cli.callStrobyStart(DEVICE_NAME);
 
 		const args = ['subscribe', '--device', DEVICE_ID];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { events, received: [msg], isCanceled } = await runAndCollectEventOutput(args);
 
 		expect(msg).to.equal(`Subscribing to all events from device ${DEVICE_ID}'s stream`);
 		expect(events).to.have.lengthOf.above(2);
@@ -162,7 +163,7 @@ describe('Subscribe Commands [@device]', () => {
 
 		const eventName = 'led';
 		const args = ['subscribe', '--device', DEVICE_ID, eventName];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { events, received: [msg], isCanceled } = await runAndCollectEventOutput(args);
 
 		expect(msg).to.equal(`Subscribing to "${eventName}" from device ${DEVICE_ID}'s stream`);
 		expect(events).to.have.lengthOf.above(2);
@@ -226,7 +227,7 @@ describe('Subscribe Commands [@device]', () => {
 
 		const eventName = 'led';
 		const args = ['subscribe', '--product', PRODUCT_01_ID];
-		const { received: [msg, ...data], isCanceled } = await collectEventOutput(args);
+		const { received: [msg, ...data], isCanceled } = await runAndCollectEventOutput(args);
 		const events = getPublishedEventsByName(data, eventName);
 
 		expect(msg).to.equal(`Subscribing to all events from product ${PRODUCT_01_ID}'s stream`);
@@ -248,7 +249,7 @@ describe('Subscribe Commands [@device]', () => {
 
 		const eventName = 'led';
 		const args = ['subscribe', '--product', PRODUCT_01_ID, eventName];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { events, received: [msg], isCanceled } = await runAndCollectEventOutput(args);
 
 		expect(msg).to.equal(`Subscribing to "${eventName}" from product ${PRODUCT_01_ID}'s stream`);
 		expect(events).to.have.lengthOf.above(2);
@@ -267,8 +268,10 @@ describe('Subscribe Commands [@device]', () => {
 	it('Subscribes to a product device\'s events', async () => {
 		await cli.callStrobyStart(PRODUCT_01_DEVICE_02_ID, PRODUCT_01_ID);
 
+		const eventName = 'led';
 		const args = ['subscribe', '--product', PRODUCT_01_ID, '--device', PRODUCT_01_DEVICE_02_ID];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { received: [msg, ...data], isCanceled } = await runAndCollectEventOutput(args);
+		const events = getPublishedEventsByName(data, eventName);
 
 		expect(msg).to.equal(`Subscribing to all events from product ${PRODUCT_01_ID} device ${PRODUCT_01_DEVICE_02_ID}'s stream`);
 		expect(events).to.have.lengthOf.above(2);
@@ -289,7 +292,7 @@ describe('Subscribe Commands [@device]', () => {
 
 		const eventName = 'led';
 		const args = ['subscribe', '--product', PRODUCT_01_ID, '--device', PRODUCT_01_DEVICE_02_ID, eventName];
-		const { events, received: [msg], isCanceled } = await collectEventOutput(args);
+		const { events, received: [msg], isCanceled } = await runAndCollectEventOutput(args);
 
 		expect(msg).to.equal(`Subscribing to "${eventName}" from product ${PRODUCT_01_ID} device ${PRODUCT_01_DEVICE_02_ID}'s stream`);
 		expect(events).to.have.lengthOf.above(2);
@@ -333,7 +336,7 @@ describe('Subscribe Commands [@device]', () => {
 	}
 
 	// TODO (mirande): capture stdout and stderr independently
-	async function collectEventOutput(...args){
+	async function runAndCollectEventOutput(...args){
 		const subprocess = cli.run(...args);
 		const received = [];
 

--- a/test/e2e/variable.e2e.js
+++ b/test/e2e/variable.e2e.js
@@ -42,7 +42,7 @@ describe('Variable Commands [@device]', () => {
 		const { stdout, stderr, exitCode } = await cli.run(['help', 'variable']);
 
 		expect(stdout).to.equal('');
-		expect(stderr.split('\n')).to.include.members(help);
+		expect(stderr.split(os.EOL)).to.include.members(help);
 		expect(exitCode).to.equal(0);
 	});
 
@@ -50,7 +50,7 @@ describe('Variable Commands [@device]', () => {
 		const { stdout, stderr, exitCode } = await cli.run('variable');
 
 		expect(stdout).to.equal('');
-		expect(stderr.split('\n')).to.include.members(help);
+		expect(stderr.split(os.EOL)).to.include.members(help);
 		expect(exitCode).to.equal(0);
 	});
 
@@ -58,7 +58,7 @@ describe('Variable Commands [@device]', () => {
 		const { stdout, stderr, exitCode } = await cli.run(['variable', '--help']);
 
 		expect(stdout).to.equal('');
-		expect(stderr.split('\n')).to.include.members(help);
+		expect(stderr.split(os.EOL)).to.include.members(help);
 		expect(exitCode).to.equal(0);
 	});
 
@@ -91,7 +91,7 @@ describe('Variable Commands [@device]', () => {
 			const subprocess = cli.run(['variable', 'get', DEVICE_ID]);
 
 			await delay(1000);
-			subprocess.stdin.end('\n');
+			subprocess.stdin.end(os.EOL);
 
 			const { stdout, stderr, exitCode } = await subprocess;
 
@@ -176,17 +176,45 @@ describe('Variable Commands [@device]', () => {
 		it('Monitors a variable', async () => {
 			const args = ['variable', 'monitor', DEVICE_ID, 'version', '--delay', 1000];
 			const subprocess = cli.run(args);
+			const received = [];
 
-			await delay(5000);
-			subprocess.cancel(); // CTRL-C
+			await waitForResult(subprocess, (data) => {
+				const log = data.toString('utf8').trim();
 
-			const { all, isCanceled } = await subprocess;
-			const [msg, ...results] = all.split('\n');
+				received.push(log);
+
+				if (received.length > 3){
+					return true;
+				}
+				return false;
+			});
+
+			const { isCanceled } = await subprocess;
+			const [msg, ...results] = received;
 
 			expect(msg).to.equal('Hit CTRL-C to stop!');
 			expect(results).to.have.lengthOf.above(2);
 			expect(isCanceled).to.equal(true);
 		});
 	});
+
+	function waitForResult(subprocess, isFinished){
+		return new Promise((resolve, reject) => {
+			subprocess.all.on('data', (data) => {
+				if (isFinished(data)){
+					subprocess.cancel();
+					resolve();
+				}
+			});
+			subprocess.all.on('error', (error) => {
+				subprocess.cancel();
+				reject(error);
+			});
+			subprocess.all.on('close', () => {
+				subprocess.cancel();
+				resolve();
+			});
+		});
+	}
 });
 

--- a/test/e2e/variable.e2e.js
+++ b/test/e2e/variable.e2e.js
@@ -8,7 +8,8 @@ const {
 	DEVICE_NAME,
 	DEVICE_PLATFORM_NAME,
 	PRODUCT_01_ID,
-	PRODUCT_01_DEVICE_02_ID
+	PRODUCT_01_DEVICE_02_ID,
+	PRODUCT_01_DEVICE_02_NAME
 } = require('../lib/env');
 
 
@@ -115,9 +116,9 @@ describe('Variable Commands [@device]', () => {
 			'  --product  Target a device within the given Product ID or Slug  [string]',
 			'',
 			'Examples:',
-			'  particle get basement temperature                  Read the temperature variable from the device basement',
-			'  particle get basement temperature --product 12345  Read the temperature variable from the device basement within product 12345',
-			'  particle get all temperature                       Read the temperature variable from all my devices'
+			'  particle get basement temperature                                  Read the `temperature` variable from the device `basement`',
+			'  particle get 0123456789abcdef01234567 temperature --product 12345  Read the `temperature` variable from the device with id `0123456789abcdef01234567` within product `12345`',
+			'  particle get all temperature                                       Read the `temperature` variable from all my devices'
 		];
 
 		it('Gets a variable by name', async () => {
@@ -140,6 +141,31 @@ describe('Variable Commands [@device]', () => {
 			expect(exitCode).to.equal(0);
 		});
 
+		it('Uses default when `--delay` is too short', async () => {
+			const args = ['variable', 'monitor', DEVICE_ID, 'version', '--delay', 1];
+			const subprocess = cli.run(args);
+			const received = [];
+
+			await waitForResult(subprocess, (data) => {
+				const log = data.toString('utf8').trim();
+
+				received.push(log);
+
+				if (received.length > 3){
+					return true;
+				}
+				return false;
+			});
+
+			const { isCanceled } = await subprocess;
+			const [alert, msg, ...results] = received;
+
+			expect(alert).to.equal('Delay was too short, resetting to 500ms');
+			expect(msg).to.equal('Hit CTRL-C to stop!');
+			expect(results).to.have.lengthOf.above(1);
+			expect(isCanceled).to.equal(true);
+		});
+
 		// TODO (mirande): need to ensure device is running expected firmware and online
 		// once flashing product devices is implemented - as it is, the expectation
 		// is that your product device is running the `stroby` firmware found in:
@@ -153,11 +179,33 @@ describe('Variable Commands [@device]', () => {
 			expect(exitCode).to.equal(0);
 		});
 
+		it('Fails to get an unknown variable', async () => {
+			const args = ['get', DEVICE_NAME, 'NOPE'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const msg = [
+				'Error: Unknown Variable: NOPE',
+				'Error while reading value: Some variables could not be read'
+			].join(os.EOL);
+
+			expect(stdout).to.include(msg);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
+
 		it('Fails to get a variable from a product device when `device` param is not provided', async () => {
 			const args = ['get', '--product', PRODUCT_01_ID];
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
 			expect(stdout).to.include('`device` parameter is required when `--product` flag is set');
+			expect(stderr.split(os.EOL)).to.include.members(help);
+			expect(exitCode).to.equal(1);
+		});
+
+		it('Fails to get a variable from a product device when `device` param is not an id', async () => {
+			const args = ['get', PRODUCT_01_DEVICE_02_NAME, 'version', '--product', PRODUCT_01_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.include(`\`device\` must be an id when \`--product\` flag is set - received: ${PRODUCT_01_DEVICE_02_NAME}`);
 			expect(stderr.split(os.EOL)).to.include.members(help);
 			expect(exitCode).to.equal(1);
 		});


### PR DESCRIPTION
## Description

Improves error messaging when `--product <id>` flag is set but `device` param is not an ID ([ch](https://app.clubhouse.io/particle/story/47215/unhelpful-error-message-when-using-device-name-and-product-flag))

## How to Test

_Note: requires you to have a Particle product with one or more devices_

Run the following commands and note the error message you see:

`particle cloud flash <device-name> <path-to-project.ino> --product <product-id>`
`particle variable get <device-name> <var-name> --product <product-id>`
`particle subscribe --device <device-name> --product <product-id>`
`particle function call <device-name> <fn-name> --product <product-id>`

Then run `particle --help` and confirm all functions which currently support the `--product` flag as well as the `product` commands themselves properly handle being called with a `<device-name>`

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

