### PR TITLE
Update binary-version-reader

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@particle/device-constants": "^3.2.0",
-        "binary-version-reader": "^2.2.0",
+        "binary-version-reader": "^2.2.1",
         "chalk": "^2.4.2",
         "cli-progress": "^3.12.0",
         "cli-spinner": "^0.2.10",
@@ -1285,9 +1285,9 @@
       }
     },
     "node_modules/binary-version-reader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-2.2.0.tgz",
-      "integrity": "sha512-BcGb3yoMHxhctMk2u9+537QpwE3vclhoelF/V4FS0yC3NvfT755+okoWNw2pOZrD2wkdpndkvt3XmdB+kYpH2Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-2.2.1.tgz",
+      "integrity": "sha512-91g9Jfu6egp3N8lGZP1qdhsrndT6NRBzF6uUzNWFkC0S07LQkIziOHNQzxjxgU+AtxSyIgCUI2snWLQhrF4QTQ==",
       "dependencies": {
         "archiver": "^5.3.1",
         "buffer-crc32": "^0.2.5",
@@ -1304,7 +1304,7 @@
         "npm": "8.x"
       },
       "peerDependencies": {
-        "@particle/device-constants": "^3.1.11"
+        "@particle/device-constants": "^3.2.0"
       }
     },
     "node_modules/binaryextensions": {
@@ -12096,9 +12096,9 @@
       }
     },
     "binary-version-reader": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-2.2.0.tgz",
-      "integrity": "sha512-BcGb3yoMHxhctMk2u9+537QpwE3vclhoelF/V4FS0yC3NvfT755+okoWNw2pOZrD2wkdpndkvt3XmdB+kYpH2Q==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/binary-version-reader/-/binary-version-reader-2.2.1.tgz",
+      "integrity": "sha512-91g9Jfu6egp3N8lGZP1qdhsrndT6NRBzF6uUzNWFkC0S07LQkIziOHNQzxjxgU+AtxSyIgCUI2snWLQhrF4QTQ==",
       "requires": {
         "archiver": "^5.3.1",
         "buffer-crc32": "^0.2.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -9,7 +9,7 @@
       "version": "3.12.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@particle/device-constants": "^3.1.11",
+        "@particle/device-constants": "^3.2.0",
         "binary-version-reader": "^2.2.0",
         "chalk": "^2.4.2",
         "cli-progress": "^3.12.0",
@@ -330,9 +330,9 @@
       }
     },
     "node_modules/@particle/device-constants": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.11.tgz",
