### PR TITLE
bug/ch75832/particle-usb-list-platform-filter

### DIFF
--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -73,7 +73,7 @@ module.exports = class UsbCommand {
 								id: usbDevice.id,
 								name: name || '',
 								type: `${type.join(', ')}`,
-								platform_id: platformID || '',
+								platform_id: platformID || usbDevice.platformId,
 								connected: !!connected
 							};
 						})

--- a/test/e2e/product.e2e.js
+++ b/test/e2e/product.e2e.js
@@ -399,9 +399,9 @@ describe('Product Commands', () => {
 			expect(stdout).to.include(`  ${PRODUCT_01_DEVICE_02_ID}${os.EOL}`);
 			expect(stdout).to.not.include('Skipped Non-Member IDs:');
 			expect(stdout).to.include(`Skipped Invalid IDs:${os.EOL}`);
-			expect(stdout).to.include(`  wat${os.EOL}`);
-			expect(stdout).to.include(`  nope${os.EOL}`);
-			expect(stdout).to.include(`  lol${os.EOL}`);
+			expect(stdout).to.include(`  WAT${os.EOL}`);
+			expect(stdout).to.include(`  NOPE${os.EOL}`);
+			expect(stdout).to.include(`  LOL${os.EOL}`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -188,6 +188,16 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 			expect(exitCode).to.equal(0);
 		});
 
+		it('Lists connected devices filtered by platform name when signed-in to a foreign account', async () => {
+			await cli.loginToForeignAcct();
+			args.push(DEVICE_PLATFORM_NAME);
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(stdout).to.include(`<no name> [${DEVICE_ID}] (${platform})`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
 		it('Fails to list devices when signed-out', async () => {
 			await cli.logout();
 			const { stdout, stderr, exitCode } = await cli.run(args);


### PR DESCRIPTION
## Description

running the `particle usb list <platform - e.g. tracker>` command fails to return matches when you have a device of that platform connected but not associated with your account ([ch](https://app.clubhouse.io/particle/story/75832/particle-usb-list-platform-does-not-work-when-device-belong-to-an-account-other-than-the-one-you-are-signed-in-with))

## How to Test

with an `argon` device connected via USB but which is not associated with the signed-in user, run `particle usb list argon` and verify that your device is listed in the result set


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing
