### PR TITLE
Add aliases to platform names

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -232,9 +232,9 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@particle/device-constants": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.8.tgz",
-      "integrity": "sha512-LSmd16a353BxM7G1ek6Vrv6v8IIiAXUUS5zVuQTFtlKljrFDz06WFEm2UkX0bP2z//f2aROLPZ82rXBwcMOUSQ=="
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.9.tgz",
+      "integrity": "sha512-YwmPa0UoVLbNSPBnxqhplVGp1pMwGZS1bKHursGpouRbDkWgNxedCn9xIczLw0V1H73Iggn8d0Css3hyQJMS6A=="
     },
     "@particle/device-os-protobuf": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     }
   ],
   "dependencies": {
-    "@particle/device-constants": "^3.1.8",
+    "@particle/device-constants": "^3.1.9",
     "binary-version-reader": "^2.0.2",
     "chalk": "^2.4.2",
     "cli-spinner": "^0.2.10",

--- a/src/cli/cloud.js
+++ b/src/cli/cloud.js
@@ -1,3 +1,5 @@
+const utilities = require('../lib/utilities');
+
 module.exports = ({ commandProcessor, root }) => {
 	const cloud = commandProcessor.createCategory(root, 'cloud', 'Access Particle cloud functionality');
 
@@ -17,7 +19,7 @@ module.exports = ({ commandProcessor, root }) => {
 			const CloudCommands = require('../cmd/cloud');
 			return new CloudCommands(args).listDevices(args);
 		},
-		epilogue: 'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name'
+		epilogue: `Param filter can be: online, offline, a platform name (${Object.keys(utilities.knownPlatformIds()).join(', ')}), a device ID or name`
 	});
 
 	commandProcessor.createCommand(cloud, 'claim', 'Register a device with your user account with the cloud', {
@@ -94,8 +96,7 @@ module.exports = ({ commandProcessor, root }) => {
 			'$0 $command photon': 'Compile the source code in the current directory in the cloud for a `photon`',
 			'$0 $command electron project --saveTo electron.bin': 'Compile the source code in the project directory in the cloud for an `electron` and save it to a file named `electron.bin`',
 		},
-		// TODO: get the platforms from config and document in epilogue
-		epilogue: 'Param deviceType can be: core, photon, p1, electron, argon, asom, boron, bsom, xenon, xsom, etc'
+		epilogue: `Param deviceType can be: ${Object.keys(utilities.knownPlatformIdsWithAliases()).join(', ')}`
 	});
 
 	commandProcessor.createCommand(cloud, 'nyan', 'Make your device shout rainbows', {

--- a/src/cli/cloud.test.js
+++ b/src/cli/cloud.test.js
@@ -64,7 +64,7 @@ describe('Cloud Command-Line Interface', () => {
 					'Display a list of your devices, as well as their variables and functions',
 					'Usage: particle cloud list [options] [filter]',
 					'',
-					'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name',
+					'Param filter can be: online, offline, a platform name (core, photon, p1, electron, argon, boron, xenon, esomx, bsom, b5som, tracker, trackerm, p2, msom), a device ID or name',
 					''
 				].join('\n'));
 			});
@@ -308,7 +308,7 @@ describe('Cloud Command-Line Interface', () => {
 					'  particle cloud compile photon                                  Compile the source code in the current directory in the cloud for a `photon`',
 					'  particle cloud compile electron project --saveTo electron.bin  Compile the source code in the project directory in the cloud for an `electron` and save it to a file named `electron.bin`',
 					'',
-					'Param deviceType can be: core, photon, p1, electron, argon, asom, boron, bsom, xenon, xsom, etc',
+					'Param deviceType can be: core, c, photon, p, p1, electron, e, argon, a, boron, b, xenon, x, esomx, bsom, b5som, tracker, assettracker, trackerm, p2, photon2, msom, muon',
 					''
 				].join('\n'));
 			});

--- a/src/cli/usb.js
+++ b/src/cli/usb.js
@@ -1,4 +1,5 @@
 const settings = require('../../settings');
+const utilities = require('../lib/utilities');
 
 function usbCommand() {
 	if (!usbCommand._instance) {
@@ -26,7 +27,7 @@ module.exports = ({ commandProcessor, root }) => {
 		handler: (args) => {
 			return usbCommand().list(args);
 		},
-		epilogue: 'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name'
+		epilogue: `Param filter can be: online, offline, a platform name (${Object.keys(utilities.knownPlatformIds()).join(', ')}), a device ID or name`
 	});
 
 	// Common options for start-listening, stop-listening, safe-mode, dfu and reset

--- a/src/cli/usb.test.js
+++ b/src/cli/usb.test.js
@@ -62,7 +62,7 @@ describe('USB Command-Line Interface', () => {
 					'  --exclude-dfu  Do not list devices which are in DFU mode  [boolean]',
 					'  --ids-only     Print only device IDs  [boolean]',
 					'',
-					'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name',
+					'Param filter can be: online, offline, a platform name (core, photon, p1, electron, argon, boron, xenon, esomx, bsom, b5som, tracker, trackerm, p2, msom), a device ID or name',
 					''
 				].join('\n'));
 			});

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -11,7 +11,6 @@ const utilities = require('../lib/utilities');
 const ensureError = require('../lib/utilities').ensureError;
 const ParticleAPI = require('./api');
 const prompts = require('../lib/prompts');
-const { PlatformId } = require('../lib/platform');
 const CLICommandBase = require('./base');
 
 const fs = require('fs-extra');
@@ -23,17 +22,7 @@ const arrow = chalk.green('>');
 const alert = chalk.yellow('!');
 
 // Use known platforms and add shortcuts
-const PLATFORMS = extend(utilities.knownPlatformIds(), {
-	'c': PlatformId.CORE,
-	'p': PlatformId.PHOTON,
-	'e': PlatformId.ELECTRON,
-	'a': PlatformId.ARGON,
-	'b': PlatformId.BORON,
-	'x': PlatformId.XENON,
-	'photon2': PlatformId.P2,
-	'assettracker': PlatformId.TRACKER
-});
-
+const PLATFORMS = utilities.knownPlatformIdsWithAliases();
 
 module.exports = class CloudCommand extends CLICommandBase {
 	constructor(...args){

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -337,6 +337,17 @@ module.exports = {
 		}, {});
 	},
 
+	knownPlatformIdsWithAliases(){
+		return PLATFORMS.reduce((platforms, platform) => {
+			platforms[platform.name] = platform.id;
+			(platform.aliases || []).reduce((platforms, alias) => {
+				platforms[alias] = platform.id;
+				return platforms;
+			}, platforms);
+			return platforms;
+		}, {});
+	},
+
 	// generates an object like { 6: 'Photon', 10: 'Electron' }
 	knownPlatformDisplayForId(){
 		return PLATFORMS.reduce((platforms, platform) => {

--- a/src/lib/utilities.test.js
+++ b/src/lib/utilities.test.js
@@ -24,6 +24,36 @@ describe('Utilities', () => {
 		});
 	});
 
+	describe('knownPlatformIdsWithAliases', () => {
+		it('returns a hash of platform ids with aliases', () => {
+			expect(util.knownPlatformIdsWithAliases()).to.eql({
+				'core': 0,
+				'c': 0,
+				'photon': 6,
+				'p': 6,
+				'p1': 8,
+				'electron': 10,
+				'e': 10,
+				'argon': 12,
+				'a': 12,
+				'boron': 13,
+				'b': 13,
+				'xenon': 14,
+				'x': 14,
+				'esomx': 15,
+				'bsom': 23,
+				'b5som': 25,
+				'tracker': 26,
+				'assettracker': 26,
+				'trackerm': 28,
+				'p2': 32,
+				'photon2': 32,
+				'msom': 35,
+				'muon': 35
+			});
+		});
+	});
+
 	describe('knownPlatformDisplayForId', () => {
 		it('returns a hash of platform display names', () => {
 			expect(util.knownPlatformDisplayForId()).to.eql({

--- a/test/e2e/compile.e2e.js
+++ b/test/e2e/compile.e2e.js
@@ -30,7 +30,7 @@ describe('Compile Commands', () => {
 		'  particle compile photon                                  Compile the source code in the current directory in the cloud for a `photon`',
 		'  particle compile electron project --saveTo electron.bin  Compile the source code in the project directory in the cloud for an `electron` and save it to a file named `electron.bin`',
 		'',
-		'Param deviceType can be: core, photon, p1, electron, argon, asom, boron, bsom, xenon, xsom, etc',
+		'Param deviceType can be: core, c, photon, p, p1, electron, e, argon, a, boron, b, xenon, x, esomx, bsom, b5som, tracker, assettracker, trackerm, p2, photon2, msom, muon',
 	];
 
 	before(async () => {

--- a/test/e2e/list.e2e.js
+++ b/test/e2e/list.e2e.js
@@ -17,7 +17,7 @@ describe('List Commands', () => {
 		'  -v, --verbose  Increases how much logging to display  [count]',
 		'  -q, --quiet    Decreases how much logging to display  [count]',
 		'',
-		'Param filter can be: online, offline, a platform name (photon, electron, etc), a device ID or name'
+		'Param filter can be: online, offline, a platform name (core, photon, p1, electron, argon, boron, xenon, esomx, bsom, b5som, tracker, trackerm, p2, msom), a device ID or name'
 	];
 
 	before(async () => {


### PR DESCRIPTION
## Description

Add aliases to the platform names for particle compile command

## How to Test

For platforms with aliases, for example, for P2
Verify that compiling with platform `p2` and `photon2` both work

```
npm start -- compile p2
npm start -- compile photon2

```
## Related Issues / Discussions

https://app.shortcut.com/particle/story/116732/support-orson-platform-in-cli-tools

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