-      "integrity": "sha512-/S18G87wWqoOpyWSALYZfHRRNe/jXGYQlbPShcgCGUJoOjO/d0EX8lL0aw2a59cj2uxv5YG7YZURzpyHh5Pylw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.2.0.tgz",
+      "integrity": "sha512-+Hc27+3av6mKydSz2DWdp5/UumDA0lfVBiBX0aFouTFqN8mBlMj2/BZO75hQFzlrRlOLxkpFBBGbtCa6rmBSug==",
       "engines": {
         "node": ">=12.x",
         "npm": "8.x"
@@ -11352,9 +11352,9 @@
       "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
     },
     "@particle/device-constants": {
-      "version": "3.1.11",
-      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.1.11.tgz",
-      "integrity": "sha512-/S18G87wWqoOpyWSALYZfHRRNe/jXGYQlbPShcgCGUJoOjO/d0EX8lL0aw2a59cj2uxv5YG7YZURzpyHh5Pylw=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@particle/device-constants/-/device-constants-3.2.0.tgz",
+      "integrity": "sha512-+Hc27+3av6mKydSz2DWdp5/UumDA0lfVBiBX0aFouTFqN8mBlMj2/BZO75hQFzlrRlOLxkpFBBGbtCa6rmBSug=="
     },
     "@particle/device-os-protobuf": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   ],
   "dependencies": {
     "@particle/device-constants": "^3.2.0",
-    "binary-version-reader": "^2.2.0",
+    "binary-version-reader": "^2.2.1",
     "chalk": "^2.4.2",
     "cli-progress": "^3.12.0",
     "cli-spinner": "^0.2.10",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     }
   ],
   "dependencies": {
-    "@particle/device-constants": "^3.1.11",
+    "@particle/device-constants": "^3.2.0",
     "binary-version-reader": "^2.2.0",
     "chalk": "^2.4.2",
     "cli-progress": "^3.12.0",

--- a/src/lib/utilities.test.js
+++ b/src/lib/utilities.test.js
@@ -70,7 +70,7 @@ describe('Utilities', () => {
 				15: 'E SoM X',
 				23: 'B SoM',
 				25: 'B5 SoM',
-				26: 'Asset Tracker',
+				26: 'Asset Tracker / Monitor One',
 				28: 'Tracker M',
 				32: 'Photon 2 / P2',
 				35: 'M SoM'

--- a/test/e2e/compile.e2e.js
+++ b/test/e2e/compile.e2e.js
@@ -541,7 +541,7 @@ describe('Compile Commands', () => {
 	});
 
 	it ('Creates a bundle with legacy flat project', async () => {
-		const platform = 'photon';
+		const platform = 'tracker';
 		const cwd = path.join(PATH_FIXTURES_THIRDPARTY_OTA_DIR, 'projects', 'stroby-with-assets');
 		const destinationZip = path.join(PATH_TMP_DIR, 'bundle.zip');
 		const args = ['compile', platform, '--saveTo', destinationZip];
@@ -576,7 +576,7 @@ describe('Compile Commands', () => {
 	});
 
 	it ('verifies bundle', async () => {
-		const platform = 'photon';
+		const platform = 'tracker';
 		const cwd = path.join(PATH_FIXTURES_THIRDPARTY_OTA_DIR, 'projects', 'stroby-with-assets');
 		const destination = path.join(PATH_TMP_DIR, 'bundle.zip');
 		const args = ['compile', platform, '--saveTo', destination];
@@ -598,7 +598,7 @@ describe('Compile Commands', () => {
 	});
 
 	it ('Creates a bundle with legacy flat project with default name', async () => {
-		const platform = 'photon';
+		const platform = 'tracker';
 		const cwd = path.join(PATH_FIXTURES_THIRDPARTY_OTA_DIR, 'projects', 'stroby-with-assets');
 		const args = ['compile', platform];
 		const { stdout, stderr, exitCode } = await cliRunWithTimer(args, { cwd });
@@ -619,12 +619,12 @@ describe('Compile Commands', () => {
 		];
 
 		expect(stdout.split('\n')).to.include.members(log);
-		expect(stdout).to.match(/[\s\S]*photon_firmware_\d+.zip/);
+		expect(stdout).to.match(/[\s\S]*tracker_firmware_\d+.zip/);
 		expect(stderr).to.equal('');
 		expect(exitCode).to.equal(0);
 
 		const files = await fs.readdir(cwd);
-		const defaultName = stdout.match(/photon_firmware_\d+.zip/)[0];
+		const defaultName = stdout.match(/tracker_firmware_\d+.zip/)[0];
 		const defaultNameExists = files.includes(defaultName);
 		if (defaultNameExists) {
 			await fs.unlink(path.join(cwd, defaultName));
@@ -632,17 +632,17 @@ describe('Compile Commands', () => {
 	});
 
 	it ('checks that the .bin file does not exist outside of the bundle', async () => {
-		const platform = 'photon';
+		const platform = 'tracker';
 		const cwd = path.join(PATH_FIXTURES_THIRDPARTY_OTA_DIR, 'projects', 'stroby-with-assets');
 		const args = ['compile', platform];
 		await cliRunWithTimer(args, { cwd });
 		const files = await fs.readdir(cwd);
 
 		files.forEach( async (file) => {
-			if (file.match(/photon_firmware_\d+.bin/)) {
+			if (file.match(/tracker_firmware_\d+.bin/)) {
 				expect(false).to.be.true;
 			}
-			if (file.match(/photon_firmware_\d+.zip/)) {
+			if (file.match(/tracker_firmware_\d+.zip/)) {
 				await fs.unlink(path.join(cwd, file));
 			}
 		});


### PR DESCRIPTION
## Description

Update device constants to support asset size limiting feature. Fix tests to make them compatible with the new bvr

## How to Test

Flash a WB project with asset(s) where asset size is larger than the specified size in device-constants.
For example, create an asset file of 3MB for tracker and create a bundle using the following
```
npm start -- bundle /path/to/app.bin --assets /path/to/folder/which/contains/large/assets
```

## Related Issues / Discussions

N/A

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

