### PR TITLE
chore/ch53020/post-merge-cleanups

### DIFF
--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -364,21 +364,13 @@ module.exports = {
 		if (filter){
 			const platforms = knownPlatforms();
 			if (filter === 'online') {
-				filterFunc = (d) => {
-					return d.connected;
-				};
+				filterFunc = (d) => d.connected;
 			} else if (filter === 'offline') {
-				filterFunc = (d) => {
-					return !d.connected;
-				};
+				filterFunc = (d) => !d.connected;
 			} else if (Object.keys(platforms).indexOf(filter) >= 0) {
-				filterFunc = (d) => {
-					return d.platform_id === platforms[filter];
-				};
+				filterFunc = (d) => d.platform_id === platforms[filter];
 			} else {
-				filterFunc = (d) => {
-					return d.id === filter || d.name === filter;
-				};
+				filterFunc = (d) => d.id === filter || d.name === filter;
 			}
 		}
 		return filterFunc;

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -74,14 +74,11 @@ describe('Cloud Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	describe('Device Listing', async () => {
-		let platform, args;
-		before(async () => {
-			await cli.revertDeviceName();
-		});
+	describe('List Subcommand', () => {
+		const platform = capitalize(DEVICE_PLATFORM_NAME);
+		let args;
 
 		beforeEach(async () => {
-			platform = capitalize(DEVICE_PLATFORM_NAME);
 			args = ['cloud', 'list'];
 		});
 
@@ -93,265 +90,266 @@ describe('Cloud Commands [@device]', () => {
 			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by Platform Name', () => {
-			it('Shows matching devices', async () => {
-				args.push(DEVICE_PLATFORM_NAME);
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists devices filtered by platform name', async () => {
+			args.push(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-				expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
-
-			it('Filters out non-matching devices', async () => {
-				// Likely platforms being used with e2e testing
-				const testPlatforms = [
-					'photon',
-					'electron',
-					'argon',
-					'boron'
-				];
-
-				// Derive platform name NOT matching those claimed by E2E test profile
-				// (i.e. find single, valid inversion of DEVICE_PLATFORM_NAME)
-				const nonE2EDevicePlatform = testPlatforms.filter((platform) => {
-					return platform !== DEVICE_PLATFORM_NAME;
-				})[0];
-
-				args.push(nonE2EDevicePlatform);
-				const { stdout, stderr, exitCode } = await cli.run(args);
-
-				expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by Device Name', () => {
-			it('Shows matching devices', async () => {
-				args.push(DEVICE_NAME);
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists devices filtered by platform name omitting test device', async () => {
+			const { knownPlatforms } = require('../../settings');
+			const platformNames = Object.entries(knownPlatforms)
+				.map(({ 1: name }) => name.replace(/\s/, '').toLowerCase());
+			// Derive platform name NOT matching those claimed by E2E test profile
+			// (i.e. find single, valid inversion of DEVICE_PLATFORM_NAME)
+			const nonE2EDevicePlatform = platformNames.filter(name => name !== DEVICE_PLATFORM_NAME);
 
-				expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			args.push(nonE2EDevicePlatform);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-			it('Filters out non-matching devices', async () => {
-				args.push('non-existent-device-name');
-				const { stdout, stderr, exitCode } = await cli.run(args);
-
-				expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.not.include(DEVICE_NAME);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by Device ID', () => {
-			it('Shows matching devices', async () => {
-				args.push(DEVICE_ID);
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists devices filtered by device name', async () => {
+			args.push(DEVICE_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-				expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
-
-			it('Filters out non-matching devices', async () => {
-				args.push('non-existent-device-id');
-				const { stdout, stderr, exitCode } = await cli.run(args);
-
-				expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by online', () => {
-			it('Shows online devices', async () => {
-				args.push('online');
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists devices filtered by device name omitting test device', async () => {
+			args.push('non-existent-device-name');
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-				expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.not.include(DEVICE_NAME);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by offline', () => {
-			it('Does not show online devices', async () => {
-				args.push('offline');
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists devices filtered by device id', async () => {
+			args.push(DEVICE_ID);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-				expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
+		it('Lists devices filtered by device id omitting test device', async () => {
+			args.push('non-existent-device-id');
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.not.include(DEVICE_NAME);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists devices filtered by `online` state', async () => {
+			args.push('online');
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists connected devices filtered by `offline` state', async () => {
+			args.push('offline');
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Compiles firmware', async () => {
-		const args = ['cloud', 'compile', 'photon', PATH_PROJ_STROBY_INO, '--saveTo', strobyBinPath];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			'Compiling code for photon',
-			'',
-			'Including:',
-			`    ${PATH_PROJ_STROBY_INO}`,
-			'attempting to compile firmware ',
-			'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
-			`saving to: ${strobyBinPath}`,
-			'Memory use: ',
-			'', // don't assert against memory stats since they may change based on current default Device OS version
-			'Compile succeeded.',
-			`Saved firmware to: ${strobyBinPath}`
-		];
+	describe('Compile Subcommand', () => {
+		it('Compiles firmware', async () => {
+			const args = ['cloud', 'compile', 'photon', PATH_PROJ_STROBY_INO, '--saveTo', strobyBinPath];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				'Compiling code for photon',
+				'',
+				'Including:',
+				`    ${PATH_PROJ_STROBY_INO}`,
+				'attempting to compile firmware ',
+				'', // don't assert against binary info since it's always unique: e.g. 'downloading binary from: /v1/binaries/5d38f108bc91fb000130a3f9'
+				`saving to: ${strobyBinPath}`,
+				'Memory use: ',
+				'', // don't assert against memory stats since they may change based on current default Device OS version
+				'Compile succeeded.',
+				`Saved firmware to: ${strobyBinPath}`
+			];
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Compiles a project with symlinks to parent/other file locations', async () => {
+			const name = 'symlinks';
+			const platform = 'photon';
+			const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
+			const destination = path.join(PATH_TMP_DIR, `${name}-${platform}.bin`);
+			const args = ['cloud', 'compile', platform, '--saveTo', destination, '--followSymlinks'];
+			const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
+			const log = [
+				`Compiling code for ${platform}`,
+				'Including:',
+				'    shared/sub_dir/helper.h',
+				'    app.ino',
+				'    shared/sub_dir/helper.cpp',
+				'    project.properties',
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Compiles a project with symlinks to parent/other file locations', async () => {
-		const name = 'symlinks';
-		const platform = 'photon';
-		const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
-		const destination = path.join(PATH_TMP_DIR, `${name}-${platform}.bin`);
-		const args = ['cloud', 'compile', platform, '--saveTo', destination, '--followSymlinks'];
-		const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
-		const log = [
-			`Compiling code for ${platform}`,
-			'Including:',
-			'    shared/sub_dir/helper.h',
-			'    app.ino',
-			'    shared/sub_dir/helper.cpp',
-			'    project.properties',
-		];
+	describe('Flash Subcommand', () => {
+		it('Flashes firmware', async () => {
+			const args = ['cloud', 'flash', DEVICE_NAME, PATH_PROJ_STROBY_INO];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				'Including:',
+				`    ${PATH_PROJ_STROBY_INO}`,
+				`attempting to flash firmware to your device ${DEVICE_NAME}`,
+				'Flash device OK:  Update started'
+			];
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+
+			await cli.waitForVariable('name', 'stroby');
+		});
+
+		it('Flashes a project with symlinks to parent/other file locations', async () => {
+			const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
+			const args = ['cloud', 'flash', DEVICE_NAME, '--followSymlinks'];
+			const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
+			const log = [
+				'Including:',
+				'    shared/sub_dir/helper.h',
+				'    app.ino',
+				'    shared/sub_dir/helper.cpp',
+				'    project.properties',
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Flashes firmware', async () => {
-		const args = ['cloud', 'flash', DEVICE_NAME, PATH_PROJ_STROBY_INO];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			'Including:',
-			`    ${PATH_PROJ_STROBY_INO}`,
-			`attempting to flash firmware to your device ${DEVICE_NAME}`,
-			'Flash device OK:  Update started'
-		];
+	describe('Remove Subcommand', () => {
+		afterEach(async () => {
+			await cli.run(['cloud', 'claim', DEVICE_ID], { reject: true });
+			await delay(5000);
+		});
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+		it('Removes device', async () => {
+			const args = ['cloud', 'remove', DEVICE_NAME, '--yes'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`releasing device ${DEVICE_NAME}`,
+				'Okay!'
+			];
 
-		await cli.waitForVariable('name', 'stroby');
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Flashes a project with symlinks to parent/other file locations', async () => {
-		const cwd = path.join(PATH_FIXTURES_PROJECTS_DIR, 'symlink', 'main-project');
-		const args = ['cloud', 'flash', DEVICE_NAME, '--followSymlinks'];
-		const { stdout, stderr, exitCode } = await cli.run(args, { cwd });
-		const log = [
-			'Including:',
-			'    shared/sub_dir/helper.h',
-			'    app.ino',
-			'    shared/sub_dir/helper.cpp',
-			'    project.properties',
-		];
+	describe('Claim Subcommand', () => {
+		it('Claims device', async () => {
+			const id = DEVICE_ID.toLowerCase();
+			const args = ['cloud', 'claim', id];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Claiming device ${id}`,
+				`Successfully claimed device ${id}`
+			];
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Claims device when device id is capitalized', async () => {
+			const id = DEVICE_ID.toUpperCase();
+			const args = ['cloud', 'claim', id];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Claiming device ${id}`,
+				`Successfully claimed device ${id}`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Fails to claim an unknown device', async () => {
+			const invalidDeviceID = '1234567890';
+			const args = ['cloud', 'claim', invalidDeviceID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Claiming device ${invalidDeviceID}`,
+				'Failed to claim device: device not found'
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
+
+		it('Fails to claim a device owned by someone else', async () => {
+			const args = ['cloud', 'claim', FOREIGN_DEVICE_ID];
+			const subprocess = cli.run(args);
+
+			await delay(1000);
+			subprocess.stdin.write('n');
+			subprocess.stdin.write('\n');
+
+			const { all, exitCode } = await subprocess;
+			const log = stripANSI(all);
+
+			expect(log).to.include(`Claiming device ${FOREIGN_DEVICE_ID}`);
+			expect(log).to.include('That device belongs to someone else. Would you like to request a transfer?');
+			expect(log).to.include('Failed to claim device: You cannot claim a device owned by someone else');
+			expect(exitCode).to.equal(1);
+		});
 	});
 
-	it('Removes device', async () => {
-		const args = ['cloud', 'remove', DEVICE_NAME, '--yes'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`releasing device ${DEVICE_NAME}`,
-			'Okay!'
-		];
+	describe('Name Subcommand', () => {
+		afterEach(async () => {
+			await cli.revertDeviceName();
+		});
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
+		it('Names a device', async () => {
+			const name = `${DEVICE_NAME}-updated`;
+			const args = ['cloud', 'name', DEVICE_ID, name];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Renaming device ${DEVICE_ID}`,
+				`Successfully renamed device ${DEVICE_ID} to: ${name}`
+			];
 
-	it('Claims device', async () => {
-		const id = DEVICE_ID.toLowerCase();
-		const args = ['cloud', 'claim', id];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Claiming device ${id}`,
-			`Successfully claimed device ${id}`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Claims device when device id is capitalized', async () => {
-		const id = DEVICE_ID.toUpperCase();
-		const args = ['cloud', 'claim', id];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Claiming device ${id}`,
-			`Successfully claimed device ${id}`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Fails to claim an unknown device', async () => {
-		const invalidDeviceID = '1234567890';
-		const args = ['cloud', 'claim', invalidDeviceID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Claiming device ${invalidDeviceID}`,
-			'Failed to claim device: device not found'
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
-	});
-
-	it('Fails to claim a device owned by someone else', async () => {
-		const args = ['cloud', 'claim', FOREIGN_DEVICE_ID];
-		const subprocess = cli.run(args);
-
-		await delay(1000);
-		subprocess.stdin.write('n');
-		subprocess.stdin.write('\n');
-
-		const { all, exitCode } = await subprocess;
-		const log = stripANSI(all);
-
-		expect(log).to.include(`Claiming device ${FOREIGN_DEVICE_ID}`);
-		expect(log).to.include('That device belongs to someone else. Would you like to request a transfer?');
-		expect(log).to.include('Failed to claim device: You cannot claim a device owned by someone else');
-		expect(exitCode).to.equal(1);
-	});
-
-	it('Names a device', async () => {
-		const name = `${DEVICE_NAME}-updated`;
-		const args = ['cloud', 'name', DEVICE_ID, name];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Renaming device ${DEVICE_ID}`,
-			`Successfully renamed device ${DEVICE_ID} to: ${name}`
-		];
-
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 });
 

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -65,10 +65,11 @@ describe('USB Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	describe('Device Listing', async () => {
-		let platform, args;
+	describe('List Subcommand', () => {
+		const platform = capitalize(DEVICE_PLATFORM_NAME);
+		let args;
+
 		beforeEach(() => {
-			platform = capitalize(DEVICE_PLATFORM_NAME);
 			args = ['usb', 'list'];
 		});
 
@@ -80,165 +81,170 @@ describe('USB Commands [@device]', () => {
 			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by Platform Name', () => {
-			it('Shows matching devices', async () => {
-				args.push(DEVICE_PLATFORM_NAME);
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists connected devices filtered by platform name', async () => {
+			args.push(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-				expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
-
-			it('Filters out non-matching devices', async () => {
-				// Likely platforms being used with e2e testing
-				const testPlatforms = [
-					'photon',
-					'electron',
-					'argon',
-					'boron'
-				];
-
-				// Derive platform name NOT matching those claimed by E2E test profile
-				// (i.e. find single, valid inversion of DEVICE_PLATFORM_NAME)
-				const nonE2EDevicePlatform = testPlatforms.filter((platform) => {
-					return platform !== DEVICE_PLATFORM_NAME;
-				})[0];
-
-				args.push(nonE2EDevicePlatform);
-				const { stdout, stderr, exitCode } = await cli.run(args);
-
-				expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by Device Name', () => {
-			it('Shows matching devices', async () => {
-				args.push(DEVICE_NAME);
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists connected devices filtered by platform name omitting test device', async () => {
+			const { knownPlatforms } = require('../../settings');
+			const platformNames = Object.entries(knownPlatforms)
+				.map(({ 1: name }) => name.replace(/\s/, '').toLowerCase());
+			// Derive platform name NOT matching those claimed by E2E test profile
+			// (i.e. find single, valid inversion of DEVICE_PLATFORM_NAME)
+			const nonE2EDevicePlatform = platformNames.filter(name => name !== DEVICE_PLATFORM_NAME);
 
-				expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			args.push(nonE2EDevicePlatform);
+			const { stdout, stderr, exitCode } = await cli.debug(args);
 
-			it('Filters out non-matching devices', async () => {
-				args.push('non-existent-device-name');
-				const { stdout, stderr, exitCode } = await cli.run(args);
-
-				expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.not.include(DEVICE_NAME);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by Device ID', () => {
-			it('Shows matching devices', async () => {
-				args.push(DEVICE_ID);
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists connected devices filtered by device name', async () => {
+			args.push(DEVICE_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-				expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
-
-			it('Filters out non-matching devices', async () => {
-				args.push('non-existent-device-id');
-				const { stdout, stderr, exitCode } = await cli.run(args);
-
-				expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by online', () => {
-			it('Shows online devices', async () => {
-				args.push('online');
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists connected devices filtered by device name omitting test device', async () => {
+			args.push('non-existent-device-name');
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-				expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.not.include(DEVICE_NAME);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 
-		describe('Filter by offline', () => {
-			it('Does not show online devices', async () => {
-				args.push('offline');
-				const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Lists connected devices filtered by device id', async () => {
+			args.push(DEVICE_ID);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-				expect(stdout).to.not.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-				expect(stderr).to.equal('');
-				expect(exitCode).to.equal(0);
-			});
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists connected devices filtered by device id omitting test device', async () => {
+			args.push('non-existent-device-id');
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.not.include(DEVICE_NAME);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists connected devices filtered by `online` state', async () => {
+			args.push('online');
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists connected devices filtered by `offline` state', async () => {
+			args.push('offline');
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.not.include(DEVICE_NAME);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 	});
 
-	it('Starts & stops listening', async () => {
-		await cli.run(['usb', 'start-listening']);
-		await delay(2000);
+	describe('Start-Listening Subcommand', () => {
+		afterEach(async () => {
+			await cli.run(['usb', 'stop-listening']);
+			await delay(2000);
+		});
 
-		const { stdout, stderr, exitCode } = await cli.run(['serial', 'identify']);
-		expect(stdout).to.include(`Your device id is ${DEVICE_ID}`);
-		expect(stdout).to.include('Your system firmware version is');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+		it('Starts listening', async () => {
+			await cli.run(['usb', 'start-listening']);
+			await delay(2000);
 
-		await cli.run(['usb', 'stop-listening']);
-		await delay(2000);
+			const { stdout, stderr, exitCode } = await cli.run(['serial', 'identify']);
 
-		// TODO (mirande): need a way to ask the device what 'mode' it is in
-		const subproc = await cli.run(['serial', 'identify']);
-		expect(subproc.stdout).to.equal('Serial timed out'); // TODO (mirande): should be stderr?
-		expect(subproc.stderr).to.equal('');
-		expect(subproc.exitCode).to.equal(1);
+			expect(stdout).to.include(`Your device id is ${DEVICE_ID}`);
+			expect(stdout).to.include('Your system firmware version is');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Sets and clears the setup done flag', async () => {
-		await cli.run(['usb', 'setup-done', '--reset']);
-		await delay(2000);
+	describe('Stop-Listening Subcommand', () => {
+		beforeEach(async () => {
+			await cli.run(['usb', 'start-listening']);
+			await delay(2000);
+		});
 
-		const platform = capitalize(DEVICE_PLATFORM_NAME);
-		const { stdout, stderr, exitCode } = await cli.run(['usb', 'list']);
-		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, LISTENING)`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+		it('Stops listening', async () => {
+			await cli.run(['usb', 'stop-listening']);
+			await delay(2000);
 
-		await cli.run(['usb', 'setup-done']);
-		await delay(2000);
+			// TODO (mirande): need a way to ask the device what 'mode' it is in
+			const { stdout, stderr, exitCode } = await cli.run(['serial', 'identify']);
 
-		const subproc = await cli.run(['usb', 'list']);
-		expect(subproc.stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-		expect(subproc.stderr).to.equal('');
-		expect(subproc.exitCode).to.equal(0);
+			expect(stdout).to.equal('Serial timed out'); // TODO (mirande): should be stderr?
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
 	});
 
-	it('Enters DFU mode with confirmation', async () => {
-		await cli.run(['usb', 'dfu', DEVICE_ID]);
+	describe('Setup-Done Subcommand', () => {
+		it('Sets and clears the setup done flag', async () => {
+			await cli.run(['usb', 'setup-done', '--reset']);
+			await delay(2000);
 
-		const platform = capitalize(DEVICE_PLATFORM_NAME);
-		const { stdout, stderr, exitCode } = await cli.run(['usb', 'list']);
-		expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, DFU)`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			const platform = capitalize(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(['usb', 'list']);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, LISTENING)`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 
-		await cli.resetDevice();
+			await cli.run(['usb', 'setup-done']);
+			await delay(2000);
 
-		const subproc = await cli.run(['usb', 'list']);
-		expect(subproc.stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
-		expect(subproc.stderr).to.equal('');
-		expect(subproc.exitCode).to.equal(0);
+			const subproc = await cli.run(['usb', 'list']);
+			expect(subproc.stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(subproc.stderr).to.equal('');
+			expect(subproc.exitCode).to.equal(0);
+		});
 	});
 
-	it('Fails to enter DFU mode when device is unrecognized', async () => {
-		const device = 'DOESNOTEXIST';
-		const { stdout, stderr, exitCode } = await cli.run(['usb', 'dfu', device]);
+	describe('DFU Subcommand', () => {
+		it('Enters DFU mode with confirmation', async () => {
+			await cli.run(['usb', 'dfu', DEVICE_ID]);
 
-		expect(stdout).to.equal(`Device not found: ${device}`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
+			const platform = capitalize(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(['usb', 'list']);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, DFU)`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+
+			await cli.resetDevice();
+
+			const subproc = await cli.run(['usb', 'list']);
+			expect(subproc.stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(subproc.stderr).to.equal('');
+			expect(subproc.exitCode).to.equal(0);
+		});
+
+		it('Fails to enter DFU mode when device is unrecognized', async () => {
+			const device = 'DOESNOTEXIST';
+			const { stdout, stderr, exitCode } = await cli.run(['usb', 'dfu', device]);
+
+			expect(stdout).to.equal(`Device not found: ${device}`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
 	});
 });


### PR DESCRIPTION
## Description

A few tweaks to `e2e` test naming + grouping and some minor refactorings.


## How to Test

1. set up your local environment to run `e2e` tests as [described here](https://github.com/particle-iot/particle-cli/blob/chore/ch53020/post-merge-cleanups/test/README.md)
2. run `npm run test:e2e`


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

