### PR TITLE
Flash mono builds over `flash --usb` command

### DIFF
--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -212,7 +212,7 @@ async function getFileFlashInfo(file) {
 	const moduleDefinition = PLATFORMS.find(p => p.id === binary.prefixInfo.platformID).firmwareModules
 		.find(firmwareModule => firmwareModule.type === moduleType);
 	if (!moduleDefinition) {
-		throw new Error(`Module type ${moduleType} unsupported for ${PLATFORMS.find(p => p.id === binary.prefixInfo.platformID)}`);
+		throw new Error(`Module type ${moduleType} unsupported for ${PLATFORMS.find(p => p.id === binary.prefixInfo.platformID).name}`);
 	}
 	return {
 		flashMode: normalModules.includes(moduleType) || moduleDefinition.storage === 'externalMcu' ? 'NORMAL' : 'DFU',

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -211,7 +211,9 @@ async function getFileFlashInfo(file) {
 	const moduleType = moduleTypeFromNumber(binary.prefixInfo.moduleFunction);
 	const moduleDefinition = PLATFORMS.find(p => p.id === binary.prefixInfo.platformID).firmwareModules
 		.find(firmwareModule => firmwareModule.type === moduleType);
-
+	if (!moduleDefinition) {
+		throw new Error(`Module type ${moduleType} unsupported for ${PLATFORMS.find(p => p.id === binary.prefixInfo.platformID)}`);
+	}
 	return {
 		flashMode: normalModules.includes(moduleType) || moduleDefinition.storage === 'externalMcu' ? 'NORMAL' : 'DFU',
 		platformId: binary.prefixInfo.platformID

--- a/src/lib/flash-helper.test.js
+++ b/src/lib/flash-helper.test.js
@@ -577,5 +577,18 @@ describe('flash-helper', () => {
 			expect(mode).to.deep.equal({ flashMode: 'NORMAL', platformId: 26 });
 		});
 
+		it ('returns an error for mono builds', async() => {
+			const p2PlatformId = 32;
+			const file = await createBinary(ModuleInfo.FunctionType.MONO_FIRMWARE, p2PlatformId);
+			let error;
+			try {
+				await getFileFlashInfo(file);
+			} catch (e) {
+				error = e;
+			}
+			expect(error).to.be.an.instanceOf(Error);
+			expect(error).to.have.property('message', 'Module type monoFirmware unsupported for p2');
+		});
+
 	});
 });


### PR DESCRIPTION
## Description

Flash mono builds over `flash --usb` command

## How to Test

Run `particle flash --usb /path/to/mono-firmware.bin` on mono supported builds.

## Related Issues / Discussions



## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

