### PR TITLE
bugfix/ch61282/doctor-keys-params

### DIFF
--- a/src/cmd/doctor.js
+++ b/src/cmd/doctor.js
@@ -349,7 +349,7 @@ module.exports = class DoctorCommand {
 			.then(() => this._verifyDeviceOwnership())
 			.then(() => this._enterDfuMode())
 			.then(() => {
-				return this.command('keys').writeServerPublicKey();
+				return this.command('keys').writeServerPublicKey({ params: {} });
 				// keys servers doesn't cause the device to reset so it is still in DFU mode
 			})
 			.then(() => {
@@ -357,7 +357,11 @@ module.exports = class DoctorCommand {
 					console.log(chalk.red('!'), 'Skipping device key because it does not report its device ID over USB');
 					return;
 				}
-				return this.command('keys').keyDoctor(this.device.deviceId);
+				return this.command('keys').keyDoctor({
+					params: {
+						deviceID: this.device.deviceId
+					}
+				});
 			})
 			.catch(this._catchSkipStep);
 	}

--- a/test/e2e/subscribe.e2e.js
+++ b/test/e2e/subscribe.e2e.js
@@ -119,7 +119,8 @@ describe('Subscribe Commands [@device]', () => {
 
 	it('Subscribes to `--all` events with partial matching', async () => {
 		await cli.callStrobyStart(DEVICE_NAME);
-		const eventName = 't';
+
+		const eventName = DEVICE_ID.substring(0, 4);
 		const args = ['subscribe', '--all', eventName];
 		const { events, received: [msg], isCanceled } = await runAndCollectEventOutput(args);
 


### PR DESCRIPTION
## Description

running the `particle doctor` command results in `Error: Cannot destructure property 'protocol' of 'undefined' as it is undefined` ([ch](https://app.clubhouse.io/particle/story/61282/particle-doctor-errors-with-cannot-destructure-property-protocol-of-undefined-as-it-is-undefined))


## How to Test

unplug all devices then plug in a Gen 2 device (e.g. `photon`, `electron`, etc) via USB, run `particle doctor`, and proceed through the steps until completion.


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [ ] CI is passing

