### PR TITLE
add hide option for command options

### DIFF
--- a/src/app/command-processor.js
+++ b/src/app/command-processor.js
@@ -108,6 +108,7 @@ class CLICommandItem {
 	 */
 	configure(yargs, { options, setup, examples, version, epilogue } = this.buildOptions()){
 		if (options){
+			this.hideOption(options);
 			this.fetchAliases(options);
 			this.configureOptions(options);
 			// avoid converting positional arguments to numbers by default
@@ -135,6 +136,21 @@ class CLICommandItem {
 		}
 
 		yargs.exitProcess(false);
+	}
+
+	/**
+	 * Hides options that are marked as hidden. (by removing the description)
+	 * See here -> https://github.com/yargs/yargs/issues/851
+	 * @param options
+	 */
+	hideOption(options){
+		const optionKeys = Object.keys(options);
+		optionKeys.forEach((key) => {
+			const option = options[key];
+			if (option.hidden){
+				option.description = undefined;
+			}
+		});
 	}
 
 	fetchAliases(options){

--- a/src/cli/logic-function.js
+++ b/src/cli/logic-function.js
@@ -4,7 +4,8 @@ module.exports = ({ commandProcessor, root }) => {
 	commandProcessor.createCommand(logicFunction, 'list', 'Lists the deployed logic functions', {
 		options: {
 			'org': {
-				description: 'Specify the organization'
+				description: 'Specify the organization',
+				hidden: true
 			}
 		},
 		handler: (args) => {
@@ -16,7 +17,8 @@ module.exports = ({ commandProcessor, root }) => {
 	commandProcessor.createCommand(logicFunction, 'get', 'Downloads the logic function', {
 		options: {
 			'org': {
-				description: 'Specify the organization'
+				description: 'Specify the organization',
+				hidden: true
 			},
 			'name': {
 				description: 'Name of the logic function'
@@ -35,7 +37,8 @@ module.exports = ({ commandProcessor, root }) => {
 		params: '[filepath]',
 		options: {
 			'org': {
-				description: 'Specify the organization'
+				description: 'Specify the organization',
+				hidden: true
 			},
 			'name': {
 				description: 'Name of the logic function'
@@ -51,7 +54,8 @@ module.exports = ({ commandProcessor, root }) => {
 		params: '[filepath]',
 		options: {
 			'org': {
-				description: 'Specify the organization'
+				description: 'Specify the organization',
+				hidden: true
 			},
 			'data': {
 				description: 'Sample test data file to verify the logic function'
@@ -70,7 +74,8 @@ module.exports = ({ commandProcessor, root }) => {
 		params: '[filepath]',
 		options: {
 			'org': {
-				description: 'Specify the organization'
+				description: 'Specify the organization',
+				hidden: true
 			}
 		},
 		handler: (args) => {
@@ -82,7 +87,8 @@ module.exports = ({ commandProcessor, root }) => {
 	commandProcessor.createCommand(logicFunction, 'disable', 'Disables a logic function in the cloud', {
 		options: {
 			'org': {
-				description: 'Specify the organization'
+				description: 'Specify the organization',
+				hidden: true
 			},
 			'name': {
 				description: 'Name of the logic function'
@@ -100,7 +106,8 @@ module.exports = ({ commandProcessor, root }) => {
 	commandProcessor.createCommand(logicFunction, 'delete', 'Deletes a logic function from the cloud', {
 		options: {
 			'org': {
-				description: 'Specify the organization'
+				description: 'Specify the organization',
+				hidden: true
 			},
 			'name': {
 				description: 'Name of the logic function'
@@ -118,7 +125,8 @@ module.exports = ({ commandProcessor, root }) => {
 	commandProcessor.createCommand(logicFunction, 'logs', 'Deletes a logic function from the cloud', {
 		options: {
 			'org': {
-				description: 'Specify the organization'
+				description: 'Specify the organization',
+				hidden: true
 			},
 			'name': {
 				description: 'Name of the logic function'


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
This PR will add the ability to hide some options in help command
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
 1. Pull down the branch: `git pull && git checkout feature/sc-123965/hide-options-in-cli`
 2. Install dependencies: `npm i`
 3. Run unit tests: `npm run test:unit`
 4. run `--help` option for every `logic-function` command
 5. Attempt to use all known options for each command.

**Outcome**
* Tests should pass
* options marked with `hidden` should not appear in help
* all options will be used
<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/123965
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

