### PR TITLE
chore/SC-116732/add-Orson-platform

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -529,9 +529,15 @@
       "optional": true
     },
     "@types/node": {
-      "version": "18.6.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.6.1.tgz",
-      "integrity": "sha512-z+2vB6yDt1fNwKOeGbckpmirO+VBDuQqecXkgeIqDlaOtmKn6hPR/viQ8cxCfqLU4fTlvM3+YjM367TukWdxpg==",
+      "version": "18.15.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
+      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
+      "optional": true
+    },
+    "@types/w3c-web-usb": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/w3c-web-usb/-/w3c-web-usb-1.0.6.tgz",
+      "integrity": "sha512-cSjhgrr8g4KbPnnijAr/KJDNKa/bBa+ixYkywFRvrhvi9n1WEl7yYbtRyzE6jqNQiSxxJxoAW3STaOQwJHndaw==",
       "optional": true
     },
     "acorn": {
@@ -889,9 +895,9 @@
       }
     },
     "binary-version-reader": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-1.1.1.tgz",
-      "integrity": "sha512-hVzfUs9rfjh0Vm7i7xVFltsCwLy44X0NO8GZQRiIVPb63ySvIKsdglz6ZFXhWHU+wPZ/rAtZFeein2luAQVijA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-2.0.1.tgz",
+      "integrity": "sha512-cLnttzayEmmjstGOjstxOTBegFz8AdEvp3Zhs/JlcE2OlELFCZA/RZyPJXvi9y11smmqoEyfKbwvbGkknMNaoA==",
       "requires": {
         "buffer-crc32": "^0.2.5",
         "when": "^3.7.3",
@@ -987,7 +993,7 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ=="
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -4878,9 +4884,9 @@
       }
     },
     "node-addon-api": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
-      "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "optional": true
     },
     "node-environment-flags": {
@@ -4902,9 +4908,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "optional": true
     },
     "node-rsa": {
@@ -5838,14 +5844,14 @@
       }
     },
     "particle-usb": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.1.1.tgz",
-      "integrity": "sha512-qJDDm1ssKlkPmSHxp8lhtnZlpmajfhzLzhHwd0Q+63V0BIk98iGNOoon3rhxZT+j5/xmIrupeGaw1YQEEWzXSQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.2.0.tgz",
+      "integrity": "sha512-f5YE6ZhOsyFuHQaMYwAkPa3ExHpIVQfmyxSxshwRCjmk2oezrfeakC6aydNSA29lu+22UzF8pWeTBel9dDtJLw==",
       "optional": true,
       "requires": {
-        "@particle/device-os-protobuf": "^1.1.0",
-        "protobufjs": "^6.11.2",
-        "usb": "1.9.2"
+        "@particle/device-os-protobuf": "^1.2.1",
+        "protobufjs": "^6.11.3",
+        "usb": "^2.5.0"
       }
     },
     "pascalcase": {
@@ -7886,13 +7892,14 @@
       }
     },
     "usb": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-1.9.2.tgz",
-      "integrity": "sha512-dryNz030LWBPAf6gj8vyq0Iev3vPbCLHCT8dBw3gQRXRzVNsIdeuU+VjPp3ksmSPkeMAl1k+kQ14Ij0QHyeiAg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.8.3.tgz",
+      "integrity": "sha512-yWr888N/pWZfvPbEMz5lR5jqSoPLp/+6okpOWMocgLmJ1CsOwkAR+poUHwrAsPNKgFwwkzguYL+4NUDJtxkWhQ==",
       "optional": true,
       "requires": {
-        "node-addon-api": "^4.2.0",
-        "node-gyp-build": "^4.3.0"
+        "@types/w3c-web-usb": "^1.0.6",
+        "node-addon-api": "^5.0.0",
+        "node-gyp-build": "^4.5.0"
       }
     },
     "use": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -232,9 +232,9 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@particle/device-constants": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-2.0.0.tgz",
-      "integrity": "sha512-GGcebFK/A7trvUnXhyq3sWq6XvX/GSO6AJsjFFiDm9Qs+UtgmlVuPdLW6xaZR7gZgMT+siBhnxvZg+iDTEfTsg=="
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.6.tgz",
+      "integrity": "sha512-qiWU3G5Wu3DrGwn5CiQAYJTsCI9ROeUTnL4wb8U6mp7eJxzcPcev7UAw1EhP5cGr0LwK/MOIC1LOYMLnZ1Nu7g=="
     },
     "@particle/device-os-protobuf": {
       "version": "1.2.1",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4884,9 +4884,9 @@
       }
     },
     "node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.0.0.tgz",
+      "integrity": "sha512-GyHvgPvUXBvAkXa0YvYnhilSB1A+FRYMpIVggKzPZqdaZfevZOuzfWzyvgzOwRLHBeo/MMswmJFsrNF4Nw1pmA==",
       "optional": true
     },
     "node-environment-flags": {
@@ -5844,9 +5844,9 @@
       }
     },
     "particle-usb": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.2.0.tgz",
-      "integrity": "sha512-f5YE6ZhOsyFuHQaMYwAkPa3ExHpIVQfmyxSxshwRCjmk2oezrfeakC6aydNSA29lu+22UzF8pWeTBel9dDtJLw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.2.1.tgz",
+      "integrity": "sha512-BFDTvPopjsPmCxVqruMqqOJKjr4VvbljGT7hezJtCATUn0vlth/RIADx9bm88kdGtsvZZ6Sz1aaTM54wnBGasQ==",
       "optional": true,
       "requires": {
         "@particle/device-os-protobuf": "^1.2.1",
@@ -7892,13 +7892,13 @@
       }
     },
     "usb": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/usb/-/usb-2.8.3.tgz",
