### PR TITLE
Fix the device id/name option

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -144,7 +144,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 	async flashLocal({ files, applicationOnly, target }) {
 		const { files: parsedFiles, deviceIdOrName, knownApp } = await this._analyzeFiles(files);
 		const { api, auth } = this._particleApi();
-		const device = await usbUtils.getOneUsbDevice({ deviceIdOrName, api, auth, ui: this.ui });
+		const device = await usbUtils.getOneUsbDevice({ idOrName: deviceIdOrName, api, auth, ui: this.ui });
 
 		const platformName = platformForId(device.platformId).name;
 		this.ui.write(`Flashing ${platformName} ${deviceIdOrName || device.id}`);


### PR DESCRIPTION
## Description

`particle flash --local <deviceIDorName> /path/to/proj --target 5.4.1` should select the specified device

## How to Test

Connect at least two devices to the computer and make sure that the correct device ID provided in the above command is picked up for flashing

## Related Issues / Discussions

https://github.com/particle-iot/cli/pull/193

## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

