### PR TITLE
fix: [sc-123209] Flashing Electron 2.3.1 using `flash --local` returns error

### DIFF
--- a/src/lib/dependency-walker.js
+++ b/src/lib/dependency-walker.js
@@ -118,27 +118,18 @@ async function sortBinariesByDependency(modules) {
 
 
 
-function moduleTypeToString(str) {
-	switch (str) {
-		case ModuleInfo.FunctionType.BOOTLOADER:
-			return 'bootloader';
-		case ModuleInfo.FunctionType.SYSTEM_PART:
-			return 'systemPart';
-		case ModuleInfo.FunctionType.USER_PART:
-			return 'userPart';
-		case ModuleInfo.FunctionType.RADIO_STACK:
-			return 'radioStack';
-		case ModuleInfo.FunctionType.NCP_FIRMWARE:
-			return 'ncpFirmware';
-		case ModuleInfo.FunctionType.ASSET:
-			return 'assets';
-		default:
-			throw new Error(`Unknown module type: ${str}`);
+function moduleTypeFromNumber(num) {
+	for (const typeStr of Object.keys(ModuleInfo.FunctionType)) {
+		if (ModuleInfo.FunctionType[typeStr] === num) {
+			// convert from capital to camel case. SYSTEM_PART => systemPart
+			return typeStr.toLowerCase().replace(/_(.)/g, (g) => g[1].toUpperCase());
+		}
 	}
+	throw new Error(`Unknown module type: ${num}`);
 }
 
 module.exports = {
 	DependencyWalker,
 	sortBinariesByDependency,
-	moduleTypeToString
+	moduleTypeFromNumber
 };

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -205,7 +205,7 @@ async function getFileFlashInfo(file) {
 	if (!await fs.pathExists(file)) {
 		return { flashMode: 'DFU' };
 	}
-	const normalModules = ['assets', 'bootloader'];
+	const normalModules = ['asset', 'bootloader'];
 	const parser = new ModuleParser();
 	const binary = await parser.parseFile(file);
 	const moduleType = moduleTypeFromNumber(binary.prefixInfo.moduleFunction);
@@ -244,7 +244,7 @@ async function createFlashSteps({ modules, isInDfuMode, factory, platformId }) {
 			factoryAddress = parseInt(segment.address, 16);
 		}
 
-		if (moduleType === 'assets') {
+		if (moduleType === 'asset') {
 			flashStep.flashMode = 'normal';
 			assetModules.push(flashStep);
 		} else if (moduleType === 'bootloader' || moduleDefinition.storage === 'externalMcu') {

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -2,7 +2,7 @@ const _ = require('lodash');
 const usbUtils = require('../cmd/usb-util');
 const { delay } = require('./utilities');
 const { PLATFORMS, platformForId } =require('./platform');
-const { moduleTypeToString, sortBinariesByDependency } = require('./dependency-walker');
+const { moduleTypeFromNumber, sortBinariesByDependency } = require('./dependency-walker');
 const { HalModuleParser: ModuleParser, ModuleInfo } = require('binary-version-reader');
 const path = require('path');
 const fs = require('fs-extra');
@@ -175,7 +175,7 @@ function filterModulesToFlash({ modules, platformId, allowAll = false }) {
 	const filteredModules = [];
 	// remove encrypted files
 	for (const moduleInfo of modules) {
-		const moduleType = moduleTypeToString(moduleInfo.prefixInfo.moduleFunction);
+		const moduleType = moduleTypeFromNumber(moduleInfo.prefixInfo.moduleFunction);
 		const platformModule = platform.firmwareModules.find(m => m.type === moduleType && m.index === moduleInfo.prefixInfo.moduleIndex);
 		// filter encrypted modules
 		const isEncrypted = platformModule && platformModule.encrypted;
@@ -208,7 +208,7 @@ async function getFileFlashInfo(file) {
 	const normalModules = ['assets', 'bootloader'];
 	const parser = new ModuleParser();
 	const binary = await parser.parseFile(file);
-	const moduleType = moduleTypeToString(binary.prefixInfo.moduleFunction);
+	const moduleType = moduleTypeFromNumber(binary.prefixInfo.moduleFunction);
 	const moduleDefinition = PLATFORMS.find(p => p.id === binary.prefixInfo.platformID).firmwareModules
 		.find(firmwareModule => firmwareModule.type === moduleType);
 
@@ -228,9 +228,9 @@ async function createFlashSteps({ modules, isInDfuMode, factory, platformId }) {
 			name: path.basename(module.filename),
 			data
 		};
-		const moduleType = moduleTypeToString(module.prefixInfo.moduleFunction);
+		const moduleType = moduleTypeFromNumber(module.prefixInfo.moduleFunction);
 		const moduleDefinition = platform.firmwareModules
-			.find(firmwareModule => firmwareModule.type === moduleType);
+			.find(firmwareModule => firmwareModule.type === moduleType) || {};
 
 		let factoryAddress;
 		if (factory) {


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/123209

Fixes the inability to flash monolithic debug firmware for Photon and Electron with `particle flash --local`.
