### PR TITLE
chore/fix-e2e-binary-size-assertions

### DIFF
--- a/test/e2e/compile.e2e.js
+++ b/test/e2e/compile.e2e.js
@@ -12,7 +12,7 @@ const {
 
 describe('Compile Commands', () => {
 	const strobyBinPath = path.join(PATH_TMP_DIR, 'photon-stroby-updated.bin');
-	const minBinSize = 4000;
+	const minBinSize = 3500;
 	const help = [
 		'Compile a source file, or directory using the cloud compiler',
 		'Usage: particle compile [options] <deviceType> [files...]',


### PR DESCRIPTION
## Description

Tune assertions in `particle compile` end-to-end tests to verify compiled binary so we're less likely to see failures as a result of updating the default Device OS version.


## How to Test

Review the [end-to-end tests setup guide](https://github.com/particle-iot/particle-cli/tree/master/test) and run `npm run test:ci`


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

