### PR TITLE
Feature/sc 122867/make particle usb flash be aware of device

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -100,11 +100,12 @@ module.exports = class FlashCommand extends CLICommandBase {
 			this.ui.write(`Flashing ${platformName} device ${device.id}`);
 			const resetAfterFlash = !factory && modulesToFlash[0].prefixInfo.moduleFunction === ModuleInfo.FunctionType.USER_PART;
 			await flashFiles({ device, flashSteps, resetAfterFlash, ui: this.ui });
+		} catch (error) {
+			throw error;
 		} finally {
 			if (device && device.isOpen) {
 				await device.close();
 			}
-			throw error;
 		}
 	}
 

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -16,7 +16,14 @@ const { knownAppNames, knownAppsForPlatform } = require('../lib/known-apps');
 const { sourcePatterns, binaryPatterns, binaryExtensions } = require('../lib/file-types');
 const deviceOsUtils = require('../lib/device-os-version-util');
 const semver = require('semver');
-const { createFlashSteps, filterModulesToFlash, parseModulesToFlash, flashFiles, validateDFUSupport } = require('../lib/flash-helper');
+const {
+	createFlashSteps,
+	filterModulesToFlash,
+	parseModulesToFlash,
+	flashFiles,
+	validateDFUSupport,
+	getFileFlashInfo
+} = require('../lib/flash-helper');
 const createApiCache = require('../lib/api-cache');
 
 module.exports = class FlashCommand extends CLICommandBase {
@@ -63,7 +70,8 @@ module.exports = class FlashCommand extends CLICommandBase {
 			}
 
 			const { api, auth } = this._particleApi();
-			device = await usbUtils.getOneUsbDevice({ api, auth, ui: this.ui });
+			const { flashMode, platformId } = await getFileFlashInfo(binary);
+			device = await usbUtils.getOneUsbDevice({ api, auth, ui: this.ui, flashMode, platformId });
 			const platformName = platformForId(device.platformId).name;
 			validateDFUSupport({ device, ui: this.ui });
 
@@ -96,6 +104,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 			if (device && device.isOpen) {
 				await device.close();
 			}
+			throw error;
 		}
 	}
 

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -192,12 +192,15 @@ async function getOneUsbDevice({ idOrName, api, auth, ui, flashMode, platformId 
 		const { id, mode } = await _getDeviceInfo(d);
 		const name = await _getDeviceName({ id, api, auth, ui });
 		return {
+			id,
 			name: `${name} [${id}] (${(platformForId(d._info.id)).displayName}${mode ? ', ' + mode : '' })`,
 			platformId: d._info.id,
 			mode,
 			value: d
 		};
 	}));
