### PR TITLE
add a missing return for single devices

### DIFF
--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -185,6 +185,7 @@ async function getOneUsbDevice({ idOrName, api, auth, ui, flashMode, platformId 
 	if (idOrName) {
 		const device = await openUsbDeviceByIdOrName(idOrName, api, auth, { dfuMode: true });
 		await checkFlashMode({ flashMode, device });
+		return device;
 	}
 
 	const usbDevices = await getUsbDevices({ dfuMode: true });


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
This PR will fix the issue regarding `flash --local` is not picking the deviceId/Name from the params
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
1. Connect several devices into your computer
2. Attempt to do a `npm start -- flash --local ${deviceName/id} binary.bin`

**outcome** 
The flash process will start with the selected device (into params)

<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions

Story details: https://app.shortcut.com/particle/story/122967/issue-particle-flash-local-is-not-getting-deviceid-name-from-params
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

