### PR TITLE
bug/sc-107005/v3-3-0-cannot-find-platform

### DIFF
--- a/platform.js
+++ b/platform.js
@@ -1,3 +1,6 @@
+// TODO (mirande): need to find a better home for this file
+// see: https://app.shortcut.com/particle/story/107005
+
 const deviceConstants = require('@particle/device-constants');
 
 /**

--- a/settings.js
+++ b/settings.js
@@ -1,31 +1,9 @@
-/**
- ******************************************************************************
- * @file    settings.js
- * @author  David Middlecamp (david@particle.io)
- * @company Particle ( https://www.particle.io/ )
- * @source https://github.com/particle-iot/particle-cli
- * @version V1.0.0
- * @date    14-February-2014
- * @brief   Setting module
- ******************************************************************************
-  Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
-  This program is free software; you can redistribute it and/or
-  modify it under the terms of the GNU Lesser General Public
-  License as published by the Free Software Foundation, either
-  version 3 of the License, or (at your option) any later version.
-
-  This program is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-  Lesser General Public License for more details.
-
-  You should have received a copy of the GNU Lesser General Public
-  License along with this program; if not, see <http://www.gnu.org/licenses/>.
-  ******************************************************************************
- */
-
-const { PlatformId } = require('./src/lib/platform');
+///////////////////////////////////////////////////////////////////////////////
+// NOTE ///////////////////////////////////////////////////////////////////////
+// Due to how the cli is packaged and distributed, we cannot require files ////
+// from the `./src` directory /////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////
+const { PlatformId } = require('./platform');
 
 const fs = require('fs');
 const path = require('path');

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -11,7 +11,7 @@ const utilities = require('../lib/utilities');
 const ensureError = require('../lib/utilities').ensureError;
 const ParticleAPI = require('./api');
 const prompts = require('../lib/prompts');
-const { PlatformId } = require('../lib/platform');
+const { PlatformId } = require('../../platform');
 const CLICommandBase = require('./base');
 
 const fs = require('fs-extra');

--- a/src/cmd/update.js
+++ b/src/cmd/update.js
@@ -2,7 +2,7 @@ const { openUsbDevice, openUsbDeviceById, openUsbDeviceByIdOrName, getUsbDevices
 const ParticleApi = require('./api');
 const dfu = require('../lib/dfu');
 const { spin } = require('../app/ui');
-const { platformForId, isKnownPlatformId } = require('../lib/platform');
+const { platformForId, isKnownPlatformId } = require('../../platform');
 const { delay } = require('../lib/utilities');
 const settings = require('../../settings');
 

--- a/src/cmd/update.test.js
+++ b/src/cmd/update.test.js
@@ -48,7 +48,7 @@ const stubs = {
 const UpdateCommand = proxyquire('./update', {
 	'./usb-util': { ...stubs.usb }, // proxyquire modifies stub objects
 	'../lib/dfu': { ...stubs.dfu },
-	'../lib/platform': { ...stubs.platform },
+	'../../platform': { ...stubs.platform },
 	'../app/ui': { ...stubs.ui },
 	'../lib/utilities': { ...stubs.util },
 	'binary-version-reader': { ...stubs.binaryVersionReader },

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -3,7 +3,7 @@ const { asyncMapSeries, buildDeviceFilter } = require('../lib/utilities');
 const { getDevice, formatDeviceInfo } = require('./device-util');
 const { getUsbDevices, openUsbDevice, openUsbDeviceByIdOrName, TimeoutError } = require('./usb-util');
 const { systemSupportsUdev, udevRulesInstalled, installUdevRules } = require('./udev');
-const { platformForId, isKnownPlatformId } = require('../lib/platform');
+const { platformForId, isKnownPlatformId } = require('../../platform');
 const ParticleApi = require('./api');
 
 

--- a/src/lib/device-specs.js
+++ b/src/lib/device-specs.js
@@ -1,6 +1,6 @@
 const path = require('path');
 const fs = require('fs');
-const { PLATFORMS } = require('./platform');
+const { PLATFORMS } = require('../../platform');
 
 /* Device specs have the following shape:
 

--- a/src/lib/dfu.js
+++ b/src/lib/dfu.js
@@ -35,7 +35,7 @@ const { systemSupportsUdev, promptAndInstallUdevRules } = require('../cmd/udev')
 const settings = require('../../settings');
 const utilities = require('./utilities');
 const deviceSpecs = require('./device-specs');
-const { platformForId } = require('./platform');
+const { platformForId } = require('../../platform');
 const log = require('./log');
 
 const prompt = inquirer.prompt;

--- a/src/lib/platform.test.js
+++ b/src/lib/platform.test.js
@@ -1,4 +1,4 @@
-const { PLATFORMS, PlatformId, platformForId, isKnownPlatformId } = require('./platform');
+const { PLATFORMS, PlatformId, platformForId, isKnownPlatformId } = require('../../platform');
 const { expect } = require('../../test/setup');
 
 const deviceConstants = require('@particle/device-constants');

--- a/src/lib/ui/index.js
+++ b/src/lib/ui/index.js
@@ -1,7 +1,7 @@
 const os = require('os');
 const Chalk = require('chalk').constructor;
 const Spinner = require('cli-spinner').Spinner;
-const { platformForId, isKnownPlatformId } = require('../platform');
+const { platformForId, isKnownPlatformId } = require('../../../platform');
 const settings = require('../../../settings');
 
 

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -32,7 +32,7 @@ const path = require('path');
 const glob = require('glob');
 const VError = require('verror');
 const childProcess = require('child_process');
-const { PLATFORMS } = require('./platform');
+const { PLATFORMS } = require('../../platform');
 const log = require('./log');
 
 


### PR DESCRIPTION
## Description

Fixes `Cannot find module './src/lib/platform'` discovered after publishing the `v3.3.0` update


## How to Test

1. Compile: `npm run compile`
2. Temporarily remove uncompiled source file: `rm -rf ./src`
3. Run commands using the compiled files: `./dist/index.js --help` (using standard command formatting - e.g. `./dist/index.js whoami`, etc)
4. Revert deleted source files: `git reset HEAD --hard`

**Outcome**

CLI should work without error targeting the compiled files


## Related Issues / Discussions

https://app.shortcut.com/particle/story/107005


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

