### PR TITLE
fix: [sc-104725] `particle-cli` package failed to publish `v3.2.0` tag via CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,6 @@ jobs:
             npm publish $NPM_TAG
 
 workflows:
-  version: 2
   test-and-publish:
     jobs:
       - test-unix:


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/104725

When we attempt to run the npm-publish job, CircleCI throws a "No
Workflow" error. This is due to the version declaration we included in
the workflow. We don't need it as we have already declared the version
on line 1 and it is the wrong version. Likely a copy paste error. For more context, see the CircleCI post titled
[No workflow when create release through github](https://discuss.circleci.com/t/no-workflow-when-create-release-through-github/388022).

My hope is that once we get this PR merged to main, we can republish the tag and it will work as expected.