### PR TITLE
feature/ch69020/list-tokens-otp

### DIFF
--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -332,7 +332,7 @@ module.exports = class ApiClient {
 	}
 
 	//GET /v1/access_tokens
-	listTokens(username, password){
+	listTokens(username, password, otp){
 		const { request } = this;
 		let self = this;
 
@@ -344,6 +344,7 @@ module.exports = class ApiClient {
 					username: username,
 					password: password
 				},
+				qs: otp ? { otp } : undefined,
 				json: true
 			};
 

--- a/test/e2e/token.e2e.js
+++ b/test/e2e/token.e2e.js
@@ -170,7 +170,8 @@ describe('Token Commands', () => {
 		const subprocess = cli.run(['token', 'list']);
 
 		await delay(1000);
-		subprocess.stdin.write(PASSWORD);
+		subprocess.stdin.write(PASSWORD + '\n');
+		await delay(500);
 		subprocess.stdin.end('\n');
 
 		const { stdout, stderr, exitCode } = await subprocess;


### PR DESCRIPTION
## Description

running the `particle token list` command currently fails with `MfaRequiredError` when the current user has MFA enabled. ([ch](https://app.clubhouse.io/particle/story/69020))


## How to Test

Using an account w/ MFA enabled, run `particle token list` and provide the OTP generated by your authentication app. Tokens should be returned without error.

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing
