### PR TITLE
Update dependencies for msom support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 3.7.0 - 21 December 2022
 
-* Add initial support for `muon` platform
+* Add initial support for `M SoM` platform
 
 ## 3.7.0 - 21 December 2022
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -232,9 +232,9 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@particle/device-constants": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.6.tgz",
-      "integrity": "sha512-qiWU3G5Wu3DrGwn5CiQAYJTsCI9ROeUTnL4wb8U6mp7eJxzcPcev7UAw1EhP5cGr0LwK/MOIC1LOYMLnZ1Nu7g=="
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.8.tgz",
+      "integrity": "sha512-LSmd16a353BxM7G1ek6Vrv6v8IIiAXUUS5zVuQTFtlKljrFDz06WFEm2UkX0bP2z//f2aROLPZ82rXBwcMOUSQ=="
     },
     "@particle/device-os-protobuf": {
       "version": "1.2.1",
@@ -529,9 +529,9 @@
       "optional": true
     },
     "@types/node": {
-      "version": "18.15.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.3.tgz",
-      "integrity": "sha512-p6ua9zBxz5otCmbpb5D3U4B5Nanw6Pk3PPyX05xnxbB/fRv71N7CPmORg7uAD5P70T0xmx1pzAx/FUfa5X+3cw==",
+      "version": "18.15.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
+      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
       "optional": true
     },
     "@types/w3c-web-usb": {
@@ -895,9 +895,9 @@
       }
     },
     "binary-version-reader": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-2.0.1.tgz",
-      "integrity": "sha512-cLnttzayEmmjstGOjstxOTBegFz8AdEvp3Zhs/JlcE2OlELFCZA/RZyPJXvi9y11smmqoEyfKbwvbGkknMNaoA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-2.0.2.tgz",
+      "integrity": "sha512-iJ0p0AWl/P1CytCM+DOnkwYJavSUizYzSXEGtaaNaBnVd8o0XBjF2dg4W3DQ5yn90mj81edzlDh1D7U4X+vmdQ==",
       "requires": {
         "buffer-crc32": "^0.2.5",
         "when": "^3.7.3",
@@ -5844,9 +5844,9 @@
       }
     },
     "particle-usb": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.2.1.tgz",
-      "integrity": "sha512-BFDTvPopjsPmCxVqruMqqOJKjr4VvbljGT7hezJtCATUn0vlth/RIADx9bm88kdGtsvZZ6Sz1aaTM54wnBGasQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.2.2.tgz",
+      "integrity": "sha512-omsw5sY18qLcSUIoyUjNDIYV9uaTe5+rWQxZraf3mlZizkz6PvBofSzvyOKnZ4WAjLWELVsz7DrK/LNUCdCdgw==",
       "optional": true,
       "requires": {
         "@particle/device-os-protobuf": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     }
   ],
   "dependencies": {
-    "@particle/device-constants": "^3.1.6",
-    "binary-version-reader": "^2.0.1",
+    "@particle/device-constants": "^3.1.8",
+    "binary-version-reader": "^2.0.2",
     "chalk": "^2.4.2",
     "cli-spinner": "^0.2.10",
     "cli-table": "^0.3.1",
@@ -98,7 +98,7 @@
     "sinon-chai": "^3.3.0"
   },
   "optionalDependencies": {
-    "particle-usb": "^2.2.1",
+    "particle-usb": "^2.2.2",
     "serialport": "^8.0.5"
   },
   "engines": {

--- a/src/lib/device-specs.test.js
+++ b/src/lib/device-specs.test.js
@@ -22,7 +22,7 @@ describe('Device Specs', () => {
 			'tracker',
 			'trackerm',
 			'p2',
-			'muon'
+			'msom'
 		]);
 	});
 
@@ -68,7 +68,7 @@ describe('Device Specs', () => {
 
 	describe('knownApps', () => {
 		it('includes `tinker` in `known apps` for offical platforms', async () => {
-			const unsupported = ['Asset Tracker', 'Tracker M', 'Photon 2 / P2', 'Muon', 'E SoM X'];
+			const unsupported = ['Asset Tracker', 'Tracker M', 'Photon 2 / P2', 'M SoM', 'E SoM X'];
 
 			for (const specs of Object.values(deviceSpecs)){
 				const { productName, knownApps } = specs;

--- a/src/lib/platform.js
+++ b/src/lib/platform.js
@@ -24,7 +24,7 @@ const PLATFORMS_BY_ID = PLATFORMS.reduce((map, p) => map.set(p.id, p), new Map()
  * @property {Number} TRACKER
  * @property {Number} TRACKERM
  * @property {Number} P2
- * @property {Number} MUON
+ * @property {Number} MSOM
  */
 const PlatformId = PLATFORMS.reduce((out, p) => {
 	out[p.name.toUpperCase()] = p.id;

--- a/src/lib/utilities.test.js
+++ b/src/lib/utilities.test.js
@@ -19,7 +19,7 @@ describe('Utilities', () => {
 				'tracker': 26,
 				'trackerm': 28,
 				'p2': 32,
-				'muon': 35
+				'msom': 35
 			});
 		});
 	});
@@ -40,7 +40,7 @@ describe('Utilities', () => {
 				26: 'Asset Tracker',
 				28: 'Tracker M',
 				32: 'Photon 2 / P2',
-				35: 'Muon'
+				35: 'M SoM'
 			});
 		});
 	});


### PR DESCRIPTION
### Description
Update dependencies to rename moun to msom
- Update `particle-usb` to 2.2.2
- Update `device-constants` to 3.1.8
- Update `binary-version-reader` to 2.0.2

### References
https://app.shortcut.com/particle/story/117445/change-muon-to-msom-in-cli-tools