-      "integrity": "sha512-yWr888N/pWZfvPbEMz5lR5jqSoPLp/+6okpOWMocgLmJ1CsOwkAR+poUHwrAsPNKgFwwkzguYL+4NUDJtxkWhQ==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/usb/-/usb-2.9.0.tgz",
+      "integrity": "sha512-G0I/fPgfHUzWH8xo2KkDxTTFruUWfppgSFJ+bQxz/kVY2x15EQ/XDB7dqD1G432G4gBG4jYQuF3U7j/orSs5nw==",
       "optional": true,
       "requires": {
         "@types/w3c-web-usb": "^1.0.6",
-        "node-addon-api": "^5.0.0",
+        "node-addon-api": "^6.0.0",
         "node-gyp-build": "^4.5.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "sinon-chai": "^3.3.0"
   },
   "optionalDependencies": {
-    "particle-usb": "^2.2.0",
+    "particle-usb": "^2.2.1",
     "serialport": "^8.0.5"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     }
   ],
   "dependencies": {
-    "@particle/device-constants": "^2.0.0",
+    "@particle/device-constants": "^3.1.6",
     "binary-version-reader": "^1.1.1",
     "chalk": "^2.4.2",
     "cli-spinner": "^0.2.10",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@particle/device-constants": "^3.1.6",
-    "binary-version-reader": "^1.1.1",
+    "binary-version-reader": "^2.0.1",
     "chalk": "^2.4.2",
     "cli-spinner": "^0.2.10",
     "cli-table": "^0.3.1",
@@ -98,7 +98,7 @@
     "sinon-chai": "^3.3.0"
   },
   "optionalDependencies": {
-    "particle-usb": "^2.1.1",
+    "particle-usb": "^2.2.0",
     "serialport": "^8.0.5"
   },
   "engines": {

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -30,6 +30,7 @@ const PLATFORMS = extend(utilities.knownPlatformIds(), {
 	'a': PlatformId.ARGON,
 	'b': PlatformId.BORON,
 	'x': PlatformId.XENON,
+	'photon2': PlatformId.P2,
 	'assettracker': PlatformId.TRACKER
 });
 

--- a/src/lib/device-specs.test.js
+++ b/src/lib/device-specs.test.js
@@ -21,7 +21,8 @@ describe('Device Specs', () => {
 			'b5som',
 			'tracker',
 			'trackerm',
-			'p2'
+			'p2',
+			'muon'
 		]);
 	});
 
@@ -67,7 +68,7 @@ describe('Device Specs', () => {
 
 	describe('knownApps', () => {
 		it('includes `tinker` in `known apps` for offical platforms', async () => {
-			const unsupported = ['Asset Tracker', 'Tracker M', 'P2', 'E SoM X'];
+			const unsupported = ['Asset Tracker', 'Tracker M', 'Photon 2 / P2', 'Muon', 'E SoM X'];
 
 			for (const specs of Object.values(deviceSpecs)){
 				const { productName, knownApps } = specs;

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -24,6 +24,7 @@ const PLATFORMS_BY_ID = PLATFORMS.reduce((map, p) => map.set(p.id, p), new Map()
  * @property {Number} TRACKER
  * @property {Number} TRACKERM
  * @property {Number} P2
+ * @property {Number} MUON
  */
 const PlatformId = PLATFORMS.reduce((out, p) => {
 	out[p.name.toUpperCase()] = p.id;

--- a/src/lib/utilities.test.js
+++ b/src/lib/utilities.test.js
@@ -19,6 +19,7 @@ describe('Utilities', () => {
 				'tracker': 26,
 				'trackerm': 28,
 				'p2': 32,
+				'muon': 35
 			});
 		});
 	});
@@ -38,7 +39,8 @@ describe('Utilities', () => {
 				25: 'B5 SoM',
 				26: 'Asset Tracker',
 				28: 'Tracker M',
-				32: 'P2',
+				32: 'Photon 2 / P2',
+				35: 'Muon'
 			});
 		});
 	});

--- a/test/e2e/product.e2e.js
+++ b/test/e2e/product.e2e.js
@@ -73,7 +73,7 @@ describe('Product Commands', () => {
 		const detailedDeviceFieldNames = ['cellular', 'connected',
 			'current_build_target', 'default_build_target', 'denied',
 			'development', 'firmware_product_id', 'firmware_updates_enabled',
-			'firmware_updates_forced', 'firmware_version', 'functions', 'groups',
+			'firmware_updates_forced', 'functions', 'groups',
 			'iccid', 'id', 'imei', 'last_handshake_at', 'last_heard',
 			'last_iccid', 'last_ip_address', 'mobile_secret', 'name', 'notes',
 			'online', 'owner', 'pinned_build_target', 'platform_id',


### PR DESCRIPTION
## Description

- Adds the new Orson platform `muon`
- Fix P2 display name as per the latest changes in the device-constants library

## How to Test
 
Prepare an Orson device with a device-os version that supports inspecting via serial (supports the 's' command via serial).
Run `npm start -- serial inspect`

## Related Issues / Discussions

https://app.shortcut.com/particle/story/116732/support-orson-platform-in-cli-tools

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] ~Docs have been updated~ Docs will be updated during release
- [x] CI is passing