+
+	devices = devices.sort((d1, d2) => d1.id.localeCompare(d2.id));
 
 	if (flashMode === 'DFU') {
 		devices = devices.filter(d => dfuModes.includes(d.mode));

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -1,7 +1,7 @@
 const _ = require('lodash');
 const usbUtils = require('../cmd/usb-util');
 const { delay } = require('./utilities');
-const { PLATFORMS } =require('./platform');
+const { PLATFORMS, platformForId } =require('./platform');
 const { moduleTypeToString, sortBinariesByDependency } = require('./dependency-walker');
 const { HalModuleParser: ModuleParser, ModuleInfo } = require('binary-version-reader');
 const path = require('path');
@@ -279,7 +279,8 @@ async function createFlashSteps({ modules, isInDfuMode, factory, platformId }) {
 }
 
 function validateDFUSupport({ device, ui }) {
-	if (!device.isInDfuMode && (!semver.valid(device.firmwareVersion) || semver.lt(device.firmwareVersion, '2.0.0'))) {
+	const platform = platformForId(device.platformId);
+	if (!device.isInDfuMode && (!semver.valid(device.firmwareVersion) || semver.lt(device.firmwareVersion, '2.0.0')) && platform.generation === 2) {
 		ui.logDFUModeRequired({ showVersionWarning: true });
 		throw new Error('Put the device in DFU mode and try again');
 	}

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -280,7 +280,7 @@ async function createFlashSteps({ modules, isInDfuMode, factory, platformId }) {
 
 function validateDFUSupport({ device, ui }) {
 	if (!device.isInDfuMode && (!semver.valid(device.firmwareVersion) || semver.lt(device.firmwareVersion, '2.0.0'))) {
-		ui.logDFUModeRequired(true);
+		ui.logDFUModeRequired({ showVersionWarning: true });
 		throw new Error('Put the device in DFU mode and try again');
 	}
 }

--- a/src/lib/flash-helper.test.js
+++ b/src/lib/flash-helper.test.js
@@ -468,7 +468,9 @@ describe('flash-helper', () => {
 		beforeEach(() => {
 			ui = {
 				write: sinon.stub(),
-				chalk
+				chalk,
+				logDFUModeRequired: sinon.stub(),
+				logNormalModeRequired: sinon.stub()
 			};
 		});
 		it('throws an error if the device os version does not support DFU', async () => {
@@ -483,7 +485,8 @@ describe('flash-helper', () => {
 			} catch (e) {
 				error = e;
 			}
-			expect(error).to.have.property('message', 'Put the device in DFU mode and try again');
+			expect(ui.logDFUModeRequired).to.be.called;
+			expect(error.message).to.equal('Put the device in DFU mode and try again');
 		});
 		it('throws an error if the current device os is not defined and the device is not in DFU', async () => {
 			let error;
@@ -496,7 +499,8 @@ describe('flash-helper', () => {
 			} catch (e) {
 				error = e;
 			}
-			expect(error).to.have.property('message', 'Put the device in DFU mode and try again');
+			expect(ui.logDFUModeRequired).to.be.called;
+			expect(error.message).to.equal('Put the device in DFU mode and try again');
 		});
 		it('passes if the device is in DFU mode', async () => {
 			let error;

--- a/src/lib/flash-helper.test.js
+++ b/src/lib/flash-helper.test.js
@@ -477,7 +477,7 @@ describe('flash-helper', () => {
 			let error;
 			const device = {
 				isInDfuMode: false,
-				platformId: 32,
+				platformId: 6,
 				firmwareVersion: '1.0.0',
 			};
 			try {
@@ -492,7 +492,7 @@ describe('flash-helper', () => {
 			let error;
 			const device = {
 				isInDfuMode: false,
-				platformId: 32,
+				platformId: 6,
 			};
 			try {
 				await validateDFUSupport({ device, ui });

--- a/src/lib/flash-helper.test.js
+++ b/src/lib/flash-helper.test.js
@@ -2,7 +2,17 @@ const { expect, sinon } = require('../../test/setup');
 const { HalModuleParser, firmwareTestHelper, ModuleInfo, createAssetModule } = require('binary-version-reader');
 const chalk = require('chalk');
 const usbUtils = require('../cmd/usb-util');
-const { createFlashSteps, filterModulesToFlash, prepareDeviceForFlash, validateDFUSupport } = require('./flash-helper');
+const {
+	createFlashSteps,
+	filterModulesToFlash,
+	prepareDeviceForFlash,
+	validateDFUSupport,
+	getFileFlashInfo
+} = require('./flash-helper');
+const { PATH_TMP_DIR } = require('../../test/lib/env');
+const path = require('path');
+const fs = require('fs-extra');
+const { ensureDir } = require('fs-extra/lib/mkdirs');
 
 describe('flash-helper', () => {
 	const createModules = async () => {
@@ -515,5 +525,53 @@ describe('flash-helper', () => {
 			}
 			expect(error).to.be.undefined;
 		});
+	});
+
+	describe('getFileFlashInfo', () => {
+		const createBinary = async (moduleFunction, platformId) => {
+			const tempPath = 'flash-mode/binaries';
+			const fileName = 'my-binary.bin';
+			const binary = firmwareTestHelper.createFirmwareBinary({
+				platformId: platformId,
+				moduleFunction: moduleFunction,
+			});
+			// save binary
+			const filePath = path.join(PATH_TMP_DIR, tempPath);
+			const file = path.join(filePath, fileName);
+			await ensureDir(filePath);
+			await fs.writeFile(file, binary);
+			return file;
+		};
+
+		afterEach(async () => {
+			await fs.remove(path.join(PATH_TMP_DIR, 'flash-mode/binaries'));
+		});
+
+		it('returns dfu for known apps', async() => {
+			const fileName = 'tinker';
+			const mode = await getFileFlashInfo(fileName);
+			expect(mode).to.deep.equal({ flashMode: 'DFU' });
+		});
+		it('returns dfu for system parts', async () => {
+			const p2PlatformId = 32;
+			const file = await createBinary(ModuleInfo.FunctionType.SYSTEM_PART, p2PlatformId);
+			const mode = await getFileFlashInfo(file);
+			expect(mode).to.deep.equal({ flashMode: 'DFU', platformId: 32 });
+		});
+
+		it('returns normal for bootloader', async() => {
+			const p2PlatformId = 32;
+			const file = await createBinary(ModuleInfo.FunctionType.BOOTLOADER, p2PlatformId);
+			const mode = await getFileFlashInfo(file);
+			expect(mode).to.deep.equal({ flashMode: 'NORMAL', platformId: 32 });
+		});
+
+		it ('returns normal for ncp', async() => {
+			const trackerPlatformId = 26;
+			const file = await createBinary(ModuleInfo.FunctionType.NCP_FIRMWARE, trackerPlatformId);
+			const mode = await getFileFlashInfo(file);
+			expect(mode).to.deep.equal({ flashMode: 'NORMAL', platformId: 26 });
+		});
+
 	});
 });

--- a/src/lib/ui/index.js
+++ b/src/lib/ui/index.js
@@ -79,6 +79,46 @@ module.exports = class UI {
 		settings.override(settings.profile, 'flashWarningShownOn', Date.now());
 	}
 
+	logDFUModeRequired({ showVersionWarning } = {}) {
+		this.write(`${this.chalk.red('!!!')} The device needs to be in DFU mode for this command.\n`);
+		if (showVersionWarning ) {
+			this.write(`${this.chalk.cyan('>')} This version of Device OS doesn't support automatically switching to DFU mode.`);
+		}
+		this.write(`${this.chalk.cyan('>')} To put your device in DFU manually, please:\n`);
+		this.write([
+			this.chalk.bold.white('1)'),
+			'Press and hold both the',
+			this.chalk.bold.cyan('RESET'),
+			'and',
+			this.chalk.bold.cyan('MODE/SETUP'),
+			'buttons simultaneously.\n'
+		].join(' '));
+		this.write([
+			this.chalk.bold.white('2)'),
+			'Release only the',
+			this.chalk.bold.cyan('RESET'),
+			'button while continuing to hold the',
+			this.chalk.bold.cyan('MODE/SETUP'),
+			'button.\n'
+		].join(' '));
+		this.write([
+			this.chalk.bold.white('3)'),
+			'Release the',
+			this.chalk.bold.cyan('MODE/SETUP'),
+			'button once the device begins to blink yellow.\n'
+		].join(' '));
+	}
+
+	logNormalModeRequired() {
+		this.write(`${this.chalk.red('!!!')} The device needs to be in Normal mode for this command.\n`);
+		this.write(`${this.chalk.cyan('>')} To put your device in Normal mode manually, please:\n`);
+		this.write([
+			'Press the',
+			this.chalk.bold.cyan('RESET'),
+			'button and Release it'
+		].join(' '));
+	}
+
 	logDeviceDetail(devices, { varsOnly = false, fnsOnly = false } = {}){
 		const { EOL, chalk } = this;
 		const deviceList = Array.isArray(devices) ? devices : [devices];


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
This PR will make `flash --usb` be aware of the device mode and the platform depending on the `binary` to be flashed.

<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test

### DFU
1. Connect several devices to the computer
2. put all the devices in normal mode
3. Attempt to flash an specific `user-part` application and platform
4. Put different devices (with different platforms) in DFU mode including your device
5. Repeat step 3
6. Put some devices (with the same platform) in DFU mode
7. Repeat step 3


**outcome** 
* After step 2 you will see an error indicating your device needs to be in DFU
* After step 4 your device will start flashing
* After step 6 you will see a list of devices in DFU mode that has the required platform for the user application you attempt to flash

### Tinker
1. Connect several devices to the computer
2. put all the devices in normal mode
3. Attempt to flash the known application:`flash --usb tinker`
4. Put different devices (with different platforms) in DFU mode including your device
5. Repeat step 3



**outcome** 
* After step 2 you will see an error indicating your device needs to be in DFU
* After step 4 you will see a list of devices in DFU mode no matter the platform 

Explanation:
Tinker word doesn't have anything that we could guess the platform the user wants to flash. That's the reason we show all connected devices with DFU mode actived.

### Normal mode / listening
1. Connect several devices to the computer
2. put all the devices in DFU mode
3. Attempt to flash a bootloader file for an specific device
4. Put different devices (with different platforms) in NORMAL/LISTENING mode including your device
5. Repeat step 3
6. Put some devices (with the same platform) in NORMAL/LISTENING mode
7. Repeat step 3


**outcome** 
* After step 2 you will see an error indicating your device needs to be in NORMAL mode
* After step 4 your device will start flashing
* After step 6 you will see a list of devices in DFU mode that has the required platform for the user application you attempt to flash


### Regression testing

1. Attempt to update your device: `npm start -- update`
2. Attempt to flash local your device (3rd Party OTA): `npm start -- flash --local ...`

## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/122867
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

