### PR TITLE
Feature/sc 120959/implement device os version api into particle

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -12,6 +12,7 @@
         "@particle/device-constants": "^3.1.9",
         "binary-version-reader": "^2.2.0",
         "chalk": "^2.4.2",
+        "cli-progress": "^3.12.0",
         "cli-spinner": "^0.2.10",
         "cli-table": "^0.3.1",
         "core-js": "^3.4.7",
@@ -1709,6 +1710,62 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-progress/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/cli-progress/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/cli-spinner": {
@@ -12377,6 +12434,49 @@
       "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
       "requires": {
         "restore-cursor": "^1.0.1"
+      }
+    },
+    "cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "requires": {
+        "string-width": "^4.2.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+        },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+          "requires": {
+            "ansi-regex": "^5.0.1"
+          }
+        }
       }
     },
     "cli-spinner": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@particle/device-constants": "^3.1.9",
     "binary-version-reader": "^2.2.0",
     "chalk": "^2.4.2",
+    "cli-progress": "^3.12.0",
     "cli-spinner": "^0.2.10",
     "cli-table": "^0.3.1",
     "core-js": "^3.4.7",

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -221,6 +221,15 @@ module.exports = class ParticleApi {
 		);
 	}
 
+	getDeviceOsVersions(platformId, version) {
+		return this._wrap(
+			this.api.get({
+				uri: `/v1/device-os/versions/${version}?platform_id=${platformId}`,
+				auth: this.accessToken
+			})
+		);
+	}
+
 	_wrap(promise){
 		return Promise.resolve(promise)
 			.then(result => result.body || result)

--- a/src/lib/device-os-version-util.js
+++ b/src/lib/device-os-version-util.js
@@ -3,49 +3,106 @@ const deviceConstants = require('@particle/device-constants');
 const path = require('path');
 const request = require('request');
 const fs = require('fs-extra');
+const { HalModuleParser } = require('binary-version-reader');
 
 /**
  * Download a file from the given url to the given directory
  * @param url - the url to download from
  * @param directory - the directory to download to
  * @param filename - the filename to use
+ * @param progressBar - an instance of ProgressBar to use for progress updates
  * @returns {Promise<unknown>} - a promise that resolves when the file is downloaded
  */
-function downloadFile(url, directory, filename) {
-	return new Promise(async (resolve, reject) => {
+async function downloadFile(url, directory, filename, progressBar) {
+	let file, totalBytes = 0;
+	try {
 		filename = filename || url.match(/.*\/(.*)/)[1];
-		console.log('Downloading ' + filename + '...');
 		await fs.ensureDir(directory);
-		let file = fs.createWriteStream(directory + '/' + filename);
-		file.on('finish', () => {
-			file.close(() => {
-				resolve(directory + '/' + filename);
+		file = fs.createWriteStream(directory + '/' + filename);
+		await new Promise((resolve, reject) => {
+			file.on('error', (error) => {
+				reject(error);
 			});
-		});
-		request
-			.get(url)
-			.pipe(file)
-			.on('error', (err) => {
-				file.close();
+			file.on('finish', () => {
+				resolve();
+			});
+			const req = request.get(url);
+			req.on('response', (response) => {
+				if (response.statusCode !== 200) {
+					req.abort();
+					reject(new Error('Failed to download file: ' + response.statusCode));
+				}
+				totalBytes = parseInt(response.headers['content-length'], 10);
+				if (progressBar) {
+					progressBar.description = filename;
+					progressBar.start(totalBytes, 0);
+				}
+				response.pipe(file);
+				response.on('data', (chunk) => {
+					if (progressBar) {
+						progressBar.increment(chunk.length);
+					}
+				});
+				response.on('end', () => {
+					if (progressBar) {
+						progressBar.stop();
+					}
+					file.end();
+					resolve(filename);
+				});
+			});
+
+			req.on('error', (err) => {
 				reject(err);
 			});
-	});
+		});
+		return filename;
+	} finally {
+		if (file) {
+			file.end();
+		}
+	}
+
 }
 
+/**
+ * Get the path to the binaries for the given version and platform
+ * @param version - the version to get the path for
+ * @param platformName - the platform name to get the path for
+ * @returns {string} - the path to the binaries
+ */
+function getBinaryPath(version, platformName) {
+	const basePath = ensureFolder();
+	return path.join(basePath, 'device-os-flash/binaries/', version, platformName);
+}
 /**
  * Download the binary for the given platform and module
  * @param api - the api object
  * @param platformName - the platform name
  * @param module - the module object to download
  * @param baseUrl - the base url for the api
+ * @param version - the version to download
+ * @param progressBar - an instance of ProgressBar to use for progress updates
  * @returns {Promise<string>} - the path to the binary
  */
-const downloadBinary = async ({ platformName, module, baseUrl, version }) => {
-	const basePath = ensureFolder();
-	const binaryPath = path.join(basePath, 'device-os-flash/binaries/', version, platformName);
+const downloadBinary = async ({ platformName, module, baseUrl, version, progressBar }) => {
+	const binaryPath= getBinaryPath(version, platformName);
 	// fetch the binary
 	const uri = `${baseUrl}/${module.filename}`;
-	return downloadFile(uri, binaryPath, module.filename);
+	return downloadFile(uri, binaryPath, module.filename, progressBar);
+};
+
+const isModuleDownloaded = async (module, version, platformName) => {
+	// check if the module is already downloaded
+	const binaryPath = getBinaryPath(version, platformName);
+	const filePath = path.join(binaryPath, module.filename);
+	const exits = await fs.pathExists(filePath);
+	if (exits) {
+		const parser = new HalModuleParser();
+		const info = await parser.parseFile(filePath);
+		return info.crc.storedCrc === module.crc.storedCrc && info.crc.actualCrc === module.crc.actualCrc;
+	}
+	return false;
 };
 
 /**
@@ -53,24 +110,41 @@ const downloadBinary = async ({ platformName, module, baseUrl, version }) => {
  * @param {Object} api - the api object
  * @param {number} platformId - the platform id
  * @param {string} version - the version to download (default: latest)
+ * @param {Object} ui - allow us to interact in the console
  * @returns {Promise<*[]>} - true if successful
  */
-const downloadDeviceOsVersionBinaries = async ({ api, platformId, version='latest' }) => {
+const downloadDeviceOsVersionBinaries = async ({ api, platformId, version='latest', ui }) => {
 	try {
 		const downloadedBinaries = [];
 		// get platform by id from device-constants
 		const platform = Object.values(deviceConstants).filter(p => p.public).find(p => p.id === platformId);
 		// get the device os versions
-		console.log('Getting device os version data for platform: ' + platformId + ' version: ' + version + '...');
 		const deviceOsVersion = await api.getDeviceOsVersions(platformId, version);
 		// download binaries for each module in the device os version
 		for await (const module of deviceOsVersion.modules) {
-			downloadedBinaries.push(await downloadBinary({
-				platformName: platform.name,
-				module,
-				baseUrl: deviceOsVersion.base_url,
-				version: deviceOsVersion.version
-			}));
+			//TODO (hmontero) - make sure downloadedBinaries returns the full path to the binary
+			const isDownloaded = await isModuleDownloaded(module, deviceOsVersion.version, platform.name);
+			const binaryPath = getBinaryPath(deviceOsVersion.version, platform.name);
+			if (!isDownloaded) {
+				let progressBar;
+				// if is in silent mode don't create a progress bar
+				if (!ui.isOutputMuted()) {
+					progressBar = ui.createProgressBar(`Downloading ${module.filename}`);
+				} else {
+					ui.write(`Downloading ${module.filename}`);
+				}
+				const downloadedBinaryName = await downloadBinary({
+					platformName: platform.name,
+					module,
+					baseUrl: deviceOsVersion.base_url,
+					version: deviceOsVersion.version,
+					progressBar,
+				});
+				downloadedBinaries.push(path.join(binaryPath, downloadedBinaryName));
+			} else {
+				ui.write(`Skipping download of ${module.filename} as it is already downloaded`);
+				downloadedBinaries.push(path.join(binaryPath, module.filename));
+			}
 		}
 		return downloadedBinaries;
 	} catch (error) {

--- a/src/lib/device-os-version-util.js
+++ b/src/lib/device-os-version-util.js
@@ -26,6 +26,7 @@ function downloadFile(url, directory, filename) {
 			.get(url)
 			.pipe(file)
 			.on('error', (err) => {
+				file.close();
 				reject(err);
 			});
 	});

--- a/src/lib/device-os-version-util.js
+++ b/src/lib/device-os-version-util.js
@@ -1,0 +1,86 @@
+const { ensureFolder } = require('../../settings');
+const deviceConstants = require('@particle/device-constants');
+const path = require('path');
+const request = require('request');
+const fs = require('fs-extra');
+
+/**
+ * Download a file from the given url to the given directory
+ * @param url - the url to download from
+ * @param directory - the directory to download to
+ * @param filename - the filename to use
+ * @returns {Promise<unknown>} - a promise that resolves when the file is downloaded
+ */
+function downloadFile(url, directory, filename) {
+	return new Promise(async (resolve, reject) => {
+		filename = filename || url.match(/.*\/(.*)/)[1];
+		console.log('Downloading ' + filename + '...');
+		await fs.ensureDir(directory);
+		let file = fs.createWriteStream(directory + '/' + filename);
+		file.on('finish', () => {
+			file.close(() => {
+				resolve(directory + '/' + filename);
+			});
+		});
+		request
+			.get(url)
+			.pipe(file)
+			.on('error', (err) => {
+				reject(err);
+			});
+	});
+}
+
+/**
+ * Download the binary for the given platform and module
+ * @param api - the api object
+ * @param platformName - the platform name
+ * @param module - the module object to download
+ * @param baseUrl - the base url for the api
+ * @returns {Promise<string>} - the path to the binary
+ */
+const downloadBinary = async ({ platformName, module, baseUrl, version }) => {
+	const basePath = ensureFolder();
+	const binaryPath = path.join(basePath, 'device-os-flash/binaries/', version, platformName);
+	// fetch the binary
+	const uri = `${baseUrl}/${module.filename}`;
+	return downloadFile(uri, binaryPath, module.filename);
+};
+
+/**
+ * Download the binaries for the given platform and version by default the latest version is downloaded
+ * @param {Object} api - the api object
+ * @param {number} platformId - the platform id
+ * @param {string} version - the version to download (default: latest)
+ * @returns {Promise<*[]>} - true if successful
+ */
+const downloadDeviceOsVersionBinaries = async ({ api, platformId, version='latest' }) => {
+	try {
+		const downloadedBinaries = [];
+		// get platform by id from device-constants
+		const platform = Object.values(deviceConstants).filter(p => p.public).find(p => p.id === platformId);
+		// get the device os versions
+		console.log('Getting device os version data for platform: ' + platformId + ' version: ' + version + '...');
+		const deviceOsVersion = await api.getDeviceOsVersions(platformId, version);
+		// download binaries for each module in the device os version
+		for await (const module of deviceOsVersion.modules) {
+			downloadedBinaries.push(await downloadBinary({
+				platformName: platform.name,
+				module,
+				baseUrl: deviceOsVersion.base_url,
+				version: deviceOsVersion.version
+			}));
+		}
+		return downloadedBinaries;
+	} catch (error) {
+		if (error.message.includes('404')) {
+			throw new Error(`Device OS version not found for platform: ${platformId} version: ${version}`);
+		}
+		throw new Error('Error downloading binaries for platform: ' + platformId + ' version: ' + version + ' error: ' + error.message);
+	}
+
+};
+
+module.exports = {
+	downloadDeviceOsVersionBinaries
+};

--- a/src/lib/device-os-version-util.test.js
+++ b/src/lib/device-os-version-util.test.js
@@ -4,21 +4,28 @@ const fs = require('fs-extra');
 const request = require('request');
 const path = require('path');
 const { downloadDeviceOsVersionBinaries } = require('./device-os-version-util');
-const PATH_TMP_DIR = './tmp';
+const nock = require('nock');
+const { PATH_TMP_DIR } = require('../../test/lib/env');
+const UI = require('./ui');
 
 // stub: request, fs, api
 describe('downloadDeviceOsVersionBinaries', () => {
+	let ui, binary;
 	const originalEnv = process.env;
-	beforeEach(() => {
+	beforeEach(async () => {
+		binary = await fs.readFile(path.join(__dirname, '../../test/__fixtures__/binaries/argon_stroby.bin'));
+		ui = new UI({ quiet: true });
+		ui.chalk.enabled = false;
 		process.env = {
 			...originalEnv,
 			home: PATH_TMP_DIR,
 		};
-		fs.ensureDirSync(PATH_TMP_DIR);
+		await fs.ensureDir(path.join(PATH_TMP_DIR, '.particle/device-os-flash/binaries'));
 	});
-	afterEach(() => {
+	afterEach(async () => {
 		process.env = originalEnv;
 		sinon.restore();
+		await fs.remove(path.join(PATH_TMP_DIR, '.particle/device-os-flash/binaries'));
 	});
 	it('should download the binaries for the given platform and version by default the latest version is downloaded', async () => {
 		const expectedPath = path.join(PATH_TMP_DIR, '.particle/device-os-flash/binaries/2.3.1/photon');
@@ -32,21 +39,17 @@ describe('downloadDeviceOsVersionBinaries', () => {
 				]
 			})
 		};
-		expect(fs.existsSync(expectedPath)).to.be.false;
-		const sinonRequest = sinon.stub(request, 'get').returns({
-			pipe: (res) => {
-				res.emit('finish');
-				return {
-					on: (event, cb) => sinon.stub().callsFake(cb)
-				};
-			}
-		});
+		nock('https://api.particle.io/v1/firmware/device-os/v2.3.1', )
+			.intercept('/photon-bootloader@2.3.1+lto.bin', 'GET')
+			.reply(200, binary);
 
-		const data = await downloadDeviceOsVersionBinaries({ api, platformId: 6 });
+		nock('https://api.particle.io/v1/firmware/device-os/v2.3.1', )
+			.intercept('/photon-system-part1@2.3.1.bin', 'GET')
+			.reply(200, binary);
+
+		const data = await downloadDeviceOsVersionBinaries({ api, platformId: 6, ui });
 		expect(api.getDeviceOsVersions).to.have.been.calledWith(6, 'latest');
 		expect(data).to.be.an('array').with.lengthOf(2);
-		expect(sinonRequest.firstCall).to.have.been.calledWith('https://api.particle.io/v1/firmware/device-os/v2.3.1/photon-bootloader@2.3.1+lto.bin');
-		expect(sinonRequest.secondCall).to.have.been.calledWith('https://api.particle.io/v1/firmware/device-os/v2.3.1/photon-system-part1@2.3.1.bin');
 		const files = fs.readdirSync(path.join(PATH_TMP_DIR, '.particle/device-os-flash/binaries/2.3.1/photon'));
 		expect(fs.existsSync(expectedPath)).to.be.true;
 		expect(files).to.be.an('array').with.lengthOf(2);
@@ -65,16 +68,15 @@ describe('downloadDeviceOsVersionBinaries', () => {
 				]
 			})
 		};
-		sinon.stub(request, 'get').returns({
-			pipe: (res) => {
-				res.emit('finish');
-				return {
-					on: (event, cb) => sinon.stub().callsFake(cb)
-				};
-			}
-		});
+		nock('https://api.particle.io/v1/firmware/device-os/v2.3.1', )
+			.intercept('/photon-bootloader@2.3.1+lto.bin', 'GET')
+			.reply(200, binary);
 
-		const data = await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1' });
+		nock('https://api.particle.io/v1/firmware/device-os/v2.3.1', )
+			.intercept('/photon-system-part1@2.3.1.bin', 'GET')
+			.reply(200, binary);
+
+		const data = await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1', ui });
 		expect(api.getDeviceOsVersions).to.have.been.calledWith(6, '2.3.1');
 		expect(data).to.be.an('array').with.lengthOf(2);
 		const files = fs.readdirSync(path.join(PATH_TMP_DIR, '.particle/device-os-flash/binaries/2.3.1/photon'));
@@ -84,13 +86,13 @@ describe('downloadDeviceOsVersionBinaries', () => {
 
 	});
 
-	it('should fail if the platform is not supported by the requested version', async()  => {
+	it('should fail if the platform is not supported by the requested version', async()=> {
 		let error;
 		const api = {
 			getDeviceOsVersions: sinon.stub().rejects(new Error('404'))
 		};
 		try {
-			await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1' });
+			await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1', ui });
 		} catch (e) {
 			error = e;
 		}
@@ -109,27 +111,15 @@ describe('downloadDeviceOsVersionBinaries', () => {
 				]
 			})
 		};
-		sinon.stub(request, 'get').returns({
-			pipe: (res) => {
-				res.emit('finish');
-				return {
-					on: (event, cb) => {
-						if (event === 'error') {
-							cb(new Error('getaddrinfo ENOTFOUND url-that-does-not-exist.com'));
-						}
-						return sinon.stub().callsFake(cb);
-					}
-				};
-			}
-		});
+		const spy = sinon.spy(request, 'get');
 
 		try {
-			await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1' });
+			await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1', ui });
 		} catch (e) {
 			error = e;
 		}
 		expect(error.message).to.equal('Error downloading binaries for platform: 6 version: 2.3.1 error: getaddrinfo ENOTFOUND url-that-does-not-exist.com');
 		expect(api.getDeviceOsVersions).to.have.been.calledWith(6, '2.3.1');
-		expect(request.get).to.have.been.calledOnce;
+		expect(spy).to.have.been.calledOnce;
 	});
 });

--- a/src/lib/device-os-version-util.test.js
+++ b/src/lib/device-os-version-util.test.js
@@ -1,0 +1,136 @@
+const { expect } = require('../../test/setup');
+const sinon = require('sinon');
+const fs = require('fs-extra');
+const request = require('request');
+const path = require('path');
+const { downloadDeviceOsVersionBinaries } = require('./device-os-version-util');
+const PATH_TMP_DIR = './tmp';
+
+// stub: request, fs, api
+describe('downloadDeviceOsVersionBinaries', () => {
+	const originalEnv = process.env;
+	beforeEach(() => {
+		process.env = {
+			...originalEnv,
+			home: PATH_TMP_DIR,
+		};
+		fs.ensureDirSync(PATH_TMP_DIR);
+	});
+	afterEach(() => {
+		process.env = originalEnv;
+		fs.removeSync(PATH_TMP_DIR);
+		sinon.restore();
+	});
+	it('should download the binaries for the given platform and version by default the latest version is downloaded', async () => {
+		const expectedPath = path.join(PATH_TMP_DIR, '.particle/device-os-flash/binaries/2.3.1/photon');
+		const api = {
+			getDeviceOsVersions: sinon.stub().resolves({
+				version: '2.3.1',
+				base_url: 'https://api.particle.io/v1/firmware/device-os/v2.3.1',
+				modules: [
+					{ filename: 'photon-bootloader@2.3.1+lto.bin' },
+					{ filename: 'photon-system-part1@2.3.1.bin' }
+				]
+			})
+		};
+		expect(fs.existsSync(expectedPath)).to.be.false;
+		const sinonRequest = sinon.stub(request, 'get').returns({
+			pipe: (res) => {
+				res.emit('finish');
+				return {
+					on: (event, cb) => sinon.stub().callsFake(cb)
+				};
+			}
+		});
+
+		const data = await downloadDeviceOsVersionBinaries({ api, platformId: 6 });
+		expect(api.getDeviceOsVersions).to.have.been.calledWith(6, 'latest');
+		expect(data).to.be.an('array').with.lengthOf(2);
+		expect(sinonRequest.firstCall).to.have.been.calledWith('https://api.particle.io/v1/firmware/device-os/v2.3.1/photon-bootloader@2.3.1+lto.bin');
+		expect(sinonRequest.secondCall).to.have.been.calledWith('https://api.particle.io/v1/firmware/device-os/v2.3.1/photon-system-part1@2.3.1.bin');
+		const files = fs.readdirSync(path.join(PATH_TMP_DIR, '.particle/device-os-flash/binaries/2.3.1/photon'));
+		expect(fs.existsSync(expectedPath)).to.be.true;
+		expect(files).to.be.an('array').with.lengthOf(2);
+		expect(files).to.include('photon-bootloader@2.3.1+lto.bin');
+		expect(files).to.include('photon-system-part1@2.3.1.bin');
+	});
+
+	it('should download the binaries for the given platform and version', async() => {
+		const api = {
+			getDeviceOsVersions: sinon.stub().resolves({
+				version: '2.3.1',
+				base_url: 'https://api.particle.io/v1/firmware/device-os/v2.3.1',
+				modules: [
+					{ filename: 'photon-bootloader@2.3.1+lto.bin' },
+					{ filename: 'photon-system-part1@2.3.1.bin' }
+				]
+			})
+		};
+		sinon.stub(request, 'get').returns({
+			pipe: (res) => {
+				res.emit('finish');
+				return {
+					on: (event, cb) => sinon.stub().callsFake(cb)
+				};
+			}
+		});
+
+		const data = await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1' });
+		expect(api.getDeviceOsVersions).to.have.been.calledWith(6, '2.3.1');
+		expect(data).to.be.an('array').with.lengthOf(2);
+		const files = fs.readdirSync(path.join(PATH_TMP_DIR, '.particle/device-os-flash/binaries/2.3.1/photon'));
+		expect(files).to.be.an('array').with.lengthOf(2);
+		expect(files).to.include('photon-bootloader@2.3.1+lto.bin');
+		expect(files).to.include('photon-system-part1@2.3.1.bin');
+
+	});
+
+	it('should fail if the platform is not supported by the requested version', async()  => {
+		let error;
+		const api = {
+			getDeviceOsVersions: sinon.stub().rejects(new Error('404'))
+		};
+		try {
+			await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1' });
+		} catch (e) {
+			error = e;
+		}
+		expect(error.message).to.equal('Device OS version not found for platform: 6 version: 2.3.1');
+	});
+
+	it('should fail in case of an error', async() => {
+		let error;
+		const api = {
+			getDeviceOsVersions: sinon.stub().resolves({
+				version: '2.3.1',
+				base_url: 'http://url-that-does-not-exist.com',
+				modules: [
+					{ filename: 'photon-bootloader@2.3.1+lto.bin' },
+					{ filename: 'photon-system-part1@2.3.1.bin' }
+				]
+			})
+		};
+		sinon.stub(request, 'get').returns({
+			pipe: (res) => {
+				res.emit('finish');
+				return {
+					on: (event, cb) => {
+						if (event === 'error') {
+							cb(new Error('getaddrinfo ENOTFOUND url-that-does-not-exist.com'));
+						}
+						return sinon.stub().callsFake(cb);
+					}
+				};
+			}
+		});
+
+		try {
+			await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1' });
+		} catch (e) {
+			error = e;
+		}
+		expect(error.message).to.equal('Error downloading binaries for platform: 6 version: 2.3.1 error: getaddrinfo ENOTFOUND url-that-does-not-exist.com');
+		expect(api.getDeviceOsVersions).to.have.been.calledWith(6, '2.3.1');
+		expect(request.get).to.have.been.calledOnce;
+	});
+});

--- a/src/lib/device-os-version-util.test.js
+++ b/src/lib/device-os-version-util.test.js
@@ -18,7 +18,6 @@ describe('downloadDeviceOsVersionBinaries', () => {
 	});
 	afterEach(() => {
 		process.env = originalEnv;
-		fs.removeSync(PATH_TMP_DIR);
 		sinon.restore();
 	});
 	it('should download the binaries for the given platform and version by default the latest version is downloaded', async () => {

--- a/src/lib/ui/index.js
+++ b/src/lib/ui/index.js
@@ -34,6 +34,7 @@ module.exports = class UI {
 		const { stderr, EOL } = this;
 		stderr.write(data + EOL);
 	}
+
 	createProgressBar(description) {
 		return new cliProgress.SingleBar({
 			format: `${description} ['{bar}'] {percentage}% | ETA: {eta}s | {value}/{total}`,
@@ -139,8 +140,6 @@ module.exports = class UI {
 				}
 			}
 		}
-
-
 	}
 };
 

--- a/src/lib/ui/index.js
+++ b/src/lib/ui/index.js
@@ -3,6 +3,7 @@ const Chalk = require('chalk').constructor;
 const Spinner = require('cli-spinner').Spinner;
 const { platformForId, isKnownPlatformId } = require('../platform');
 const settings = require('../../../settings');
+const cliProgress = require('cli-progress');
 
 
 module.exports = class UI {
@@ -25,9 +26,18 @@ module.exports = class UI {
 		stdout.write(data + EOL);
 	}
 
+	isOutputMuted(){
+		return !this.stdout.isTTY;
+	}
+
 	error(data){
 		const { stderr, EOL } = this;
 		stderr.write(data + EOL);
+	}
+	createProgressBar(description) {
+		return new cliProgress.SingleBar({
+			format: `${description} ['{bar}'] {percentage}% | ETA: {eta}s | {value}/{total}`,
+		}, cliProgress.Presets.shades_classic);
 	}
 
 	showBusySpinnerUntilResolved(text, promise){
@@ -129,6 +139,8 @@ module.exports = class UI {
 				}
 			}
 		}
+
+
 	}
 };
 


### PR DESCRIPTION
Adds the library that helps to download binaries using Device Os Versions API.

### How to test
This new function receives: `platformId`, `version`, an `api` instance and an `ui` instance.

This is an example on how to use
```
const UI = require('../lib/ui'); // ui from src/lib/ui/index.js
const ParticleApi = require('./api'); // from src/cmd/api
const { downloadDeviceOsVersionBinaries } = require('../lib/device-os-version-util');
const settings = require('../../settings');
const auth = 'XYZ'; // your token

async function download() {
  const particleApi = new ParticleApi(settings.apiUrl, { accessToken: auth });
  const ui = new UI();

  const binaries =  await downloadDeviceOsVersionBinaries({
     platformId: 12,
     api: particleApi,
     ui: ui,
     version: 'latest'
   });
   return binaries;
}

download().then(res => console.log(res)).catch(error => console.log(error))

```

** outcome **
In case the binary already exists it will skip the download process, in other case it will show a progress bar tracking the download progress.
In case the command is being used with a output pipe ( 'npm start -- usb list > output.txt') it will not print the progress but a message indicating the file is being downloaded.
