### PR TITLE
Rename compile aliases keyword

### DIFF
--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -337,7 +337,7 @@ module.exports = {
 	knownPlatformIdsWithAliases(){
 		return PLATFORMS.reduce((platforms, platform) => {
 			platforms[platform.name] = platform.id;
-			(platform.aliases || []).reduce((platforms, alias) => {
+			(platform.compileAliases || []).reduce((platforms, alias) => {
 				platforms[alias] = platform.id;
 				return platforms;
 			}, platforms);

--- a/src/lib/utilities.test.js
+++ b/src/lib/utilities.test.js
@@ -28,7 +28,7 @@ describe('Utilities', () => {
 	});
 
 	describe('knownPlatformIdsWithAliases', () => {
-		it('returns a hash of platform ids with aliases', () => {
+		it('returns a hash of platform ids with compile aliases', () => {
 			expect(util.knownPlatformIdsWithAliases()).to.eql({
 				'core': 0,
 				'c': 0,


### PR DESCRIPTION
## Description

Rename `aliases` keyword to `compileAliases` to match with the new device-constants implemenation.

Please see : 
- https://app.shortcut.com/particle/story/121441/rename-platform-name-s-in-wb-ui
- https://github.com/particle-iot-inc/device-constants/pull/33


## How to Test

- Run `npm test`


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

