### PR TITLE
feature/ch61878/flash-error-include-filename

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -59,12 +59,12 @@ module.exports = class FlashCommand {
 
 				try {
 					stats = fs.statSync(binary);
-				} catch (ex){
+				} catch (error){
 					// file does not exist
 					binary = dfu.checkKnownApp(binary);
 
 					if (binary === undefined){
-						throw new Error('file does not exist and no known app found.');
+						throw new Error(`file does not exist and no known app found. tried: \`${error.path}\``);
 					} else {
 						flashingKnownApp = true;
 						return binary;

--- a/test/e2e/flash.e2e.js
+++ b/test/e2e/flash.e2e.js
@@ -185,7 +185,7 @@ describe('Flash Commands [@device]', () => {
 		await cli.waitForVariable('name', 'blank');
 	});
 
-	it('Fails to flash missing or unrecognized` app', async () => {
+	it('Fails to flash missing or unrecognized app', async () => {
 		const args = ['flash', DEVICE_NAME, 'WATNOPE.bin'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 		const log = [
@@ -197,7 +197,7 @@ describe('Flash Commands [@device]', () => {
 		expect(exitCode).to.equal(1);
 	});
 
-	it('Fails to flash missing or unrecognized` app when using usb', async () => {
+	it('Fails to flash missing or unrecognized app when using usb', async () => {
 		await cli.enterDFUMode();
 		const args = ['flash', 'WATNOPE.bin', '--usb'];
 		const { stdout, stderr, exitCode } = await cli.run(args);
@@ -210,4 +210,3 @@ describe('Flash Commands [@device]', () => {
 		expect(exitCode).to.equal(1);
 	});
 });
-


### PR DESCRIPTION
## Description

running the `particle flash <filename> --usb`  when `<filename>` doesn't exist results in an error which isn't super-helpful. this change adds `<filename>` to the error message. ([ch](https://app.clubhouse.io/particle/story/61878/update-particle-flash-error-message-to-indicate-filename))


## How to Test

with your device in DFU mode, run `particle flash <filename> --usb` where `<filename>` does not exist and verify the error message


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

