### PR TITLE
chore/ch53020/e2e-test-naming

### DIFF
--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -56,7 +56,7 @@ module.exports = class UsbCommand {
 								type.push('DFU');
 							}
 
-							if (mode && mode !== 'UNKNOWN'){
+							if (mode && (mode !== 'UNKNOWN' && mode !== 'NORMAL')){
 								type.push(mode);
 							}
 

--- a/test/README.md
+++ b/test/README.md
@@ -88,7 +88,7 @@ test
 
 ### Naming
 
-Your top-level `describe()` title should be formatted like `<cmd> Commands [<tags>]` where `cmd` is the 1st level command you are testing (e.g. "Cloud", "Call", etc) and `tags` are a comma-delimited set of tokens prefixed with `@` (e.g. `@device`).
+Tests should be grouped by command. Your top-level `describe()` title should be formatted like `<cmd> Commands [<tags>]` where `cmd` is the 1st level command you are testing (e.g. "Cloud", "Call", etc) and `tags` are a comma-delimited set of tokens prefixed with `@` (e.g. `@device`). Nested `describe()` titles should be formatted like `<subcmd> Subcommand`. Avoid deeply nesting `describe()` calls (2 levels is ideal).
 
 `describe()` titles should be title-case, `it()` names should be sentence-case.
 
@@ -96,9 +96,11 @@ Your top-level `describe()` title should be formatted like `<cmd> Commands [<tag
 For example:
 
 ```js
-describe('Mesh Commands [@device]', () => {
-	it('Removes device from network', async () => {
-		//...
+describe('USB Commands [@device]', () => {
+	describe('USB DFU Subcommand', () => {
+		it('Enters DFU mode with confirmation', async () => {
+			//...
+		});
 	});
 });
 
@@ -112,7 +114,7 @@ Tags provide an easy way to filter tests using use mocha's `--grep` feature ([do
 
 ## Known Issues
 
-* tests run somewhat slowly (~10m) and are generally less stable than unitish tests
+* tests run somewhat slowly (~30m) and are generally less stable than unitish tests
 * currently known to work under macOS _only_ when running with a device
-* tests should run in docker
+* tests should run in docker to acheive proper isolation
 

--- a/test/e2e/binary.e2e.js
+++ b/test/e2e/binary.e2e.js
@@ -44,110 +44,112 @@ describe('Binary Commands', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	const specs = [
-		{
-			file: 'core_tinker.bin',
-			contents: [
-				'core_tinker.bin',
-				' CRC is ok (aded513e)',
-				' Compiled for core',
-				' This is a monolithic firmware number 0 at version 0'
-			]
-		},
-		{
-			file: 'photon_tinker.bin',
-			contents: [
-				'photon_tinker.bin',
-				' CRC is ok (ba4f59ab)',
-				' Compiled for photon',
-				' This is an application module number 1 at version 2',
-				' It depends on a system module number 2 at version 1'
-			]
-		},
-		{
-			file: 'photon_tinker-0.4.5.bin',
-			contents: [
-				'photon_tinker-0.4.5.bin',
-				' CRC is ok (4a738441)',
-				' Compiled for photon',
-				' This is an application module number 1 at version 3',
-				' It depends on a system module number 2 at version 6'
-			]
-		},
-		{
-			file: 'p1_tinker.bin',
-			contents: [
-				'p1_tinker.bin',
-				' CRC is ok (61972e4d)',
-				' Compiled for p1',
-				' This is an application module number 1 at version 2',
-				' It depends on a system module number 2 at version 3'
-			]
-		},
-		{
-			file: 'p1_tinker-0.4.5.bin',
-			contents: [
-				'p1_tinker-0.4.5.bin',
-				' CRC is ok (70e7c48c)',
-				' Compiled for p1',
-				' This is an application module number 1 at version 3',
-				' It depends on a system module number 2 at version 6'
-			]
-		},
-		{
-			file: 'electron_tinker.bin',
-			contents: [
-				'electron_tinker.bin',
-				' CRC is ok (b3934494)',
-				' Compiled for electron',
-				' This is an application module number 1 at version 3',
-				' It depends on a system module number 2 at version 10'
-			]
-		},
-		{
-			file: 'argon_stroby.bin',
-			contents: [
-				'argon_stroby.bin',
-				' CRC is ok (da140931)',
-				' Compiled for argon',
-				' This is an application module number 1 at version 6',
-				' It depends on a system module number 1 at version 1213'
-			]
-		},
-		{
-			file: 'boron_blank.bin',
-			contents: [
-				'boron_blank.bin',
-				' CRC is ok (4d02d94f)',
-				' Compiled for boron',
-				' This is an application module number 1 at version 6',
-				' It depends on a system module number 1 at version 1213'
-			]
-		},
-		{
-			file: 'product_firmware.bin',
-			contents: [
-				'product_firmware.bin',
-				' CRC is ok (e309c618)',
-				' Compiled for electron',
-				' This is an application module number 1 at version 6',
-				' It is firmware for product id 8178 at version 13',
-				' It depends on a system module number 2 at version 1201'
-			]
-		}
-	];
+	describe('Binary Inspect Subcommand', () => {
+		const specs = [
+			{
+				file: 'core_tinker.bin',
+				contents: [
+					'core_tinker.bin',
+					' CRC is ok (aded513e)',
+					' Compiled for core',
+					' This is a monolithic firmware number 0 at version 0'
+				]
+			},
+			{
+				file: 'photon_tinker.bin',
+				contents: [
+					'photon_tinker.bin',
+					' CRC is ok (ba4f59ab)',
+					' Compiled for photon',
+					' This is an application module number 1 at version 2',
+					' It depends on a system module number 2 at version 1'
+				]
+			},
+			{
+				file: 'photon_tinker-0.4.5.bin',
+				contents: [
+					'photon_tinker-0.4.5.bin',
+					' CRC is ok (4a738441)',
+					' Compiled for photon',
+					' This is an application module number 1 at version 3',
+					' It depends on a system module number 2 at version 6'
+				]
+			},
+			{
+				file: 'p1_tinker.bin',
+				contents: [
+					'p1_tinker.bin',
+					' CRC is ok (61972e4d)',
+					' Compiled for p1',
+					' This is an application module number 1 at version 2',
+					' It depends on a system module number 2 at version 3'
+				]
+			},
+			{
+				file: 'p1_tinker-0.4.5.bin',
+				contents: [
+					'p1_tinker-0.4.5.bin',
+					' CRC is ok (70e7c48c)',
+					' Compiled for p1',
+					' This is an application module number 1 at version 3',
+					' It depends on a system module number 2 at version 6'
+				]
+			},
+			{
+				file: 'electron_tinker.bin',
+				contents: [
+					'electron_tinker.bin',
+					' CRC is ok (b3934494)',
+					' Compiled for electron',
+					' This is an application module number 1 at version 3',
+					' It depends on a system module number 2 at version 10'
+				]
+			},
+			{
+				file: 'argon_stroby.bin',
+				contents: [
+					'argon_stroby.bin',
+					' CRC is ok (da140931)',
+					' Compiled for argon',
+					' This is an application module number 1 at version 6',
+					' It depends on a system module number 1 at version 1213'
+				]
+			},
+			{
+				file: 'boron_blank.bin',
+				contents: [
+					'boron_blank.bin',
+					' CRC is ok (4d02d94f)',
+					' Compiled for boron',
+					' This is an application module number 1 at version 6',
+					' It depends on a system module number 1 at version 1213'
+				]
+			},
+			{
+				file: 'product_firmware.bin',
+				contents: [
+					'product_firmware.bin',
+					' CRC is ok (e309c618)',
+					' Compiled for electron',
+					' This is an application module number 1 at version 6',
+					' It is firmware for product id 8178 at version 13',
+					' It depends on a system module number 2 at version 1201'
+				]
+			}
+		];
 
-	specs.forEach(spec => {
-		const { file, contents } = spec;
+		specs.forEach(spec => {
+			const { file, contents } = spec;
 
-		it(`Inspects binary file: ${file}`, async () => {
-			const bin = path.join(PATH_FIXTURES_BINARIES_DIR, file);
-			const args = ['binary', 'inspect', bin];
-			const { stdout, stderr, exitCode } = await cli.run(args);
+			it(`Inspects binary file: ${file}`, async () => {
+				const bin = path.join(PATH_FIXTURES_BINARIES_DIR, file);
+				const args = ['binary', 'inspect', bin];
+				const { stdout, stderr, exitCode } = await cli.run(args);
 
-			expect(stdout.split('\n')).to.include.members(contents);
-			expect(stderr).to.equal('');
-			expect(exitCode).to.equal(0);
+				expect(stdout.split('\n')).to.include.members(contents);
+				expect(stderr).to.equal('');
+				expect(exitCode).to.equal(0);
+			});
 		});
 	});
 });

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -74,7 +74,7 @@ describe('Cloud Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	describe('List Subcommand', () => {
+	describe('Cloud List Subcommand', () => {
 		const platform = capitalize(DEVICE_PLATFORM_NAME);
 		let args;
 
@@ -170,7 +170,7 @@ describe('Cloud Commands [@device]', () => {
 		});
 	});
 
-	describe('Compile Subcommand', () => {
+	describe('Cloud Compile Subcommand', () => {
 		it('Compiles firmware', async () => {
 			const args = ['cloud', 'compile', 'photon', PATH_PROJ_STROBY_INO, '--saveTo', strobyBinPath];
 			const { stdout, stderr, exitCode } = await cli.run(args);
@@ -215,7 +215,7 @@ describe('Cloud Commands [@device]', () => {
 		});
 	});
 
-	describe('Flash Subcommand', () => {
+	describe('Cloud Flash Subcommand', () => {
 		it('Flashes firmware', async () => {
 			const args = ['cloud', 'flash', DEVICE_NAME, PATH_PROJ_STROBY_INO];
 			const { stdout, stderr, exitCode } = await cli.run(args);
@@ -251,7 +251,7 @@ describe('Cloud Commands [@device]', () => {
 		});
 	});
 
-	describe('Remove Subcommand', () => {
+	describe('Cloud Remove Subcommand', () => {
 		afterEach(async () => {
 			await cli.run(['cloud', 'claim', DEVICE_ID], { reject: true });
 			await delay(5000);
@@ -271,7 +271,7 @@ describe('Cloud Commands [@device]', () => {
 		});
 	});
 
-	describe('Claim Subcommand', () => {
+	describe('Cloud Claim Subcommand', () => {
 		// TODO (mirande): unclaim beforeEach..?
 		it('Claims device', async () => {
 			const id = DEVICE_ID.toLowerCase();
@@ -333,7 +333,7 @@ describe('Cloud Commands [@device]', () => {
 		});
 	});
 
-	describe('Name Subcommand', () => {
+	describe('Cloud Name Subcommand', () => {
 		afterEach(async () => {
 			await cli.revertDeviceName();
 		});

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -272,6 +272,7 @@ describe('Cloud Commands [@device]', () => {
 	});
 
 	describe('Claim Subcommand', () => {
+		// TODO (mirande): unclaim beforeEach..?
 		it('Claims device', async () => {
 			const id = DEVICE_ID.toLowerCase();
 			const args = ['cloud', 'claim', id];

--- a/test/e2e/device.e2e.js
+++ b/test/e2e/device.e2e.js
@@ -58,44 +58,50 @@ describe('Device Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Removes device', async () => {
-		const args = ['device', 'remove', DEVICE_NAME, '--yes'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`releasing device ${DEVICE_NAME}`,
-			'Okay!'
-		];
+	describe('Device Remove Subcommand', () => {
+		it('Removes device', async () => {
+			const args = ['device', 'remove', DEVICE_NAME, '--yes'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`releasing device ${DEVICE_NAME}`,
+				'Okay!'
+			];
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Claims device', async () => {
-		const args = ['device', 'add', DEVICE_ID];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Claiming device ${DEVICE_ID}`,
-			`Successfully claimed device ${DEVICE_ID}`
-		];
+	describe('Device Claim Subcommand', () => {
+		it('Claims device', async () => {
+			const args = ['device', 'add', DEVICE_ID];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Claiming device ${DEVICE_ID}`,
+				`Successfully claimed device ${DEVICE_ID}`
+			];
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Names a device', async () => {
-		const name = `${DEVICE_NAME}-updated`;
-		const args = ['device', 'rename', DEVICE_ID, name];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const log = [
-			`Renaming device ${DEVICE_ID}`,
-			`Successfully renamed device ${DEVICE_ID} to: ${name}`
-		];
+	describe('Device Rename Subcommand', () => {
+		it('Renames a device', async () => {
+			const name = `${DEVICE_NAME}-updated`;
+			const args = ['device', 'rename', DEVICE_ID, name];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`Renaming device ${DEVICE_ID}`,
+				`Successfully renamed device ${DEVICE_ID} to: ${name}`
+			];
 
-		expect(stdout.split('\n')).to.include.members(log);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 });
 

--- a/test/e2e/function.e2e.js
+++ b/test/e2e/function.e2e.js
@@ -55,32 +55,36 @@ describe('Function Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Lists available functions', async () => {
-		const { stdout, stderr, exitCode } = await cli.run(['function', 'list']);
+	describe('Function List Subcommand', () => {
+		it('Lists available functions', async () => {
+			const { stdout, stderr, exitCode } = await cli.run(['function', 'list']);
 
-		expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
-		expect(stdout).to.include('int toggle(String args)');
-		expect(stdout).to.include('int check(String args)');
-		expect(stderr).to.include('polling server to see what devices are online, and what functions are available');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
+			expect(stdout).to.include('int toggle(String args)');
+			expect(stdout).to.include('int check(String args)');
+			expect(stderr).to.include('polling server to see what devices are online, and what functions are available');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Calls a function', async () => {
-		const args = ['function', 'call', DEVICE_NAME, 'check'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+	describe('Function Call Subcommand', () => {
+		it('Calls a function', async () => {
+			const args = ['function', 'call', DEVICE_NAME, 'check'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal('200');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
+			expect(stdout).to.equal('200');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 
-	it('Fails when attempting to call an unknown function', async () => {
-		const args = ['function', 'call', DEVICE_NAME, 'WATNOPE'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Fails when attempting to call an unknown function', async () => {
+			const args = ['function', 'call', DEVICE_NAME, 'WATNOPE'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.equal('Function call failed: Function WATNOPE not found');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(1);
+			expect(stdout).to.equal('Function call failed: Function WATNOPE not found');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
+		});
 	});
 });
 

--- a/test/e2e/identify.e2e.js
+++ b/test/e2e/identify.e2e.js
@@ -1,5 +1,4 @@
 const { expect } = require('../setup');
-const { runForAtLeast } = require('../lib/mocha-utils');
 const cli = require('../lib/cli');
 const {
 	DEVICE_ID
@@ -24,11 +23,12 @@ describe('Identify Commands [@device]', () => {
 		await cli.startListeningMode();
 	});
 
-	after(runForAtLeast(15, async () => {
+	after(async () => {
 		await cli.stopListeningMode();
+		await cli.waitUntilOnline();
 		await cli.logout();
 		await cli.setDefaultProfile();
-	}));
+	});
 
 	it('Shows `help` content', async () => {
 		const { stdout, stderr, exitCode } = await cli.run(['help', 'identify']);

--- a/test/e2e/keys.e2e.js
+++ b/test/e2e/keys.e2e.js
@@ -77,7 +77,7 @@ describe('Keys Commands [@device]', function cliKeysCommands(){
 		expect(exitCode).to.equal(0);
 	});
 
-	describe('New Subcommand', () => {
+	describe('Keys New Subcommand', () => {
 		const filename = path.join(PATH_TMP_DIR, `${DEVICE_NAME}.pem`);
 		const expectedKeys = [`${DEVICE_NAME}.der`, `${DEVICE_NAME}.pem`, `${DEVICE_NAME}.pub.pem`];
 
@@ -135,7 +135,7 @@ describe('Keys Commands [@device]', function cliKeysCommands(){
 		});
 	});
 
-	describe('Save Subcommand', () => {
+	describe('Keys Save Subcommand', () => {
 		const filename = path.join(PATH_TMP_DIR, `${DEVICE_NAME}.pem`);
 		const expectedKeys = [`${DEVICE_NAME}.der`, `${DEVICE_NAME}.pub.pem`];
 		const help = [
@@ -183,7 +183,7 @@ describe('Keys Commands [@device]', function cliKeysCommands(){
 		});
 	});
 
-	describe('Doctor Subcommand', () => {
+	describe('Keys Doctor Subcommand', () => {
 		before(async () => {
 			await cli.setTestProfileAndLogin();
 		});
@@ -216,7 +216,7 @@ describe('Keys Commands [@device]', function cliKeysCommands(){
 		});
 	});
 
-	describe('Server Subcommand', () => {
+	describe('Keys Server Subcommand', () => {
 		before(async () => {
 			await cli.setTestProfileAndLogin();
 		});
@@ -265,7 +265,7 @@ describe('Keys Commands [@device]', function cliKeysCommands(){
 		});
 	});
 
-	describe('Address Subcommand', () => {
+	describe('Keys Address Subcommand', () => {
 		it('Reads server address from device\'s server public key', async () => {
 			await cli.enterDFUMode();
 			const { stdout, stderr, exitCode } = await cli.run(['keys', 'address']);
@@ -288,7 +288,7 @@ describe('Keys Commands [@device]', function cliKeysCommands(){
 		});
 	});
 
-	describe('Protocol Subcommand', () => {
+	describe('Keys Protocol Subcommand', () => {
 		it('Reads server address from device\'s server public key', async () => {
 			await cli.enterDFUMode();
 			const { stdout, stderr, exitCode } = await cli.run(['keys', 'protocol']);

--- a/test/e2e/keys.e2e.js
+++ b/test/e2e/keys.e2e.js
@@ -1,6 +1,5 @@
 const path = require('path');
 const { expect } = require('../setup');
-const { delay } = require('../lib/mocha-utils');
 const dfuUtil = require('../lib/dfu-util');
 const openSSL = require('../lib/open-ssl');
 const cli = require('../lib/cli');
@@ -13,8 +12,8 @@ const {
 } = require('../lib/env');
 
 
-describe('Keys Commands [@device]', () => {
-	const extendedTimeout = 5 * 60 * 1000;
+describe('Keys Commands [@device]', function cliKeysCommands(){
+	this.timeout(5 * 60 * 1000);
 
 	const help = [
 		'Manage your device\'s key pair and server public key',
@@ -84,6 +83,7 @@ describe('Keys Commands [@device]', () => {
 
 		afterEach(async () => {
 			await cli.resetDevice();
+			await cli.waitUntilOnline();
 		});
 
 		it('Generate a new set of keys for your device', async () => {
@@ -150,16 +150,6 @@ describe('Keys Commands [@device]', () => {
 			'  --force  Force overwriting of <filename> if it exists  [boolean] [default: false]'
 		];
 
-		afterEach(async () => {
-			await cli.resetDevice();
-		});
-
-		after(async () => {
-			// TODO (mirande): replace w/ `cli.waitForDeviceToGetOnline()`
-			// helper when available
-			await delay(30 * 1000);
-		});
-
 		it('Saves device keys', async () => {
 			await cli.enterDFUMode();
 			const { stdout, stderr, exitCode } = await cli.run(['keys', 'save', filename]);
@@ -171,6 +161,9 @@ describe('Keys Commands [@device]', () => {
 				const stats = await fs.stat(path.join(PATH_TMP_DIR, key));
 				expect(stats.size).to.be.above(100);
 			}
+
+			await cli.resetDevice();
+			await cli.waitUntilOnline();
 		});
 
 		it('Fails to save device keys when device is not in DFU mode', async () => {
@@ -193,7 +186,6 @@ describe('Keys Commands [@device]', () => {
 	describe('Doctor Subcommand', () => {
 		before(async () => {
 			await cli.setTestProfileAndLogin();
-			await cli.flashStrobyFirmwareOTAForTest();
 		});
 
 		it('Fixes devices keys', async () => {
@@ -212,8 +204,8 @@ describe('Keys Commands [@device]', () => {
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 
-			await cli.waitForVariable('name', 'stroby');
-		}).timeout(extendedTimeout);
+			await cli.waitUntilOnline();
+		});
 
 		it('Fails to fix device keys when device is not in DFU mode', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['keys', 'doctor', DEVICE_ID]);
@@ -227,7 +219,6 @@ describe('Keys Commands [@device]', () => {
 	describe('Server Subcommand', () => {
 		before(async () => {
 			await cli.setTestProfileAndLogin();
-			await cli.flashStrobyFirmwareOTAForTest();
 		});
 
 		it('Switches server public keys', async () => {
@@ -239,8 +230,8 @@ describe('Keys Commands [@device]', () => {
 			expect(exitCode).to.equal(0);
 
 			await cli.resetDevice();
-			await cli.waitForVariable('name', 'stroby');
-		}).timeout(extendedTimeout);
+			await cli.waitUntilOnline();
+		});
 
 		it('Fails to switch server public keys when device is not in DFU mode', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['keys', 'server']);
@@ -254,7 +245,7 @@ describe('Keys Commands [@device]', () => {
 			const filename = path.join(PATH_TMP_DIR, `${DEVICE_NAME}-test.der`);
 			await cli.run(['keys', 'new', filename, '--protocol', 'udp'], { reject: true });
 			const args = ['keys', 'server', filename, '--deviceType', DEVICE_PLATFORM_NAME];
-			const { stdout, stderr, exitCode } = await cli.debug(args);
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
 			expect(stdout).to.equal('Okay!  Formated server key file generated for this type of device.');
 			// TODO (mirande): fix `(node:3228) [DEP0005] DeprecationWarning:
@@ -263,7 +254,7 @@ describe('Keys Commands [@device]', () => {
 			// methods instead.
 			expect(stderr).to.exist;
 			expect(exitCode).to.equal(0);
-		}).timeout(extendedTimeout);
+		});
 
 		it('Fails when `--deviceType` is set but `filename` param is omitted', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['keys', 'server', '--deviceType', 'Electron']);
@@ -285,7 +276,8 @@ describe('Keys Commands [@device]', () => {
 			expect(exitCode).to.equal(0);
 
 			await cli.resetDevice();
-		}).timeout(extendedTimeout);
+			await cli.waitUntilOnline();
+		});
 
 		it('Fails to save device keys when device is not in DFU mode', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['keys', 'address']);
@@ -308,7 +300,8 @@ describe('Keys Commands [@device]', () => {
 			expect(exitCode).to.equal(0);
 
 			await cli.resetDevice();
-		}).timeout(extendedTimeout);
+			await cli.waitUntilOnline();
+		});
 
 		it('Fails to save device keys when device is not in DFU mode', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['keys', 'protocol']);

--- a/test/e2e/library.e2e.js
+++ b/test/e2e/library.e2e.js
@@ -87,7 +87,7 @@ describe('Library Commands', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	describe('Search Subcommand', () => {
+	describe('Library Search Subcommand', () => {
 		after(async () => {
 			await cli.setTestProfileAndLogin();
 		});
@@ -182,7 +182,7 @@ describe('Library Commands', () => {
 		});
 	});
 
-	describe('View Subcommand', () => {
+	describe('Library View Subcommand', () => {
 		after(async () => {
 			await cli.setTestProfileAndLogin();
 		});
@@ -377,7 +377,7 @@ describe('Library Commands', () => {
 		});
 	});
 
-	describe('List Subcommand', () => {
+	describe('Library List Subcommand', () => {
 		after(async () => {
 			await cli.setTestProfileAndLogin();
 		});
@@ -512,7 +512,7 @@ describe('Library Commands', () => {
 		});
 	});
 
-	describe('Add Subcommand', () => {
+	describe('Library Add Subcommand', () => {
 		const libDirPath = path.join(PATH_TMP_DIR, 'lib-valid');
 
 		beforeEach(async () => {
@@ -632,7 +632,7 @@ describe('Library Commands', () => {
 		});
 	});
 
-	describe('Copy Subcommand', () => {
+	describe('Library Copy Subcommand', () => {
 		it('Copies a library to a project', async () => {
 			const opts = { cwd: projPath };
 			const args = ['library', 'copy', 'dotstar'];
@@ -699,7 +699,7 @@ describe('Library Commands', () => {
 		});
 	});
 
-	describe('Install Subcommand', () => {
+	describe('Library Install Subcommand', () => {
 		it('Installs a library to a project', async () => {
 			const name = 'dotstar';
 			const opts = { cwd: projPath };
@@ -801,7 +801,7 @@ describe('Library Commands', () => {
 		});
 	});
 
-	describe('Create Subcommand', () => {
+	describe('Library Create Subcommand', () => {
 		it('Creates a library', async () => {
 			const name = 'testlib';
 			const version = '1.0.0';
@@ -938,7 +938,7 @@ describe('Library Commands', () => {
 		});
 	});
 
-	describe('Migrate Subcommand', () => {
+	describe('Library Migrate Subcommand', () => {
 		const { libraryTestResources } = require('particle-commands');
 		const libV1Path = path.join(PATH_TMP_DIR, 'lib-v1');
 		const libV2Path = path.join(PATH_TMP_DIR, 'lib-v2');

--- a/test/e2e/project.e2e.js
+++ b/test/e2e/project.e2e.js
@@ -54,82 +54,84 @@ describe('Project Commands', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Creates a project', async () => {
-		const args = ['project', 'create', PATH_TMP_DIR];
-		const subprocess = cli.run(args);
+	describe('Project Create Subcommand', () => {
+		it('Creates a project', async () => {
+			const args = ['project', 'create', PATH_TMP_DIR];
+			const subprocess = cli.run(args);
 
-		await delay(1000);
-		subprocess.stdin.write(projName);
-		subprocess.stdin.end('\n');
+			await delay(1000);
+			subprocess.stdin.write(projName);
+			subprocess.stdin.end('\n');
 
-		const { stdout, stderr, exitCode } = await subprocess;
+			const { stdout, stderr, exitCode } = await subprocess;
 
-		expect(await fs.exists(localProjPath)).to.equal(true);
-		expect(stdout).to.include(`Initializing project in directory ${localProjPath}...`);
-		expect(stdout).to.include(`A new project has been initialized in directory ${localProjPath}`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(await fs.exists(localProjPath)).to.equal(true);
+			expect(stdout).to.include(`Initializing project in directory ${localProjPath}...`);
+			expect(stdout).to.include(`A new project has been initialized in directory ${localProjPath}`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 
-		const contents = await fs.getDirectoryContents(localProjPath, { maxDepth: 2 });
-		const stripRoot = (x) => x.replace(localProjPath + path.sep, '');
+			const contents = await fs.getDirectoryContents(localProjPath, { maxDepth: 2 });
+			const stripRoot = (x) => x.replace(localProjPath + path.sep, '');
 
-		expect(contents.map(stripRoot)).to.eql([
-			'README.md',
-			'project.properties',
-			'src',
-			'src/test-proj.ino'
-		]);
-	});
+			expect(contents.map(stripRoot)).to.eql([
+				'README.md',
+				'project.properties',
+				'src',
+				'src/test-proj.ino'
+			]);
+		});
 
-	it('Creates a project in the default location', async () => {
-		const args = ['project', 'create'];
-		const subprocess = cli.run(args);
+		it('Creates a project in the default location', async () => {
+			const args = ['project', 'create'];
+			const subprocess = cli.run(args);
 
-		await delay(1000);
-		subprocess.stdin.write(projName);
-		subprocess.stdin.write('\n');
-		await delay(1000);
-		subprocess.stdin.write('y');
-		subprocess.stdin.end('\n');
+			await delay(1000);
+			subprocess.stdin.write(projName);
+			subprocess.stdin.write('\n');
+			await delay(1000);
+			subprocess.stdin.write('y');
+			subprocess.stdin.end('\n');
 
-		const { stdout, stderr, exitCode } = await subprocess;
+			const { stdout, stderr, exitCode } = await subprocess;
 
-		expect(await fs.exists(globalProjPath)).to.equal(true);
-		expect(stdout).to.include(`Initializing project in directory ${globalProjPath}...`);
-		expect(stdout).to.include(`A new project has been initialized in directory ${globalProjPath}`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(await fs.exists(globalProjPath)).to.equal(true);
+			expect(stdout).to.include(`Initializing project in directory ${globalProjPath}...`);
+			expect(stdout).to.include(`A new project has been initialized in directory ${globalProjPath}`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 
-		const contents = await fs.getDirectoryContents(globalProjPath, { maxDepth: 2 });
-		const stripRoot = (x) => x.replace(globalProjPath + path.sep, '');
+			const contents = await fs.getDirectoryContents(globalProjPath, { maxDepth: 2 });
+			const stripRoot = (x) => x.replace(globalProjPath + path.sep, '');
 
-		expect(contents.map(stripRoot)).to.eql([
-			'README.md',
-			'project.properties',
-			'src',
-			'src/test-proj.ino'
-		]);
-	});
+			expect(contents.map(stripRoot)).to.eql([
+				'README.md',
+				'project.properties',
+				'src',
+				'src/test-proj.ino'
+			]);
+		});
 
-	it('Creates a project using the `--name` flag', async () => {
-		const args = ['project', 'create', '--name', projName, PATH_TMP_DIR];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+		it('Creates a project using the `--name` flag', async () => {
+			const args = ['project', 'create', '--name', projName, PATH_TMP_DIR];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(await fs.exists(localProjPath)).to.equal(true);
-		expect(stdout).to.include(`Initializing project in directory ${localProjPath}...`);
-		expect(stdout).to.include(`A new project has been initialized in directory ${localProjPath}`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(await fs.exists(localProjPath)).to.equal(true);
+			expect(stdout).to.include(`Initializing project in directory ${localProjPath}...`);
+			expect(stdout).to.include(`A new project has been initialized in directory ${localProjPath}`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 
-		const contents = await fs.getDirectoryContents(localProjPath, { maxDepth: 2 });
-		const stripRoot = (x) => x.replace(localProjPath + path.sep, '');
+			const contents = await fs.getDirectoryContents(localProjPath, { maxDepth: 2 });
+			const stripRoot = (x) => x.replace(localProjPath + path.sep, '');
 
-		expect(contents.map(stripRoot)).to.eql([
-			'README.md',
-			'project.properties',
-			'src',
-			'src/test-proj.ino'
-		]);
+			expect(contents.map(stripRoot)).to.eql([
+				'README.md',
+				'project.properties',
+				'src',
+				'src/test-proj.ino'
+			]);
+		});
 	});
 });
 

--- a/test/e2e/serial.e2e.js
+++ b/test/e2e/serial.e2e.js
@@ -1,7 +1,6 @@
 const words = require('lodash/words');
 const capitalize = require('lodash/capitalize');
 const { expect } = require('../setup');
-const { runForAtLeast } = require('../lib/mocha-utils');
 const cli = require('../lib/cli');
 const {
 	DEVICE_ID,
@@ -35,9 +34,10 @@ describe('Serial Commands [@device]', () => {
 		await cli.startListeningMode();
 	});
 
-	after(runForAtLeast(15, async () => {
+	after(async () => {
 		await cli.stopListeningMode();
-	}));
+		await cli.waitUntilOnline();
+	});
 
 	it('Shows `help` content', async () => {
 		const { stdout, stderr, exitCode } = await cli.run(['help', 'serial']);

--- a/test/e2e/update.e2e.js
+++ b/test/e2e/update.e2e.js
@@ -1,5 +1,4 @@
 const { expect } = require('../setup');
-const { delay } = require('../lib/mocha-utils');
 const cli = require('../lib/cli');
 const {
 	DEVICE_ID,
@@ -53,7 +52,7 @@ describe('Update Commands [@device]', () => {
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
 
-		await delay(5000);
+		await cli.waitUntilOnline();
 		const cmd = await cli.run(['usb', 'list']);
 
 		expect(cmd.stdout).to.include(DEVICE_ID);

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -69,7 +69,7 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 		expect(exitCode).to.equal(0);
 	});
 
-	describe('List Subcommand', () => {
+	describe('USB List Subcommand', () => {
 		const platform = capitalize(DEVICE_PLATFORM_NAME);
 		let args;
 
@@ -167,7 +167,7 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 		});
 	});
 
-	describe('Start-Listening Subcommand', () => {
+	describe('USB Start-Listening Subcommand', () => {
 		afterEach(async () => {
 			await cli.run(['usb', 'stop-listening']);
 			await cli.waitUntilOnline();
@@ -186,7 +186,7 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 		});
 	});
 
-	describe('Stop-Listening Subcommand', () => {
+	describe('USB Stop-Listening Subcommand', () => {
 		beforeEach(async () => {
 			await cli.run(['usb', 'start-listening']);
 			await delay(2000);
@@ -209,7 +209,7 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 		});
 	});
 
-	describe('Setup-Done Subcommand', () => {
+	describe('USB Setup-Done Subcommand', () => {
 		it('Sets and clears the setup done flag', async () => {
 			await cli.run(['usb', 'setup-done', '--reset']);
 			await delay(2000);
@@ -230,7 +230,7 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 		});
 	});
 
-	describe('DFU Subcommand', () => {
+	describe('USB DFU Subcommand', () => {
 		after(async () => {
 			await cli.resetDevice();
 			await cli.waitUntilOnline();
@@ -264,7 +264,7 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 		});
 	});
 
-	describe('Cloud Status Subcommand', () => {
+	describe('USB Cloud Status Subcommand', () => {
 		it('Reports current cloud connection status', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['usb', 'cloud-status', DEVICE_NAME]);
 

--- a/test/e2e/variable.e2e.js
+++ b/test/e2e/variable.e2e.js
@@ -59,76 +59,82 @@ describe('Variable Commands [@device]', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Lists all available variables', async () => {
-		const { stdout, stderr, exitCode } = await cli.run(['variable', 'list']);
+	describe('Variable List Subcommand', () => {
+		it('Lists all available variables', async () => {
+			const { stdout, stderr, exitCode } = await cli.run(['variable', 'list']);
 
-		expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
-		expect(stdout).to.include('name (string)');
-		expect(stdout).to.include('version (int32)');
-		expect(stdout).to.include('blinking (int32)');
-		expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
+			expect(stdout).to.include('name (string)');
+			expect(stdout).to.include('version (int32)');
+			expect(stdout).to.include('blinking (int32)');
+			expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists all available variables (alt)', async () => {
+			const { stdout, stderr, exitCode } = await cli.run(['variable', 'get']);
+
+			expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
+			expect(stdout).to.include('name (string)');
+			expect(stdout).to.include('version (int32)');
+			expect(stdout).to.include('blinking (int32)');
+			expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Lists variables available on device and prompts to pick', async () => {
+			const subprocess = cli.run(['variable', 'get', DEVICE_ID]);
+
+			await delay(1000);
+			subprocess.stdin.end('\n');
+
+			const { stdout, stderr, exitCode } = await subprocess;
+			const log = stripANSI(stdout);
+
+			expect(log).to.include('Which variable did you want?');
+			expect(log).to.include(`name (string)${os.EOL}stroby`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Lists all available variables (alt)', async () => {
-		const { stdout, stderr, exitCode } = await cli.run(['variable', 'get']);
+	describe('Variable Get Subcommand', () => {
+		it('Gets a variable by name', async () => {
+			const args = ['get', DEVICE_ID, 'version'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.include(`${DEVICE_NAME} (${DEVICE_ID}) has`);
-		expect(stdout).to.include('name (string)');
-		expect(stdout).to.include('version (int32)');
-		expect(stdout).to.include('blinking (int32)');
-		expect(stderr).to.include('polling server to see what devices are online, and what variables are available');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.equal('42');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Gets a variable by name with timestamp', async () => {
+			const args = ['variable', 'get', DEVICE_ID, 'version', '--time'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const [timestamp, version] = stdout.split(', ');
+
+			expect(timestamp.split(':')).to.have.lengthOf(4);
+			expect(version).to.equal('42');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Lists variables available on device and prompts to pick', async () => {
-		const subprocess = cli.run(['variable', 'get', DEVICE_ID]);
+	describe('Variable Monitor Subcommand', () => {
+		it('Monitors a variable', async () => {
+			const args = ['variable', 'monitor', DEVICE_ID, 'version', '--delay', 1000];
+			const subprocess = cli.run(args);
 
-		await delay(1000);
-		subprocess.stdin.end('\n');
+			await delay(5000);
+			subprocess.cancel(); // CTRL-C
 
-		const { stdout, stderr, exitCode } = await subprocess;
-		const log = stripANSI(stdout);
+			const { all, isCanceled } = await subprocess;
+			const [msg, ...results] = all.split('\n');
 
-		expect(log).to.include('Which variable did you want?');
-		expect(log).to.include(`name (string)${os.EOL}stroby`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Gets a variable by name', async () => {
-		const args = ['get', DEVICE_ID, 'version'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.equal('42');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Gets a variable by name with timestamp', async () => {
-		const args = ['variable', 'get', DEVICE_ID, 'version', '--time'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-		const [timestamp, version] = stdout.split(', ');
-
-		expect(timestamp.split(':')).to.have.lengthOf(4);
-		expect(version).to.equal('42');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Monitors a variable', async () => {
-		const args = ['variable', 'monitor', DEVICE_ID, 'version', '--delay', 1000];
-		const subprocess = cli.run(args);
-
-		await delay(5000);
-		subprocess.cancel(); // CTRL-C
-
-		const { all, isCanceled } = await subprocess;
-		const [msg, ...results] = all.split('\n');
-
-		expect(msg).to.equal('Hit CTRL-C to stop!');
-		expect(results).to.have.lengthOf.above(2);
-		expect(isCanceled).to.equal(true);
+			expect(msg).to.equal('Hit CTRL-C to stop!');
+			expect(results).to.have.lengthOf.above(2);
+			expect(isCanceled).to.equal(true);
+		});
 	});
 });
 

--- a/test/e2e/webhook.e2e.js
+++ b/test/e2e/webhook.e2e.js
@@ -63,68 +63,74 @@ describe('Webhook Commands', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Creates a webhook', async () => {
-		const args = ['webhook', 'create', event, url];
-		const { stdout, stderr, exitCode } = await cli.run(args);
+	describe('Webhook Create Subcommand', () => {
+		it('Creates a webhook', async () => {
+			const args = ['webhook', 'create', event, url];
+			const { stdout, stderr, exitCode } = await cli.run(args);
 
-		expect(stdout).to.include('Successfully created webhook with ID');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.include('Successfully created webhook with ID');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Lists all webhooks', async () => {
-		await cli.run(['webhook', 'create', event, url]);
+	describe('Webhook List Subcommand', () => {
+		it('Lists all webhooks', async () => {
+			await cli.run(['webhook', 'create', event, url]);
 
-		const { stdout, stderr, exitCode } = await cli.run(['webhook', 'list']);
-		const hookIDs = matches(stdout, /Hook ID (.*) is watching for "test-event"/g);
+			const { stdout, stderr, exitCode } = await cli.run(['webhook', 'list']);
+			const hookIDs = matches(stdout, /Hook ID (.*) is watching for "test-event"/g);
 
-		expect(hookIDs).to.have.lengthOf.at.least(1);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(hookIDs).to.have.lengthOf.at.least(1);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
 	});
 
-	it('Deletes a webhook by ID', async () => {
-		const args = ['webhook', 'create', event, url];
-		await cli.run(args);
-		const { stdout: log } = await cli.run(args);
-		const id = matches(log, /Successfully created webhook with ID (.*)$/g)[0];
-		await cli.run(args);
+	describe('Webhook Delete Subcommand', () => {
+		it('Deletes a webhook by ID', async () => {
+			const args = ['webhook', 'create', event, url];
+			await cli.run(args);
+			const { stdout: log } = await cli.run(args);
+			const id = matches(log, /Successfully created webhook with ID (.*)$/g)[0];
+			await cli.run(args);
 
-		expect(id).to.be.a('string').with.lengthOf.above(10);
+			expect(id).to.be.a('string').with.lengthOf.above(10);
 
-		const { stdout, stderr, exitCode } = await cli.run(['webhook', 'delete', id]);
+			const { stdout, stderr, exitCode } = await cli.run(['webhook', 'delete', id]);
 
-		expect(stdout).to.equal('');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.equal('');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 
-		const { stdout: list } = await cli.run(['webhook', 'list']);
-		const hookIDs = matches(list, /Hook ID (.*) is watching for "test-event"/g);
+			const { stdout: list } = await cli.run(['webhook', 'list']);
+			const hookIDs = matches(list, /Hook ID (.*) is watching for "test-event"/g);
 
-		expect(hookIDs).to.not.include(id);
-	});
+			expect(hookIDs).to.not.include(id);
+		});
 
-	// TODO (mirande): only deletes one hook at a time - fix!
-	it.skip('BUG: Deletes all webhooks', async () => {
-		const { stdout: log } = await cli.run(['webhook', 'create', event, url]);
+		// TODO (mirande): only deletes one hook at a time - fix!
+		it.skip('BUG: Deletes all webhooks', async () => {
+			const { stdout: log } = await cli.run(['webhook', 'create', event, url]);
 
-		expect(log).to.include('Successfully created webhook with ID');
+			expect(log).to.include('Successfully created webhook with ID');
 
-		const subprocess = cli.run(['webhook', 'delete', 'all']);
+			const subprocess = cli.run(['webhook', 'delete', 'all']);
 
-		await delay(1000);
-		subprocess.stdin.write('y');
-		subprocess.stdin.end('\n');
+			await delay(1000);
+			subprocess.stdin.write('y');
+			subprocess.stdin.end('\n');
 
-		const { stdout, stderr, exitCode } = await subprocess;
+			const { stdout, stderr, exitCode } = await subprocess;
 
-		expect(stdout).to.equal('');
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
+			expect(stdout).to.equal('');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 
-		const { stdout: list } = await cli.run(['webhook', 'list']);
+			const { stdout: list } = await cli.run(['webhook', 'list']);
 
-		expect(list).to.include('Found 0 hooks registered');
+			expect(list).to.include('Found 0 hooks registered');
+		});
 	});
 });
 

--- a/test/lib/cli.js
+++ b/test/lib/cli.js
@@ -83,16 +83,14 @@ module.exports.stopListeningMode = () => {
 	return run(['usb', 'stop-listening', DEVICE_ID], { reject: true });
 };
 
-module.exports.enterDFUMode = async (device = DEVICE_ID) => {
+module.exports.enterDFUMode = async () => {
 	const { run } = module.exports;
-	return run(['usb', 'dfu', device], { reject: true });
+	return run(['usb', 'dfu', DEVICE_ID], { reject: true });
 };
 
-// TODO (mirande): add w/ `cli.waitForDeviceToGetOnline()` helper
-module.exports.resetDevice = async (device = DEVICE_ID) => {
+module.exports.resetDevice = async () => {
 	const { run } = module.exports;
-	await run(['usb', 'reset', device], { reject: true });
-	await delay(45 * 1000);
+	await run(['usb', 'reset', DEVICE_ID], { reject: true });
 };
 
 module.exports.compileBlankFirmwareForTest = async (platform = 'photon') => {
@@ -138,6 +136,18 @@ module.exports.getNameVariable = async () => {
 	const { run } = module.exports;
 	const { stdout } = await run(['get', DEVICE_NAME, 'name'], { reject: true });
 	return stdout;
+};
+
+module.exports.getCloudConnectionStatus = async () => {
+	const { run } = module.exports;
+	const args = ['usb', 'cloud-status', DEVICE_ID];
+	return run(args, { reject: true });
+};
+
+module.exports.waitUntilOnline = async () => {
+	const { run } = module.exports;
+	const args = ['usb', 'cloud-status', DEVICE_ID, '--until', 'connected', '--timeout', 5 * 60 * 1000];
+	return run(args, { reject: true });
 };
 
 module.exports.waitForVariable = async (name, value) => {


### PR DESCRIPTION
## Description

Replaced adhoc delays in `e2e` tests w/ `cli.waitUntilOnline()` helper plus a few more tweaks to `e2e` test naming + grouping


## How to Test

1. set up your local environment to run `e2e` tests as [described here](https://github.com/particle-iot/particle-cli/blob/18f0b6500d0db9f09920d5d225a215cc5a1eaaf6/test/README.md)
2. run `npm run test:e2e`


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

