### PR TITLE
Feature/clean wifi creds

### DIFF
--- a/src/cli/serial.js
+++ b/src/cli/serial.js
@@ -42,6 +42,10 @@ module.exports = ({ commandProcessor, root }) => {
 		options: Object.assign({
 			'file': {
 				description: 'Take the credentials from a JSON file instead of prompting for them'
+			},
+			'clear': {
+				boolean: true,
+				description: 'Remove existing credentials in the device'
 			}
 		}, portOption),
 		handler: (args) => {
@@ -50,7 +54,8 @@ module.exports = ({ commandProcessor, root }) => {
 		},
 		examples: {
 			'$0 $command': 'Prompt for Wi-Fi credentials and send them to a device over serial',
-			'$0 $command --file credentials.json': 'Read Wi-Fi credentials from credentials.json and send them to a device over serial'
+			'$0 $command --file credentials.json': 'Read Wi-Fi credentials from credentials.json and send them to a device over serial',
+			'$0 $command --clear': 'Clear device stored Wi-Fi credentials'
 		},
 		epilogue: unindent(`
 			The JSON file for passing Wi-Fi credentials should look like this:


### PR DESCRIPTION
## Description

CLI side of the wifi credential erasing functionality at https://github.com/particle-iot/device-os/pull/2242

## How to Test

Just try to erase a device credentials with a `particle serial wifi --clear` command


## Related Issues / Discussions

https://github.com/particle-iot/device-os/pull/2242
https://github.com/particle-iot/device-os/issues/2240

## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

