### PR TITLE
Keep flashing if Device OS version for app cannot be determined

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -373,7 +373,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 		}
 
 		// if Device OS needs to be upgraded, or we don't know the current Device OS version, download the binaries
-		if (!currentDeviceOsVersion || semver.lt(currentDeviceOsVersion, applicationDeviceOsVersion)) {
+		if (applicationDeviceOsVersion && (!currentDeviceOsVersion || semver.lt(currentDeviceOsVersion, applicationDeviceOsVersion))) {
 			return deviceOsUtils.downloadDeviceOsVersionBinaries({
 				api: particleApi,
 				platformId,


### PR DESCRIPTION
I got `Invalid version. Must be a string. Got type "object".` when the API didn't return a value for the Device OS version for an app. In that case, bypass downloading the Device OS files. This could happen for a development release or because the API call fails (likely what happened to Eric).