### PR TITLE
Print help messages and usage info to stdout, rather than stderr

### DIFF
--- a/src/app/cli.js
+++ b/src/app/cli.js
@@ -141,7 +141,7 @@ module.exports = class CLI {
 		}
 
 		if (argv.help){
-			commandProcessor.showHelp();
+			commandProcessor.showHelp('log');
 		} else if (argv.clierror){
 			throw argv.clierror;
 		} else if (argv.clicommand){

--- a/src/app/command-processor.js
+++ b/src/app/command-processor.js
@@ -427,7 +427,7 @@ function consoleErrorLogger(console, yargs, exit, error){
 	const verbose = (global.verboseLevel || 0) > 1;
 
 	if (usage){
-		yargs.showHelp();
+		yargs.showHelp('log');
 	}
 
 	if (error){

--- a/src/app/command-processor.js
+++ b/src/app/command-processor.js
@@ -253,7 +253,7 @@ class CLICommandItem {
 	}
 
 	showHelp(){
-		Yargs.showHelp();
+		Yargs.showHelp('log');
 	}
 
 	addInheritedOptions(target){


### PR DESCRIPTION
## Description

I find it odd that help messages and usage information should be printed to stderr, when most commands print to stdout. This pull request would effectively change calls to [`yargs.showHelp()`](https://github.com/yargs/yargs/blob/master/docs/api.md#showhelpconsolelevel--printcallback) to `yargs.showHelp('log')` making help messages and usage information get printed to stdout, rather than stderr.

## How to Test

Here is some Python code to verify that the help messages are printed to stdout instead of stderr:

```python
from subprocess import run, PIPE

# Run `particle`
out = run(['npm', 'start'], stdout=PIPE, stderr=PIPE)
print(out.stdout.decode('utf-8'))

# Run `particle help`
out = run(['npm', 'start', 'help'], stdout=PIPE, stderr=PIPE)
print(out.stdout.decode('utf-8'))

# Run `particle help cloud`
out = run(['npm', 'start', 'help', 'cloud'], stdout=PIPE, stderr=PIPE)
print(out.stdout.decode('utf-8'))
```

## Related Issues / Discussions

https://community.particle.io/t/particle-cli-help-messages-printed-to-stderr/59499


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

