### PR TITLE
bugfix/ch52805/ctrl-c-exit

### DIFF
--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -148,10 +148,9 @@ module.exports = class SerialCommand {
 		const handleClose = () => {
 			if (follow && !cleaningUp){
 				console.log(chalk.bold.white('Serial connection closed.  Attempting to reconnect...'));
-				reconnect();
-			} else {
-				console.log(chalk.bold.white('Serial connection closed.'));
+				return reconnect();
 			}
+			console.log(chalk.bold.white('Serial connection closed.'));
 		};
 
 		// Handle interrupts and close the port gracefully
@@ -164,6 +163,7 @@ module.exports = class SerialCommand {
 				if (serialPort && serialPort.isOpen){
 					serialPort.close();
 				}
+				process.exit(0);
 			}
 		};
 
@@ -219,6 +219,7 @@ module.exports = class SerialCommand {
 
 		process.on('SIGINT', handleInterrupt);
 		process.on('SIGQUIT', handleInterrupt);
+		process.on('SIGBREAK', handleInterrupt);
 		process.on('SIGTERM', handleInterrupt);
 		process.on('exit', () => handleInterrupt(true));
 

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -1,3 +1,4 @@
+const os = require('os');
 const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
@@ -146,6 +147,7 @@ module.exports = class SerialCommand {
 
 		// Called when port closes
 		const handleClose = () => {
+			console.log(os.EOL);
 			if (follow && !cleaningUp){
 				console.log(chalk.bold.white('Serial connection closed.  Attempting to reconnect...'));
 				return reconnect();


### PR DESCRIPTION
## Description

minor tweak to explicitly exit when signal events are received.


## How to Test

1. connect a single device via usb
2. run `particle serial monitor --follow`
3. unplug your device
4. press `ctrl+c` on your keyboard

## Related Issues / Discussions

fixes https://github.com/particle-iot/particle-cli/issues/573


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

