### PR TITLE
[Gen 3] 256KB application binary support when flashing over DFU

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2848,12 +2848,11 @@
       "optional": true
     },
     "binary-version-reader": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-0.8.2.tgz",
-      "integrity": "sha512-7NUhdbSRAFl1pa3iwuyIvYhM27AZdI/zHNAH8Jglll3me05iOdNI2n8n/Ev5UgYSulLubWBLSmdwrdQ09tlh2Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-1.0.1.tgz",
+      "integrity": "sha512-Dhn3W9eRuWSiK+2VOxVu+8aMmTl8jzKD1MngEJpJ/cF0BcPXWFYJHMeCKf35wq2SJGO66duChxKYnYzI1HEgvg==",
       "requires": {
         "buffer-crc32": "^0.2.5",
-        "h5.buffers": "^0.1.1",
         "when": "^3.7.3",
         "xtend": "^4.0.2"
       }
@@ -5875,11 +5874,6 @@
         "pumpify": "^1.3.3",
         "through2": "^2.0.3"
       }
-    },
-    "h5.buffers": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/h5.buffers/-/h5.buffers-0.1.1.tgz",
-      "integrity": "sha1-JEh3MFMOSwDkm1rxcEldrPpAEb4="
     },
     "handlebars": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     }
   ],
   "dependencies": {
-    "binary-version-reader": "^0.8.2",
+    "binary-version-reader": "^1.0.1",
     "chalk": "^2.4.2",
     "cli-spinner": "^0.2.10",
     "cli-table": "^0.3.1",

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -113,6 +113,11 @@ module.exports = class FlashCommand {
 								break;
 							case ModuleInfo.FunctionType.USER_PART:
 								// use existing destSegment for userFirmware/factoryReset
+								// Use destination address from the module prefix if flashing
+								// into normal location
+								if (!factory) {
+									destAddress = '0x0' + info.prefixInfo.moduleStartAddy;
+								}
 								break;
 							case ModuleInfo.FunctionType.RADIO_STACK:
 								destSegment = 'radioStack';


### PR DESCRIPTION
## Description

In preparation for 3.1.0-rc.1 Device OS release with support for [256KB (vs 128KB prior) application binaries](https://docs.google.com/document/d/1DvOFlKDMDqB1JotDDHTFnWLNPyqYZ9ZADfSXr4W8P9U/edit#heading=h.vc7udwm4tepa), CLI needs to be updated to take destination address when performing DFU flashing from the binary module prefix, instead of using a hardcoded location.

This PR also bumps `binary-version-reader` dependency to the version with particle-iot/binary-version-reader#41, which improves how module prefixes are parsed.

I have not updated `src/lib/deviceSpecs/specifications.js` with the new location of the user application binary for Gen 3 platforms. This new location is only true for devices running >= 3.1.0, but it should not matter much anyway given that we are taking the destination address from the actual binary, which should cover both older (128KB) and newer (256KB) applications.

@busticated Any tests that we can update to validate this change?

## How to Test

1. Use a Tracker and update it to 3.0.0 first, then flash 3.1.0-alpha.1: [tracker@3.1.0-alpha.1.zip](https://github.com/particle-iot/particle-cli/files/6563189/tracker%403.1.0-alpha.1.zip)
```
particle usb listen
particle flash --serial tracker-bootloader@3.1.0-alpha.1.bin
particle usb dfu
particle flash --usb tracker-system-part1@3.1.0-alpha.1.bin
```
2. Attempt to flash attached `tracker-tinker-large@3.1.0-alpha.1.bin` with current version of CLI over DFU. It should fail with
```
dfu-util: Last page at 0x000fb2fb is not writeable
```
3. CLI from this branch should correctly flash this binary over DFU without an error
4. Put the device into listening mode and do `serial inspect`, it should report 256KB application (note the '262144 bytes max size)
```
  User module #2 - version 6, main location, 262144 bytes max size
    UUID: 85839E2B7CD45A4FDF7F28F7CD782914533923B13D8F5F8AB7C7561B832131E1
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      System module #1 - version 3100
```
5. Put the device into DFU mode and flash old tinker, it should work again just fine and the device should report 128KB application
```
$ particle usb dfu
$ particle flash --usb tinker
$ particle usb listen
$ particle serial inspect
...
  User module #1 - version 6, main location, 131072 bytes max size
    UUID: E48F6E1301CC55562FED63FFDF7BB756B4D043F0B7A894028827D9205AFB60A5
    Integrity: PASS
    Address Range: PASS
    Platform: PASS
    Dependencies: PASS
      System module #1 - version 1514
```

## Related Issues / Discussions

- [CH60338]
- https://github.com/particle-iot/device-os/pull/2322
- https://github.com/particle-iot/binary-version-reader/pull/41

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

