### PR TITLE
bug/sc-104725/v.3.3.0-failed-to-publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+tag_filters: &tag_filters
+  filters:
+    tags:
+      only: /^v.*/
+
 executors:
   linux:
     docker:
@@ -131,6 +136,7 @@ workflows:
   test-and-publish:
     jobs:
       - test-unix:
+          <<: *tag_filters
           context:
             - particle-ci-private
           matrix:
@@ -138,12 +144,14 @@ workflows:
               os: [linux, macos]
               node-version: ["10", "12", "14", "16"]
       - test-windows:
+          <<: *tag_filters
           context:
             - particle-ci-private
           matrix:
             parameters:
               node-version: ["10", "12", "14", "16"]
       - test-e2e:
+          <<: *tag_filters
           name: test-e2e-linux
           context:
             - particle-ci-private
@@ -152,6 +160,7 @@ workflows:
               os: [linux]
               node-version: ["12"]
       - test-e2e:
+          <<: *tag_filters
           name: test-e2e-macos
           requires:
             - test-e2e-linux
@@ -162,6 +171,7 @@ workflows:
               os: [macos]
               node-version: ["12"]
       - test-coverage:
+          <<: *tag_filters
           context:
             - particle-ci-private
           matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.3.1 - 19 July 2022
+
+* Fix `ERROR: Cannot find module './src/lib/platform'`
+
 ## 3.3.0 - 19 July 2022
 
 * Improve `update` command: Flash using control requests, tune module update order so bootloader is first, automatically enter DFU mode when possible


### PR DESCRIPTION
## Description

Fixes CI `publish-npm` job's triggering so packages are published upon tagging again


## How to Test


1. Observe [CI passing](https://app.circleci.com/pipelines/github/particle-iot/particle-cli/86/workflows/0b969d95-e9e0-45ff-9441-a31e36ce8902)

**Outcome**

_Unfortunately, there is not an easy way to verify these changes further without actually publishing things_ 😬 

## Related Issues / Discussions

https://app.shortcut.com/particle/story/104725


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

