### PR TITLE
Add proxyUrl example to config help

### DIFF
--- a/src/cli/config.js
+++ b/src/cli/config.js
@@ -14,7 +14,8 @@ module.exports = ({ commandProcessor, root }) => {
 		examples: {
 			'$0 $command company': 'Switch to a profile called company',
 			'$0 $command particle': 'Switch back to the default profile',
-			'$0 $command set apiUrl http://localhost:9090': 'Change the apiUrl setting for the current profile'
+			'$0 $command set apiUrl http://localhost:9090': 'Change the apiUrl setting for the current profile',
+			'$0 $command set proxyUrl http://proxy:8080': 'Change the proxyUrl setting for the current profile'
 		}
 	});
 };


### PR DESCRIPTION
## Description
Adds minimal documentation for newly added `proxyUrl` parameter of `config` command

## How to Test
run: `particle config --help`
see "Examples" section

## Related Issues / Discussions
Continues https://github.com/particle-iot/particle-cli/issues/108 
Originally fixed in https://github.com/particle-iot/particle-cli/commit/1345fbb769f2391165b925a3a137737e7f0a24aa

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [ ] CI is passing

