### PR TITLE
Flash Device OS only when version is known to be outdated

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -325,8 +325,8 @@ module.exports = class FlashCommand extends CLICommandBase {
 			return [];
 		}
 
-		// if Device OS needs to be upgraded, or we don't know the current Device OS version, download the binaries
-		if (applicationDeviceOsVersion && (!currentDeviceOsVersion || semver.lt(currentDeviceOsVersion, applicationDeviceOsVersion))) {
+		// if Device OS needs to be upgraded, so download the binaries
+		if (applicationDeviceOsVersion && currentDeviceOsVersion && semver.lt(currentDeviceOsVersion, applicationDeviceOsVersion)) {
 			return deviceOsUtils.downloadDeviceOsVersionBinaries({
 				api: particleApi,
 				platformId,
@@ -334,7 +334,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 				ui: this.ui,
 			});
 		} else {
-			// Device OS is up to date, no need to download binaries
+			// Device OS is up to date or we don't know the current Device OS version, so no need to download binaries
 			return [];
 		}
 	}


### PR DESCRIPTION
Change based on discussion in Slack: when doing `particle flash --local` or Workbench: Flash application (local), don't update Device OS if we can't read the version. This is most common when the device is in DFU mode. This avoids needlessfly flashing Device OS over and over.