### PR TITLE
feature/sc-102023/circleci-macos-image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ executors:
           password: $DOCKERHUB_PASSWORD
   macos:
     macos:
-      xcode: 13
+      xcode: 13.4.1
 
 orbs:
   node: circleci/node@5.0.2


### PR DESCRIPTION
## Description

Use full version to work-around breaking change in CircleCI resulting in `failed to create host: Image xcode:13 is not supported`


## How to Test

1. Observe [CI passing](https://app.circleci.com/pipelines/github/particle-iot/particle-cli/73/workflows/16eeeaca-67ee-427e-8253-b5d1e220d916/jobs/906)


## Related Issues / Discussions

https://app.circleci.com/pipelines/github/particle-iot/particle-cli/72/workflows/fc68db40-6486-4a88-a479-7f5fdd2f1916
https://github.com/particle-iot/particle-cli/pull/623#issuecomment-1172546695
https://circleci.com/docs/2.0/using-macos#supported-xcode-versions
https://app.shortcut.com/particle/story/102023


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

