### PR TITLE
nyan: fix disconnect between command and description in help

### DIFF
--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -110,8 +110,8 @@ module.exports = ({ commandProcessor, root }) => {
 			return new CloudCommands(args).nyanMode(args);
 		},
 		examples: {
-			'$0 $command green': 'Make the device named `blue` start signaling',
-			'$0 $command green off': 'Make the device named `blue` stop signaling',
+			'$0 $command blue': 'Make the device named `blue` start signaling',
+			'$0 $command blue off': 'Make the device named `blue` stop signaling',
 			'$0 $command blue --product 12345': 'Make the device named `blue` within product `12345` start signaling'
 		}
 	});

--- a/src/cli/cloud.test.js
+++ b/src/cli/cloud.test.js
@@ -357,8 +357,8 @@ describe('Cloud Command-Line Interface', () => {
 					'  --product  Target a device within the given Product ID or Slug  [string]',
 					'',
 					'Examples:',
-					'  particle cloud nyan green                 Make the device named `blue` start signaling',
-					'  particle cloud nyan green off             Make the device named `blue` stop signaling',
+					'  particle cloud nyan blue                  Make the device named `blue` start signaling',
+					'  particle cloud nyan blue off              Make the device named `blue` stop signaling',
 					'  particle cloud nyan blue --product 12345  Make the device named `blue` within product `12345` start signaling',
 					''
 				].join(os.EOL));

--- a/test/e2e/cloud.e2e.js
+++ b/test/e2e/cloud.e2e.js
@@ -498,8 +498,8 @@ describe('Cloud Commands [@device]', () => {
 			'  --product  Target a device within the given Product ID or Slug  [string]',
 			'',
 			'Examples:',
-			'  particle cloud nyan green                 Make the device named `blue` start signaling',
-			'  particle cloud nyan green off             Make the device named `blue` stop signaling',
+			'  particle cloud nyan blue                  Make the device named `blue` start signaling',
+			'  particle cloud nyan blue off              Make the device named `blue` stop signaling',
 			'  particle cloud nyan blue --product 12345  Make the device named `blue` within product `12345` start signaling',
 		];
 


### PR DESCRIPTION
## Description

The `particle nyan --help` had different device name in the command and the description of the command's effect. Reconciled that.

## How to Test

Check the results by `particle nyan --help`, and the existing automated tests were also update.

## Related Issues / Discussions

N/A

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

