### PR TITLE
feature/sc-121836/ask-user-to-switch-to-dfu-for-os-2-0-0-in

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -16,7 +16,7 @@ const { knownAppNames, knownAppsForPlatform } = require('../lib/known-apps');
 const { sourcePatterns, binaryPatterns, binaryExtensions } = require('../lib/file-types');
 const deviceOsUtils = require('../lib/device-os-version-util');
 const semver = require('semver');
-const { createFlashSteps, filterModulesToFlash, parseModulesToFlash, flashFiles } = require('../lib/flash-helper');
+const { createFlashSteps, filterModulesToFlash, parseModulesToFlash, flashFiles, validateDFUSupport } = require('../lib/flash-helper');
 
 module.exports = class FlashCommand extends CLICommandBase {
 	constructor(...args) {
@@ -61,6 +61,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 
 		const device = await usbUtils.getOneUsbDevice({ ui: this.ui });
 		const platformName = platformForId(device.platformId).name;
+		validateDFUSupport({ device, ui: this.ui });
 
 		let files;
 		const knownAppPath = knownAppsForPlatform(platformName)[binary];
@@ -96,7 +97,9 @@ module.exports = class FlashCommand extends CLICommandBase {
 		const device = await usbUtils.getOneUsbDevice({ idOrName: deviceIdOrName, api, auth, ui: this.ui });
 
 		const platformName = platformForId(device.platformId).name;
+
 		this.ui.write(`Flashing ${platformName} ${deviceIdOrName || device.id}`);
+		validateDFUSupport({ device, ui: this.ui });
 
 		let { skipDeviceOSFlash, files: filesToFlash } = await this._prepareFilesToFlash({
 			knownApp,

--- a/src/cmd/update.js
+++ b/src/cmd/update.js
@@ -6,7 +6,7 @@ const semver = require('semver');
 const usbUtils = require('./usb-util');
 const deviceOsUtils = require('../lib/device-os-version-util');
 const CLICommandBase = require('./base');
-const { parseModulesToFlash, filterModulesToFlash, createFlashSteps, flashFiles } = require('../lib/flash-helper');
+const { parseModulesToFlash, filterModulesToFlash, createFlashSteps, flashFiles, validateDFUSupport } = require('../lib/flash-helper');
 
 module.exports = class UpdateCommand extends CLICommandBase {
 
@@ -24,6 +24,7 @@ module.exports = class UpdateCommand extends CLICommandBase {
 		const device = await usbUtils.getOneUsbDevice({ idOrName: deviceIdOrName, api, auth, ui: this.ui });
 
 		const version = target || 'latest';
+		validateDFUSupport({ device, ui: this.ui });
 
 		// get platform info
 		const platformName = platformForId(device.platformId).name;

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -262,10 +262,34 @@ async function createFlashSteps({ modules, isInDfuMode, factory, platformId }) {
 }
 
 function validateDFUSupport({ device, ui }) {
-	if (!device.isInDfuMode && (!device.firmwareVersion || semver.lt(device.firmwareVersion, '2.0.0'))) {
-		ui.error('DFU mode is not supported on this device os version.');
-		ui.error('Please switch the device into DFU mode and try again.');
-		throw new Error('DFU mode not supported');
+	if (!device.isInDfuMode && (!semver.valid(device.firmwareVersion) || semver.lt(device.firmwareVersion, '2.0.0'))) {
+		const { chalk } = ui;
+		ui.write(`${chalk.red('!!!')} The device needs to be in DFU mode for this command.\n`);
+		ui.write(`${chalk.cyan('>')} This version of Device OS doesn't support automatically switching to DFU mode.`);
+		ui.write(`${chalk.cyan('>')} To put your device in DFU manually, please:\n`);
+		ui.write([
+			chalk.bold.white('1)'),
+			'Press and hold both the',
+			chalk.bold.cyan('RESET'),
+			'and',
+			chalk.bold.cyan('MODE/SETUP'),
+			'buttons simultaneously.\n'
+		].join(' '));
+		ui.write([
+			chalk.bold.white('2)'),
+			'Release only the',
+			chalk.bold.cyan('RESET'),
+			'button while continuing to hold the',
+			chalk.bold.cyan('MODE/SETUP'),
+			'button.\n'
+		].join(' '));
+		ui.write([
+			chalk.bold.white('3)'),
+			'Release the',
+			chalk.bold.cyan('MODE/SETUP'),
+			'button once the device begins to blink yellow.\n'
+		].join(' '));
+		throw new Error('Put the device in DFU mode and try again');
 	}
 }
 

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -6,6 +6,8 @@ const { moduleTypeToString, sortBinariesByDependency } = require('./dependency-w
 const { HalModuleParser: ModuleParser, ModuleInfo } = require('binary-version-reader');
 const path = require('path');
 const os = require('os');
+const semver = require('semver');
+
 // Flashing an NCP firmware can take a few minutes
 const FLASH_TIMEOUT = 4 * 60000;
 
@@ -259,10 +261,19 @@ async function createFlashSteps({ modules, isInDfuMode, factory, platformId }) {
 	}
 }
 
+function validateDFUSupport({ device, ui }) {
+	if (!device.isInDfuMode && (!device.firmwareVersion || semver.lt(device.firmwareVersion, '2.0.0'))) {
+		ui.error('DFU mode is not supported on this device os version.');
+		ui.error('Please switch the device into DFU mode and try again.');
+		throw new Error('DFU mode not supported');
+	}
+}
+
 module.exports = {
 	flashFiles,
 	filterModulesToFlash,
 	parseModulesToFlash,
 	createFlashSteps,
-	prepareDeviceForFlash
+	prepareDeviceForFlash,
+	validateDFUSupport
 };

--- a/src/lib/flash-helper.test.js
+++ b/src/lib/flash-helper.test.js
@@ -1,5 +1,6 @@
 const { expect, sinon } = require('../../test/setup');
 const { HalModuleParser, firmwareTestHelper, ModuleInfo, createAssetModule } = require('binary-version-reader');
+const chalk = require('chalk');
 const usbUtils = require('../cmd/usb-util');
 const { createFlashSteps, filterModulesToFlash, prepareDeviceForFlash, validateDFUSupport } = require('./flash-helper');
 
@@ -457,11 +458,15 @@ describe('flash-helper', () => {
 		});
 	});
 	describe('validateDFUSupport', () => {
+		let ui;
+		beforeEach(() => {
+			ui = {
+				write: sinon.stub(),
+				chalk
+			};
+		});
 		it('throws an error if the device os version does not support DFU', async () => {
 			let error;
-			const ui = {
-				error: sinon.stub(),
-			};
 			const device = {
 				isInDfuMode: false,
 				platformId: 32,
@@ -472,15 +477,10 @@ describe('flash-helper', () => {
 			} catch (e) {
 				error = e;
 			}
-			expect(error).to.have.property('message', 'DFU mode not supported');
-			expect(ui.error).to.have.been.calledWithMatch('DFU mode is not supported on this device os version.');
-			expect(ui.error).to.have.been.calledWithMatch('Please switch the device into DFU mode and try again.');
+			expect(error).to.have.property('message', 'Put the device in DFU mode and try again');
 		});
 		it('throws an error if the current device os is not defined and the device is not in DFU', async () => {
 			let error;
-			const ui = {
-				error: sinon.stub(),
-			};
 			const device = {
 				isInDfuMode: false,
 				platformId: 32,
@@ -490,15 +490,10 @@ describe('flash-helper', () => {
 			} catch (e) {
 				error = e;
 			}
-			expect(error).to.have.property('message', 'DFU mode not supported');
-			expect(ui.error).to.have.been.calledWithMatch('DFU mode is not supported on this device os version.');
-			expect(ui.error).to.have.been.calledWithMatch('Please switch the device into DFU mode and try again.');
+			expect(error).to.have.property('message', 'Put the device in DFU mode and try again');
 		});
 		it('passes if the device is in DFU mode', async () => {
 			let error;
-			const ui = {
-				error: sinon.stub(),
-			};
 			const device = {
 				isInDfuMode: true,
 				platformId: 32,
@@ -512,9 +507,6 @@ describe('flash-helper', () => {
 		});
 		it('passes if the current device OS is greater than - equals to 2.0.0', async () => {
 			let error;
-			const ui = {
-				error: sinon.stub(),
-			};
 			const device = {
 				isInDfuMode: false,
 				platformId: 32,


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
This PR will add a validation in order to make the user put the device in DFU before using the flash local.
That validation will be required when the current device os version is lower than 2.0.0
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
* Downgrade your device with a very old version: `npm start -- update --target 1.5.0`
* Attempt to flash an application: `npm start -- flash --local ${deviceId} ${binary}`
* Update your device with the latest version: `npm start -- update`
* Attempt to flash an application: `npm start -- flash --local ${deviceId} ${binary}`

**outcome**
For old device os versions: A message will appear indicating that the user needs to put their device in DFU before start the flashing.
For latest device os version: You will be able to flash your device without any message
<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions

Story details: https://app.shortcut.com/particle/story/121836/ask-user-to-switch-to-dfu-for-os-2-0-0-in-local-flash
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

