### PR TITLE
Feature/sc 121398/sort and create recipe for flashing a list

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -165,7 +165,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 		// TODO: check that all the files are for the correct platform
 
 		const deviceOsBinaries = await this._getDeviceOsBinaries({
-			currentDeviceOsVersion: device.version,
+			currentDeviceOsVersion: device.firmwareVersion,
 			skipDeviceOSFlash,
 			target,
 			modules: fileModules,

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -147,6 +147,8 @@ module.exports = class FlashCommand extends CLICommandBase {
 		const device = await usbUtils.getOneUsbDevice({ deviceIdOrName, api, auth, ui: this.ui });
 
 		const platformName = platformForId(device.platformId).name;
+		this.ui.write(`Flashing ${platformName} ${deviceIdOrName || device.id}`);
+
 		let { skipDeviceOSFlash, files: filesToFlash } = await this._prepareFilesToFlash({
 			knownApp,
 			parsedFiles,
@@ -157,9 +159,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 
 		filesToFlash = await this._processBundle({ filesToFlash });
 
-		this.ui.write(`Flashing ${platformName} ${deviceIdOrName || device.id}`);
 		const fileModules = await this._parseModules({ files: filesToFlash });
-		// TODO: check that all the files are for the correct platform
 		await this._validateModulesForPlatform({ modules: fileModules, platformId: device.platformId, platformName });
 
 		const deviceOsBinaries = await this._getDeviceOsBinaries({
@@ -172,12 +172,10 @@ module.exports = class FlashCommand extends CLICommandBase {
 		});
 		const deviceOsModules = await this._parseModules({ files: deviceOsBinaries });
 		let modulesToFlash = [...fileModules, ...deviceOsModules];
-		modulesToFlash = await this._filterModulesToFlash({ modules: modulesToFlash, platformId: device.platformId });
+		modulesToFlash = this._filterModulesToFlash({ modules: modulesToFlash, platformId: device.platformId });
 
 		const flashSteps = await this._createFlashSteps({ modules: modulesToFlash, isInDfuMode: device.isInDfuMode , platformId: device.platformId });
 		await this._flashFiles({ device, flashSteps });
-		await device.close();
-
 	}
 
 
@@ -341,9 +339,9 @@ module.exports = class FlashCommand extends CLICommandBase {
 
 	async _getDeviceOsBinaries({ skipDeviceOSFlash, target, modules, currentDeviceOsVersion, platformId, applicationOnly }) {
 		const { particleApi } = this._particleApi();
-		const { file: application, applicationDeviceOsVersion } = await this._pickApplicationBinary(modules, particleApi);
+		const { module: application, applicationDeviceOsVersion } = await this._pickApplicationBinary(modules, particleApi);
 
-		// if we have specific deviceOs Binaries, don't download them from the cloud
+		// if files to flash include Device OS binaries, don't override them with the ones from the cloud
 		const includedDeviceOsModuleFunctions = [ModuleInfo.FunctionType.SYSTEM_PART, ModuleInfo.FunctionType.BOOTLOADER];
 		const systemPartBinaries = modules.filter(m => includedDeviceOsModuleFunctions.includes(m.prefixInfo.moduleFunction));
 		if (systemPartBinaries.length) {
@@ -354,8 +352,6 @@ module.exports = class FlashCommand extends CLICommandBase {
 		if (!application) {
 			return [];
 		}
-
-		// TODO: if files to flash include Device OS binaries, don't override them with the ones from the cloud
 
 		// need to get the binary required version
 		if (applicationOnly) {
@@ -392,22 +388,21 @@ module.exports = class FlashCommand extends CLICommandBase {
 		}
 	}
 
-	async _pickApplicationBinary(files, api) {
-		for (const file of files) {
+	async _pickApplicationBinary(modules, api) {
+		for (const module of modules) {
 			// parse file and look for moduleFunction
-			if (file.prefixInfo.moduleFunction === ModuleInfo.FunctionType.USER_PART) {
-				const internalVersion = file.prefixInfo.depModuleVersion;
-				// TODO: handle the case when the Device OS version is not available
+			if (module.prefixInfo.moduleFunction === ModuleInfo.FunctionType.USER_PART) {
+				const internalVersion = module.prefixInfo.depModuleVersion;
 				let applicationDeviceOsVersionData = { version: null };
 				try {
-					applicationDeviceOsVersionData = await api.getDeviceOsVersions(file.prefixInfo.platformID, internalVersion);
+					applicationDeviceOsVersionData = await api.getDeviceOsVersions(module.prefixInfo.platformID, internalVersion);
 				} catch (error) {
-					// ignore
+					// ignore if Device OS version from the application cannot be identified
 				}
-				return { file, applicationDeviceOsVersion: applicationDeviceOsVersionData.version };
+				return { module, applicationDeviceOsVersion: applicationDeviceOsVersionData.version };
 			}
 		}
-		return { file: null, applicationDeviceOsVersion: null };
+		return { module: null, applicationDeviceOsVersion: null };
 	}
 
 	async _flashFiles({ device, flashSteps }) {
@@ -522,7 +517,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 
 	}
 
-	async _filterModulesToFlash({ modules, platformId, allowAll = false }) {
+	_filterModulesToFlash({ modules, platformId, allowAll = false }) {
 		const platform = PLATFORMS.find(p => p.id === platformId);
 		const filteredModules = [];
 		// remove encrypted files
@@ -542,30 +537,31 @@ module.exports = class FlashCommand extends CLICommandBase {
 
 	async _createFlashSteps({ modules, isInDfuMode, platformId }) {
 		const platform = PLATFORMS.find(p => p.id === platformId);
-		const binaries = await sortBinariesByDependency(modules);
+		const sortedModules = await sortBinariesByDependency(modules);
 		const assetModules = [], normalModules = [], dfuModules = [];
-		binaries.forEach(binary => {
-			const data = binary.prefixInfo.moduleFlags === ModuleInfo.Flags.DROP_MODULE_INFO ? binary.fileBuffer.slice(binary.prefixInfo.prefixSize) : binary.fileBuffer;
-			const module = {
-				name: path.basename(binary.filename),
-				moduleInfo: { crc: binary.crc, prefixInfo: binary.prefixInfo, suffixInfo: binary.suffixInfo },
+		sortedModules.forEach(module => {
+			const data = module.prefixInfo.moduleFlags === ModuleInfo.Flags.DROP_MODULE_INFO ? module.fileBuffer.slice(module.prefixInfo.prefixSize) : module.fileBuffer;
+			const flashStep = {
+				name: path.basename(module.filename),
+				moduleInfo: { crc: module.crc, prefixInfo: module.prefixInfo, suffixInfo: module.suffixInfo },
 				data
 			};
-			const moduleType = moduleTypeToString(binary.prefixInfo.moduleFunction);
+			const moduleType = moduleTypeToString(module.prefixInfo.moduleFunction);
 			const storage = platform.firmwareModules
 				.find(firmwareModule => firmwareModule.type === moduleType);
 			if (moduleType === 'assets') {
-				module.flashMode = 'normal';
-				assetModules.push(module);
+				flashStep.flashMode = 'normal';
+				assetModules.push(flashStep);
 			} else if (moduleType === 'bootloader' || storage.storage === 'external') {
-				module.flashMode = 'normal';
-				normalModules.push(module);
+				flashStep.flashMode = 'normal';
+				normalModules.push(flashStep);
 			} else {
-				module.flashMode = 'dfu';
-				dfuModules.push(module);
+				flashStep.flashMode = 'dfu';
+				dfuModules.push(flashStep);
 			}
 		});
 
+		// avoid switching to normal mode if device is already in DFU so a device with broken Device OS can get fixed
 		if (isInDfuMode) {
 			return [...dfuModules, ...normalModules, ...assetModules];
 		} else {

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -158,11 +158,9 @@ module.exports = class FlashCommand extends CLICommandBase {
 		filesToFlash = await this._processBundle({ filesToFlash });
 
 		this.ui.write(`Flashing ${platformName} ${deviceIdOrName || device.id}`);
-
-		// TODO: process all the files with binary version reader
 		const fileModules = await this._parseModules({ files: filesToFlash });
-
 		// TODO: check that all the files are for the correct platform
+		await this._validateModulesForPlatform({ modules: fileModules, platformId: device.platformId, platformName });
 
 		const deviceOsBinaries = await this._getDeviceOsBinaries({
 			currentDeviceOsVersion: device.firmwareVersion,
@@ -330,6 +328,15 @@ module.exports = class FlashCommand extends CLICommandBase {
 		}));
 
 		return processed.flat();
+	}
+
+	async _validateModulesForPlatform({ modules, platformId, platformName }) {
+		for (const moduleInfo of modules) {
+			if (moduleInfo.prefixInfo.platformID !== platformId) {
+				throw new Error(`Module ${moduleInfo.filename} is not compatible with platform ${platformName}`);
+			}
+		}
+
 	}
 
 	async _getDeviceOsBinaries({ skipDeviceOSFlash, target, modules, currentDeviceOsVersion, platformId, applicationOnly }) {

--- a/src/cmd/flash.test.js
+++ b/src/cmd/flash.test.js
@@ -297,7 +297,7 @@ describe('FlashCommand', () => {
 		it('returns empty if there is no application binary', async () => {
 			const modules = await createModules();
 			const userPart = modules.find(m => m.filename === 'systemPart1.bin');
-			const deviceOsBinaries = await flash._getDeviceOsBinaries({ files: [userPart] });
+			const deviceOsBinaries = await flash._getDeviceOsBinaries({ modules: [userPart] });
 			expect(deviceOsBinaries).to.eql([]);
 		});
 		it('returns empty list if applicationOnly is true', async () => {
@@ -310,7 +310,7 @@ describe('FlashCommand', () => {
 			const userPart = modules.find(m => m.filename === 'userPart1.bin');
 			const binaries = await flash._getDeviceOsBinaries({
 				applicationOnly: true,
-				files: [userPart]
+				modules: [userPart]
 			});
 			expect(binaries).to.eql([]);
 		});
@@ -326,7 +326,7 @@ describe('FlashCommand', () => {
 			const binaries = await flash._getDeviceOsBinaries({
 				skipDeviceOSFlash: true,
 				currentDeviceOsVersion: '0.7.0',
-				files: [userPart]
+				modules: [userPart]
 			});
 			expect(binaries).to.eql([]);
 		});
@@ -345,7 +345,7 @@ describe('FlashCommand', () => {
 			]);
 			const binaries = await flash._getDeviceOsBinaries({
 				target: '4.1.0',
-				files: [userPart],
+				modules: [userPart],
 				platformId: 6
 			});
 			expect(binaries.some(file => file.includes('photon-bootloader@4.1.0+lto.bin'))).to.be.true;
@@ -368,7 +368,7 @@ describe('FlashCommand', () => {
 			]);
 			const binaries = await flash._getDeviceOsBinaries({
 				platformId: 6,
-				files: [userPart],
+				modules: [userPart],
 			});
 			expect(binaries.some(file => file.includes('photon-bootloader@4.1.0+lto.bin'))).to.be.true;
 			expect(binaries.some(file => file.includes('photon-system-part1@4.1.0.bin'))).to.be.true;

--- a/src/cmd/flash.test.js
+++ b/src/cmd/flash.test.js
@@ -382,23 +382,6 @@ describe('FlashCommand', () => {
 		});
 	});
 
-	describe('_sortBinariesByDependency', () => {
-		it('returns a list of files sorted by dependency', async () => {
-			const modules = await createModules();
-			const expected = [
-				modules.find( m => m.filename === 'preBootloader.bin'),
-				modules.find( m => m.filename === 'bootloader.bin'),
-				modules.find( m => m.filename === 'systemPart1.bin'),
-				modules.find( m => m.filename === 'systemPart2.bin'),
-				modules.find( m => m.filename === 'userPart1.bin'),
-			];
-			const binaries = await flash._sortBinariesByDependency(modules);
-			binaries.forEach((binary, index) => {
-				expect(binary.filename).to.equal(expected[index].filename);
-			});
-		});
-	});
-
 	describe('_createFlashSteps', () => {
 		let preBootloaderStep, bootloaderStep, systemPart1Step, systemPart2Step, userPart1Step, modules, assetModules, asset1Step, asset2Step;
 		beforeEach(async() => {

--- a/src/lib/dependency-walker.js
+++ b/src/lib/dependency-walker.js
@@ -1,0 +1,70 @@
+class DependencyWalker {
+	constructor({ modules, log }) {
+		this._log = log;
+		this._modules = modules;
+		this._adjacencyList = new Map();
+	}
+
+	sortByDependencies(modules) {
+		if (modules) {
+			this._modules = modules;
+		}
+
+		this._fillAdjacencyList();
+
+		// This is pretty naive but works fine for our purposes
+		const ordered = [];
+		const visited = new Set();
+		for (const [m, deps] of this._adjacencyList.entries()) {
+			if (m in visited) {
+				continue;
+			}
+			const chain = [];
+			visited.add(m);
+			chain.push(m);
+			for (const d of deps) {
+				if (d in visited) {
+					continue;
+				}
+				visited.add(d);
+				chain.push(d);
+			}
+			const last = chain[chain.length - 1];
+			// Place into the appropriate location in the list
+			ordered.splice(ordered.indexOf(last), 0, ...chain);
+		}
+		// Remove any duplicates
+		return new Set(ordered);
+	}
+
+	_addEdgesByDependencies(module) {
+		// Fills the adjacency list in the reverse order of the dependencies
+		// e.g. system-part1 depends on bootloader: the list will contain bootloader -> system-part1 edge
+		for (const dep of module.dependencies) {
+			for (const m of this._modules) {
+				if (dep.func === m.prefixInfo.moduleFunction &&
+					dep.index === m.prefixInfo.moduleIndex &&
+					dep.version === m.prefixInfo.moduleVersion) {
+					// Version is ignored as we don't really known what's on device
+					const moduleDependencies = this._adjacencyList.get(m);
+					moduleDependencies.add(module);
+				}
+			}
+		}
+	}
+
+	_fillAdjacencyList() {
+		this._adjacencyList = new Map();
+		for (const m of this._modules) {
+			this._adjacencyList.set(m, new Set());
+		}
+		for (const m of this._modules) {
+			this._addEdgesByDependencies(m);
+		}
+	}
+
+}
+
+module.exports = {
+	DependencyWalker
+};

--- a/src/lib/dependency-walker.js
+++ b/src/lib/dependency-walker.js
@@ -114,7 +114,6 @@ async function sortBinariesByDependency(modules) {
 	const sortedDependencies = dependencyWalker.sortByDependencies(binariesWithDependencies);
 
 	return Array.from(sortedDependencies);
-
 }
 
 

--- a/src/lib/dependency-walker.test.js
+++ b/src/lib/dependency-walker.test.js
@@ -1,0 +1,74 @@
+const { expect } = require('../../test/setup');
+const { HalModuleParser, firmwareTestHelper, ModuleInfo } = require('binary-version-reader');
+const { sortBinariesByDependency } = require('./dependency-walker');
+describe('_sortBinariesByDependency', () => {
+
+	const createModules = async () => {
+		const parser = new HalModuleParser();
+		const preBootloaderBuffer = await firmwareTestHelper.createFirmwareBinary({
+			moduleFunction: ModuleInfo.FunctionType.BOOTLOADER,
+			moduleIndex: 0,
+			moduleVersion: 1200,
+			deps: []
+		});
+		const preBootloader = await parser.parseBuffer({ fileBuffer: preBootloaderBuffer });
+		const bootloaderBuffer = await firmwareTestHelper.createFirmwareBinary({
+			moduleFunction: ModuleInfo.FunctionType.BOOTLOADER,
+			moduleIndex: 1,
+			moduleVersion: 1210,
+			deps: [
+				{ func: ModuleInfo.FunctionType.BOOTLOADER, index: 0, version: 1200 }
+			]
+		});
+		const bootloader = await parser.parseBuffer({ fileBuffer: bootloaderBuffer });
+		const systemPart1Buffer = await firmwareTestHelper.createFirmwareBinary({
+			moduleFunction: ModuleInfo.FunctionType.SYSTEM_PART,
+			moduleIndex: 1,
+			moduleVersion: 4100,
+			deps: [
+				{ func: ModuleInfo.FunctionType.BOOTLOADER, index: 1, version: 1210 }
+			]
+		});
+		const systemPart1 = await parser.parseBuffer({ fileBuffer: systemPart1Buffer });
+		const systemPart2Buffer = await firmwareTestHelper.createFirmwareBinary({
+			moduleFunction: ModuleInfo.FunctionType.SYSTEM_PART,
+			moduleIndex: 2,
+			moduleVersion: 4100,
+			deps: [
+				{ func: ModuleInfo.FunctionType.SYSTEM_PART, index: 1, version: 4100 }
+			]
+		});
+		const systemPart2 = await parser.parseBuffer({ fileBuffer: systemPart2Buffer });
+		const userPart1Buffer = await firmwareTestHelper.createFirmwareBinary({
+			moduleFunction: ModuleInfo.FunctionType.USER_PART,
+			moduleIndex: 1,
+			moduleVersion: 4100,
+			deps: [
+				{ func: ModuleInfo.FunctionType.SYSTEM_PART, index: 2, version: 4100 }
+			]
+		});
+		const userPart1 = await parser.parseBuffer({ fileBuffer: userPart1Buffer });
+		return [
+			{ filename: 'preBootloader.bin', ...preBootloader },
+			{ filename: 'bootloader.bin', ...bootloader },
+			{ filename: 'systemPart1.bin', ...systemPart1 },
+			{ filename: 'systemPart2.bin', ...systemPart2 },
+			{ filename: 'userPart1.bin', ...userPart1 }
+		];
+	};
+
+	it('returns a list of files sorted by dependency', async () => {
+		const modules = await createModules();
+		const expected = [
+			modules.find( m => m.filename === 'preBootloader.bin'),
+			modules.find( m => m.filename === 'bootloader.bin'),
+			modules.find( m => m.filename === 'systemPart1.bin'),
+			modules.find( m => m.filename === 'systemPart2.bin'),
+			modules.find( m => m.filename === 'userPart1.bin'),
+		];
+		const binaries = await sortBinariesByDependency(modules);
+		binaries.forEach((binary, index) => {
+			expect(binary.filename).to.equal(expected[index].filename);
+		});
+	});
+});


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
This PR wil add the ability to get a list of modules and sort it out depending on the device mode, in that way we can get a list of steps to flash a device with the specific device mode for each module.

<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
* Attempt to flash a device by using: 
   * `npm start -- flash -- local /my/dir/binary.bin`
   * `npm start -- flash -- local /my/dir/binary.bin --target x.x.x`
   * `npm start -- flash -- local /my/dir/binary.bin --application-only`

repeat the same but picking a dir instead a binary


## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

