### PR TITLE
bug/sc-104725/v.3.3.2-failed-to-publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,16 +115,17 @@ jobs:
   # https://github.com/particle-iot-inc/app-metrics/blob/034e6dd5d77ce3b0683310c81e6f6994be2d1c80/.circleci/config.yml
   # https://github.com/particle-iot-inc/device-service-discovery/blob/d1f4dbcdcab1efba7ba92794670c6e4e973e6265/.circleci/config.yml
   publish-npm:
-    working_directory: ~/repo
     docker:
       - image: cimg/node:12.22 # Primary execution image
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
     steps:
-      - attach_workspace:
-          at: ~/repo
+      - checkout
       - configure-npm-token
+      - run:
+          name: Install packages
+          command: npm ci
       - run:
           name: Publish package
           command: |


### PR DESCRIPTION
## Description

Adds missing steps to CI's `publish-npm` job to fix `ENOENT: no such file or directory, open 'package.json'`


## How to Test


1. Observe [CI passing](https://app.circleci.com/pipelines/github/particle-iot/particle-cli/90/workflows/5a89eb2f-2928-4d3c-a195-359189e4aaf9)

**Outcome**

_Unfortunately, there is not an easy way to verify these changes further without actually publishing things_ 😬😬 

## Related Issues / Discussions

https://app.shortcut.com/particle/story/104725
https://github.com/particle-iot/particle-cli/pull/626


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing