### PR TITLE
Add support for XDG_DATA_HOME

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -201,7 +201,12 @@ settings.findHomePath = () => {
 };
 
 settings.ensureFolder = () => {
-	let particleDir = path.join(settings.findHomePath(), '.particle');
+	let base = '.particle';
+	let dir = process.env['XDG_DATA_HOME'];
+	if (dir && fs.existsSync(dir)) {
+		base = 'particle';
+	}
+	let particleDir = path.join(settings.findHomePath(), base);
 	if (!fs.existsSync(particleDir)) {
 		fs.mkdirSync(particleDir);
 	}

--- a/settings.js
+++ b/settings.js
@@ -184,6 +184,7 @@ function envValueBoolean(varName, defaultValue) {
 
 settings.findHomePath = () => {
 	let envVars = [
+		'XDG_DATA_HOME',
 		'home',
 		'HOME',
 		'HOMEPATH',


### PR DESCRIPTION
## Description

In particle-cli-wrapper, the default location for particle-cli dependencies can be overridden by setting the `XDG_DATA_HOME` environment variable.

https://github.com/particle-iot/particle-cli-wrapper/blob/master/filesystem.go#L21

However, in particle-cli this override is not honored and the default path of `$HOME/.particle` is used.

In particle-cli-wrapper, when `XDG_DATA_HOME` is set, the path becomes `$XDG_DATA_HOME/particle`. With the changes I've proposed so far, the path for particle-cli would also become `$XDG_DATA_HOME/particle`.

## How to Test

- Copy the `particle` executable from particle-cli-wrapper or Workbench to the current working directory.

- Run the following commands:

```bash
$ rm -rf ~/.particle
$ mkdir build
$ export XDG_DATA_HOME="$PWD/build"
$ ./particle
```

- Observe the contents of `build`:

```text
$ tree -L 2 build
build
`-- particle
    |-- autoupdate
    |-- error.log
    |-- node-v12.16.1-linux-x64
    |-- node_modules
    |-- package-lock.json
    |-- plugin-cache.json
    `-- tmp

4 directories, 4 files
```

- Observe that `~/.particle` was created:

```bash
$ ls ~/.particle
profile.json
```

With the changes I'm proposing, `profile.json` would have been created at `build/particle/profile.json` and not `~/.particle/profile.json`.

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

