### PR TITLE
Improve usb device selector output

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -61,8 +61,9 @@ module.exports = class FlashCommand extends CLICommandBase {
 			if (utilities.getFilenameExt(binary) === '.zip') {
 				throw new Error("Use 'particle flash --local' to flash a zipped bundle.");
 			}
-
-			device = await usbUtils.getOneUsbDevice({ ui: this.ui });
+			
+			const { api, auth } = this._particleApi();
+			device = await usbUtils.getOneUsbDevice({ api, auth, ui: this.ui });
 			const platformName = platformForId(device.platformId).name;
 			validateDFUSupport({ device, ui: this.ui });
 

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -61,7 +61,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 			if (utilities.getFilenameExt(binary) === '.zip') {
 				throw new Error("Use 'particle flash --local' to flash a zipped bundle.");
 			}
-			
+
 			const { api, auth } = this._particleApi();
 			device = await usbUtils.getOneUsbDevice({ api, auth, ui: this.ui });
 			const platformName = platformForId(device.platformId).name;

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -32,7 +32,7 @@ async function _getDeviceInfo(device) {
 		}
 	} catch (err) {
 		if (err instanceof TimeoutError) {
-			return { id, mode: 'UNKNOWN'};
+			return { id, mode: 'UNKNOWN' };
 		} else {
 			throw new Error(`Unable to get device mode: ${err.message}`);
 		}
@@ -198,7 +198,7 @@ async function getOneUsbDevice({ idOrName, api, auth, ui }) {
 					const { id, mode } = await _getDeviceInfo(d);
 					const name = await _getDeviceName({ id, api, auth, ui });
 					return {
-						name: `${name || '<no name>'} [${id}] (${platformForId(d._info.id).displayName}${mode ? ', ' + mode : ''})`,
+						name: `${name || '<no name>'} [${id}] (${platformForId(d._info.id).displayName}${mode ? ', ' + mode : '' })`,
 						value: d
 					};
 				}));

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -40,7 +40,6 @@ async function _getDeviceMode(device) {
 	try {
 		await device.open();
 		const mode = await device.getDeviceMode({ timeout: 10 * 1000 });
-		console.log('mode', mode);
 		if (mode && (mode !== 'NORMAL')) {
 			return mode;
 		}
@@ -54,6 +53,15 @@ async function _getDeviceMode(device) {
 		if (device.isOpen) {
 			await device.close();
 		}
+	}
+}
+
+async function _getDeviceName({ id, api, auth, ui }) {
+	try {
+		const device = await getDevice({ id, api, auth, ui });
+		return device.name;
+	} catch (err) {
+		// ignore error
 	}
 }
 
@@ -198,8 +206,9 @@ async function getOneUsbDevice({ idOrName, api, auth, ui }) {
 				return Promise.all(usbDevices.map(async (d) => {
 					const id = await _getDeviceId(d);
 					const mode = await _getDeviceMode(d);
+					const name = await _getDeviceName({ id, api, auth, ui });
 					return {
-						name: `[${id}] (${platformForId(d._info.id).displayName}${mode ? ', ' + mode : ''})`,
+						name: `${name? name: ''} [${id}] (${platformForId(d._info.id).displayName}${mode ? ', ' + mode : ''})`,
 						value: d
 					};
 				}));

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -59,10 +59,13 @@ async function _getDeviceMode(device) {
 async function _getDeviceName({ id, api, auth, ui }) {
 	try {
 		const device = await getDevice({ id, api, auth, ui });
-		return device.name;
+		if (device && device.name) {
+			return device.name;
+		}
 	} catch (err) {
-		// ignore error
+		return '<unknown>';
 	}
+	return null;
 }
 
 /**
@@ -208,7 +211,7 @@ async function getOneUsbDevice({ idOrName, api, auth, ui }) {
 					const mode = await _getDeviceMode(d);
 					const name = await _getDeviceName({ id, api, auth, ui });
 					return {
-						name: `${name? name: ''} [${id}] (${platformForId(d._info.id).displayName}${mode ? ', ' + mode : ''})`,
+						name: `${name || '<no name>'} [${id}] (${platformForId(d._info.id).displayName}${mode ? ', ' + mode : ''})`,
 						value: d
 					};
 				}));


### PR DESCRIPTION
## Description

Device selector will now show more details

With user creds and api connectivity available
```

? Which device would you like to select? (Use arrow keys)
❯ seal_penguin [0a10aced202194944a02c4d4] (Photon 2 / P2, LISTENING) 
  morphing_banjo [e00fce6819ef5f971ea9563a] (Argon) 

```

Without api connectivity, it does not show the name
```
? Which device would you like to select? (Use arrow keys)
❯  [0a10aced202194944a02c4d4] (Photon 2 / P2, LISTENING) 
   [e00fce6819ef5f971ea9563a] (Argon) 
```

## How to Test

1. Checkout his branch to test
2. Connect at least two devices
3. Run `npm start -- flash --usb app.bin`
4. Ensure the output is as expected

## Related Issues / Discussions
 NA


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

