### PR TITLE
feature/ch82655/cli-flash-warning

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -37,6 +37,7 @@ var settings = {
 	access_token: null,
 	minimumApiDelay: 500,
 	useSudoForDfu: false,
+	flashWarningShownOn: null,
 	// TODO set to false once we give flags to control this
 	disableUpdateCheck: envValueBoolean('PARTICLE_DISABLE_UPDATE', false),
 	updateCheckInterval: 24 * 60 * 60 * 1000, // 24 hours

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -210,6 +210,7 @@ module.exports = class CloudCommand extends CLICommandBase {
 				return createAPI().markAsDevelopmentDevice(deviceId, true, product);
 			})
 			.then(() => {
+				this.ui.logFirstTimeFlashWarning();
 				this.ui.stdout.write(`attempting to flash firmware to your device ${deviceId}${os.EOL}`);
 				return createAPI().flashDevice(deviceId, fileMapping, targetVersion, product);
 			})

--- a/src/lib/ui/index.js
+++ b/src/lib/ui/index.js
@@ -55,10 +55,10 @@ module.exports = class UI {
 		if (settings.flashWarningShownOn){
 			return;
 		}
-		this.write(':::: WARNING!');
-		this.write(':::: Your first flash may take up to 10m to complete with');
-		this.write(':::: your device rapidly blinking magenta as Device OS');
-		this.write(':::: upgrades are applied. Please be patient!');
+		this.write(':::: NOTICE:');
+		this.write(':::: Your first flash may take up to 10m to complete - during');
+		this.write(':::: this time, your device may regularly change LED states');
+		this.write(':::: as Device OS upgrades are applied.');
 		settings.override(settings.profile, 'flashWarningShownOn', Date.now());
 	}
 

--- a/src/lib/ui/index.js
+++ b/src/lib/ui/index.js
@@ -2,6 +2,7 @@ const os = require('os');
 const Chalk = require('chalk').constructor;
 const Spinner = require('cli-spinner').Spinner;
 const platformsById = require('../../cmd/constants').platformsById;
+const settings = require('../../../settings');
 
 
 module.exports = class UI {
@@ -48,6 +49,17 @@ module.exports = class UI {
 				spinner.stop(clear);
 				throw error;
 			});
+	}
+
+	logFirstTimeFlashWarning(){
+		if (settings.flashWarningShownOn){
+			return;
+		}
+		this.write(':::: WARNING!');
+		this.write(':::: Your first flash may take up to 10m to complete with');
+		this.write(':::: your device rapidly blinking magenta as Device OS');
+		this.write(':::: upgrades are applied. Please be patient!');
+		settings.override(settings.profile, 'flashWarningShownOn', Date.now());
 	}
 
 	logDeviceDetail(devices, { varsOnly = false, fnsOnly = false } = {}){


### PR DESCRIPTION
## Description

Adds a warning shown the first time any flash command is run which informs the user of potential latency related to [Safe Mode Healer](https://docs.particle.io/tutorials/device-os/device-os/#safe-mode-healer):

```
:::: NOTICE:
:::: Your first flash may take up to 10m to complete - during
:::: this time, your device may regularly change LED states
:::: as Device OS upgrades are applied.
```


## How to Test

1. Using this branch...
2. Run any `flash` command (see: `npm start help`)
3. Verify you are shown the warning
4. Re-run the same command
5. Verify you are NOT shown the warning


## Related Issues / Discussions

https://app.clubhouse.io/particle/story/82655
https://github.com/particle-iot/workbench/pull/162


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

