### PR TITLE
Extract modules from bundle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
 
 orbs:
   node: circleci/node@5.0.2
-  win: circleci/windows@4.1.1
+  win: circleci/windows@5.0.0
 
 commands:
   configure-npm-token:
@@ -75,7 +75,7 @@ jobs:
       - run:
           name: Install Node
           command: |
-            nvm install --lts << parameters.node-version >>
+            nvm install << parameters.node-version >>
             nvm use << parameters.node-version >>
       - configure-npm-token
       - run:

--- a/src/cmd/bundle.test.js
+++ b/src/cmd/bundle.test.js
@@ -317,4 +317,17 @@ describe('BundleCommands', () => {
 			});
 		});
 	});
+
+	describe('extractModulesFromBundle',  () => {
+		it ('extracts modules from bundle', async () => {
+			const bundle = path.join(PATH_FIXTURES_THIRDPARTY_OTA_DIR, 'bundle.zip');
+			const expectedRes = ['app.bin', 'cat.txt', 'house.txt', 'water.txt'];
+
+			const res = await bundleCommands.extractModulesFromBundle(bundle);
+
+			expect(res).to.be.an.instanceof(Array);
+			expect(res).to.have.lengthOf(4);
+			expect(res.map(module => path.basename(module))).to.eql(expectedRes);
+		});
+	});
 });

--- a/src/cmd/bundle.test.js
+++ b/src/cmd/bundle.test.js
@@ -320,14 +320,14 @@ describe('BundleCommands', () => {
 
 	describe('extractModulesFromBundle',  () => {
 		it ('extracts modules from bundle', async () => {
-			const bundle = path.join(PATH_FIXTURES_THIRDPARTY_OTA_DIR, 'bundle.zip');
+			const bundleFilename = path.join(PATH_FIXTURES_THIRDPARTY_OTA_DIR, 'bundle.zip');
 			const expectedRes = ['app.bin', 'cat.txt', 'house.txt', 'water.txt'];
 
-			const res = await bundleCommands.extractModulesFromBundle(bundle);
+			const modulePaths = await bundleCommands.extractModulesFromBundle({ bundleFilename });
 
-			expect(res).to.be.an.instanceof(Array);
-			expect(res).to.have.lengthOf(4);
-			expect(res.map(module => path.basename(module))).to.eql(expectedRes);
+			expect(modulePaths).to.be.an.instanceof(Array);
+			expect(modulePaths).to.have.lengthOf(4);
+			expect(modulePaths.map(module => path.basename(module))).to.eql(expectedRes);
 		});
 	});
 });


### PR DESCRIPTION
### Description

This PR adds support to extract asset modules from a bundle.
The provided bundle.zip file is extracted locally, unpacked and wrapped into asset modules by the binary version reader.

The method `extractModulesFromBundle` returns the path of the app binary and wrapped asset modules.

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

