### PR TITLE
bugfix/ch61378/flash-tinker-product-device

### DIFF
--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -247,7 +247,22 @@ module.exports = class CloudCommand extends CLICommandBase {
 
 		return createAPI().getDeviceAttributes(deviceId)
 			.then((attrs) => {
-				const productId = product ? attrs.platform_id :attrs.product_id;
+				let productId;
+
+				if (product || attrs.platform_id !== attrs.product_id){
+					if (!product){
+						product = attrs.product_id;
+					}
+
+					if (!this.isDeviceId(deviceId)){
+						deviceId = attrs.id;
+					}
+
+					productId = attrs.platform_id;
+				} else {
+					productId = attrs.product_id;
+				}
+
 				const spec = _.find(specs, { productId });
 
 				if (spec){
@@ -258,6 +273,8 @@ module.exports = class CloudCommand extends CLICommandBase {
 					if (spec.productName){
 						throw new VError(`I don't have a ${filePath} binary for ${spec.productName}.`);
 					}
+				} else {
+					throw new Error(`Unable to find ${filePath} for platform ${productId}`);
 				}
 			})
 			.then((fileMapping) => {

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -247,7 +247,7 @@ module.exports = class CloudCommand extends CLICommandBase {
 
 		return createAPI().getDeviceAttributes(deviceId)
 			.then((attrs) => {
-				let productId;
+				let productId = attrs.platform_id; // b/c legacy naming
 
 				if (product || attrs.platform_id !== attrs.product_id){
 					if (!product){
@@ -257,10 +257,6 @@ module.exports = class CloudCommand extends CLICommandBase {
 					if (!this.isDeviceId(deviceId)){
 						deviceId = attrs.id;
 					}
-
-					productId = attrs.platform_id;
-				} else {
-					productId = attrs.product_id;
 				}
 
 				const spec = _.find(specs, { productId });

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -327,6 +327,25 @@ describe('Cloud Commands [@device]', () => {
 			await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductFunction()` helper
 		});
 
+		it('Flashes a `known app` on to a product device using legacy command', async () => {
+			const args = ['flash', PRODUCT_01_DEVICE_01_NAME, 'tinker'];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+			const log = [
+				`marking device ${PRODUCT_01_DEVICE_01_ID} as a development device`,
+				`attempting to flash firmware to your device ${PRODUCT_01_DEVICE_01_ID}`,
+				'Flash device OK: Update started',
+				`device ${PRODUCT_01_DEVICE_01_ID} is now marked as a developement device and will NOT receive automatic product firmware updates.`,
+				'to resume normal updates, please visit:',
+				`https://console.particle.io/${PRODUCT_01_ID}/devices/unmark-development/${PRODUCT_01_DEVICE_01_ID}`
+			];
+
+			expect(stdout.split('\n')).to.include.members(log);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+
+			await delay(40 * 1000); // TODO (mirande): replace w/ `cli.waitForProductFunction()` helper
+		});
+
 		it('Fails to flash a product device when `device` param is not an id', async () => {
 			const args = ['cloud', 'flash', PRODUCT_01_DEVICE_01_NAME, PATH_PROJ_BLANK_INO, '--product', PRODUCT_01_ID];
 			const { stdout, stderr, exitCode } = await cli.run(args);


### PR DESCRIPTION
## Description

running the `particle flash <my-device> tinker` when `<my-device>` is in a product fails with: `Failed to flash <device-name>: Cannot read property 'map' of undefined` ([ch](https://app.clubhouse.io/particle/story/61378/particle-flash-my-device-tinker-fails-when-device-is-in-a-product))


## How to Test

using a product device, run `particle flash <my-device> tinker` then repeat that command using a non-product device and verify that both devices are flashed appropriately


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

