### PR TITLE
bugfix/ch58689/function-call-error-message

### DIFF
--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -231,7 +231,14 @@ module.exports = class ParticleApi {
 		const { UnauthorizedError } = module.exports;
 
 		if ([400, 401].includes(err.statusCode)){
-			return Promise.reject(new UnauthorizedError(err.shortErrorDescription));
+			const { body = {}, errorDescription, shortErrorDescription, } = err;
+			let msg = shortErrorDescription;
+
+			if (!msg){
+				msg = body.error_description || body.error || errorDescription;
+			}
+
+			return Promise.reject(new UnauthorizedError(msg));
 		}
 		return Promise.reject(err);
 	}

--- a/test/e2e/subscribe.e2e.js
+++ b/test/e2e/subscribe.e2e.js
@@ -317,7 +317,7 @@ describe('Subscribe Commands [@device]', () => {
 		await cli.logout();
 		const { stdout, stderr, exitCode } = await cli.run(['subscribe']);
 
-		expect(stdout).to.include('Error fetching event stream: Invalid access token');
+		expect(stdout).to.include('Error fetching event stream: The access token provided is invalid.');
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(1);
 	});


### PR DESCRIPTION
## Description

When device is offline or otherwise unreachable, the error message shown was misleading: `Error calling function: 'foo': Invalid access token`


## How to Test

run `particle function call <device> <fn>` against an offline device an verify the error message is (more) accurate


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

