### PR TITLE
Feature/sc 123399/delete and disable

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8742,7 +8742,6 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
       "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
-      "deprecated": "16.1.1",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.4.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -8742,6 +8742,7 @@
       "version": "7.5.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
       "integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+      "deprecated": "16.1.1",
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.4.0",

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -257,6 +257,23 @@ module.exports = class ParticleApi {
 		}));
 	}
 
+	deleteLogicFunction({ org, id }) {
+		return this._wrap(this.api.deleteLogicFunction({
+			org: org,
+			logicFunctionId: id,
+			auth: this.accessToken,
+		}));
+	}
+
+	updateLogicFunction({ org, id, logicFunctionData }) {
+		return this._wrap(this.api.updateLogicFunction({
+			org: org,
+			logicFunctionId: id,
+			data: logicFunctionData,
+			auth: this.accessToken
+		}));
+	}
+
 	_wrap(promise){
 		return Promise.resolve(promise)
 			.then(result => result.body || result)

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -269,7 +269,7 @@ module.exports = class ParticleApi {
 		return this._wrap(this.api.updateLogicFunction({
 			org: org,
 			logicFunctionId: id,
-			data: logicFunctionData,
+			logicFunction: logicFunctionData,
 			auth: this.accessToken
 		}));
 	}

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -334,8 +334,14 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 	}
 
 	async disable({ org, name, id }) {
-		// TODO
-		console.log(org, name, id);
+		const api = createAPI();
+		({ name, id } = await this._getLogicFunctionIdAndName(org, name, id));
+
+		try {
+			await api.updateLogicFunction({ org, id, logicFunctionData});
+		} catch (err) {
+			throw new Error(`Error disabling Logic Function ${name}: ${err.message}`);
+		}
 	}
 
 	async delete({ org, name, id }) {

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -339,8 +339,27 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 	}
 
 	async delete({ org, name, id }) {
-		// TODO
-		console.log(org, name, id);
+		const api = createAPI();
+		({ name, id } = await this._getLogicFunctionIdAndName(org, name, id));
+
+		const confirm = await this._prompt({
+			type: 'confirm',
+			name: 'delete',
+			message: `Are you sure you want to delete Logic Function ${name}? This action cannot be undone.`,
+			choices: Boolean
+		});
+
+		if (confirm.delete) {
+			try {
+				await api.deleteLogicFunction({ org, id });
+				this.ui.stdout.write(`Logic Function ${name}(${id}) has been successfully deleted.`);
+			} catch (err) {
+				throw new Error(`Error deleting Logic Function ${name}: ${err.message}`);
+			}
+		} else {
+			this.ui.stdout.write(`Aborted.${os.EOL}`);
+			process.exit(0);
+		}
 	}
 
 	async logs({ org, name, id, saveTo }) {

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -337,8 +337,14 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 		const api = createAPI();
 		({ name, id } = await this._getLogicFunctionIdAndName(org, name, id));
 
+		let logicFunctionJson = await this._getLogicFunctionData({ org, id });
+		logicFunctionJson.logic_function.enabled = false;
+		const obj = logicFunctionJson.logic_function;
+
 		try {
-			await api.updateLogicFunction({ org, id, logicFunctionData});
+			const res = await api.updateLogicFunction({ org, id, logicFunctionData: obj  });
+			this.ui.stdout.write(`Logic Function ${name}(${id}) is now disabled.${os.EOL}`);
+			return res;
 		} catch (err) {
 			throw new Error(`Error disabling Logic Function ${name}: ${err.message}`);
 		}

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -183,6 +183,7 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 				_exit();
 			}
 		}
+		return exists;
 	}
 
 	// Prompts the user to overwrite if any files exist
@@ -355,13 +356,21 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 	}
 
 	async _overwriteIfLFExistsLocally(name, id) {
+		const { dirPath, jsonPath, jsPath } = this._getLocalLFPathNames(name);
+
+		const exist = await this._validatePaths({ dirPath, jsonPath, jsPath });
+
+		if (!exist) {
+			return;
+		}
+
 		const logicFunctionData = await this._getLogicFunctionData(id);
 
 		const { logicFunctionConfigData, logicFunctionCode } = this._serializeLogicFunction(logicFunctionData);
 
-		const { dirPath, jsonPath, jsPath } = await this._generateFiles({ logicFunctionConfigData, logicFunctionCode, name });
+		const { genDirPath, genJsonPath, genJsPath } = await this._generateFiles({ logicFunctionConfigData, logicFunctionCode, name });
 
-		this._printDisableNewFilesOutput({ dirPath, jsonPath, jsPath });
+		this._printDisableNewFilesOutput({ dirPath: genDirPath, jsonPath: genJsonPath, jsPath: genJsPath });
 	}
 
 	_printDisableOutput(name, id) {

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -344,7 +344,7 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 		logicFunctionJson.logic_function.enabled = false;
 
 		try {
-			await this.api.updateLogicFunction({ org, id, logicFunctionData: logicFunctionJson.logic_function  });
+			await this.api.updateLogicFunction({ org, id, logicFunctionData: logicFunctionJson.logic_function });
 			this._printDisableOutput(name, id);
 		} catch (err) {
 			throw new Error(`Error disabling Logic Function ${name}: ${err.message}`);

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -691,12 +691,12 @@ describe('LogicFunctionCommands', () => {
 				.reply(201, { logic_function: logicFunc1Data });
 			sinon.stub(logicFunctionCommands, '_prompt').resolves({ overwrite: true });
 			sinon.stub(logicFunctionCommands, '_printDisableOutput').resolves({ });
-			sinon.stub(logicFunctionCommands, 'get').resolves({ });
+			sinon.stub(logicFunctionCommands, '_overwriteIfLFExistsLocally').resolves({ });
 
 			await logicFunctionCommands.disable({ name: 'LF1' });
 
 			expect(logicFunctionCommands._printDisableOutput).to.have.been.calledOnce;
-			expect(logicFunctionCommands.get).to.have.been.calledOnce;
+			expect(logicFunctionCommands._overwriteIfLFExistsLocally).to.have.been.calledOnce;
 		});
 
 		it('disables a logic function with id', async() => {
@@ -705,12 +705,12 @@ describe('LogicFunctionCommands', () => {
 				.intercept('/logic/functions/0021e8f4-64ee-416d-83f3-898aa909fb1b', 'PUT')
 				.reply(201, { logic_function: logicFunc1Data });
 			sinon.stub(logicFunctionCommands, '_printDisableOutput').resolves({ });
-			sinon.stub(logicFunctionCommands, 'get').resolves({ });
+			sinon.stub(logicFunctionCommands, '_overwriteIfLFExistsLocally').resolves({ });
 
 			await logicFunctionCommands.disable({ id: '0021e8f4-64ee-416d-83f3-898aa909fb1b' });
 
 			expect(logicFunctionCommands._printDisableOutput).to.have.been.calledOnce;
-			expect(logicFunctionCommands.get).to.have.been.calledOnce;
+			expect(logicFunctionCommands._overwriteIfLFExistsLocally).to.have.been.calledOnce;
 		});
 
 		it('fails to disable a logic function', async() => {

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -631,7 +631,7 @@ describe('LogicFunctionCommands', () => {
 			}
 
 			expect(error).to.be.an.instanceOf(Error);
-			expect(error.message).to.eql('Error deleting logic function');
+			expect(error.message).to.contain('Error deleting Logic Function LF1');
 			expect(exitStub.called).to.be.false;
 		});
 	});

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -616,12 +616,12 @@ describe('LogicFunctionCommands', () => {
 			expect(exitStub.called).to.be.true;
 		});
 
-		it('throws an error if deleting fails', async() => {
+		it('throws an error if deletion fails', async() => {
 			const exitStub = sinon.stub(process, 'exit');
-			sinon.stub(logicFunctionCommands, '_prompt').resolves({ delete: false });
+			sinon.stub(logicFunctionCommands, '_prompt').resolves({ delete: true });
 			nock('https://api.particle.io/v1',)
 				.intercept('/logic/functions/0021e8f4-64ee-416d-83f3-898aa909fb1b', 'DELETE')
-				.reply(404, { });
+				.reply(404, {});
 
 			let error;
 			try {

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -640,7 +640,7 @@ describe('LogicFunctionCommands', () => {
 			await logicFunctionCommands.delete({ name: 'LF1' });
 
 			expect(logicFunctionCommands.ui.stdout.write.callCount).to.equal(1);
-			expect(logicFunctionCommands.ui.stdout.write.lastCall.lastArg).to.equal('Aborted.\n');
+			expect(logicFunctionCommands.ui.stdout.write.lastCall.lastArg).to.equal(`Aborted.${os.EOL}`);
 		});
 
 		it('throws an error if deletion fails', async() => {

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -618,7 +618,7 @@ describe('LogicFunctionCommands', () => {
 
 		it('throws an error if deleting fails', async() => {
 			const exitStub = sinon.stub(process, 'exit');
-			sinon.stub(logicFunctionCommands, '_prompt').resolves({ delete: true });
+			sinon.stub(logicFunctionCommands, '_prompt').resolves({ delete: false });
 			nock('https://api.particle.io/v1',)
 				.intercept('/logic/functions/0021e8f4-64ee-416d-83f3-898aa909fb1b', 'DELETE')
 				.reply(404, { });
@@ -637,6 +637,34 @@ describe('LogicFunctionCommands', () => {
 	});
 
 	describe('disable', () => {
-		
+		let logicFunctions = [];
+		logicFunctions.push(logicFunc1.logic_functions[0]);
+		logicFunctions.push(logicFunc2.logic_functions[0]);
+
+		beforeEach(() => {
+			const logicFunc1Data = logicFunc1.logic_functions[0];
+			logicFunc1Data.enabled = false;
+			nock('https://api.particle.io/v1',)
+				.intercept('/logic/functions/0021e8f4-64ee-416d-83f3-898aa909fb1b', 'PUT')
+				.reply(201, { logic_function: logicFunc1Data });
+			nock('https://api.particle.io/v1',)
+				.intercept('/logic/functions/0021e8f4-64ee-416d-83f3-898aa909fb1b', 'GET')
+				.reply(200, { logic_function: logicFunc1.logic_functions[0] });
+			nock('https://api.particle.io/v1',)
+				.intercept('/logic/functions', 'GET')
+				.reply(200, { logic_functions: logicFunctions });
+		});
+
+		it('disables a logic function with name', async() => {
+			const res = await logicFunctionCommands.disable({ name: 'LF1' });
+
+			expect(res.logic_function.enabled).to.be.false;
+		});
+
+		it('disables a logic function with id', async() => {
+			const res = await logicFunctionCommands.disable({ id: '0021e8f4-64ee-416d-83f3-898aa909fb1b' });
+
+			expect(res.logic_function.enabled).to.be.false;
+		});
 	});
 });

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -340,7 +340,7 @@ describe('LogicFunctionCommands', () => {
 
 			const paths = ['dir/', 'dir/path/to/file'];
 
-			const res = await logicFunctionCommands._validatePaths({ dirPath: paths[0], jsonPath: paths[1], _exit: false });
+			const res = await logicFunctionCommands._validatePaths({ dirPath: paths[0], jsonPath: paths[1], _exit: sinon.stub() });
 
 			expect(res).to.eql(false);
 

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -635,4 +635,8 @@ describe('LogicFunctionCommands', () => {
 			expect(exitStub.called).to.be.false;
 		});
 	});
+
+	describe('disable', () => {
+		
+	});
 });

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -342,7 +342,7 @@ describe('LogicFunctionCommands', () => {
 
 			const res = await logicFunctionCommands._validatePaths({ dirPath: paths[0], jsonPath: paths[1], _exit: false });
 
-			expect(res).to.eql(undefined);
+			expect(res).to.eql(false);
 
 		});
 
@@ -365,7 +365,7 @@ describe('LogicFunctionCommands', () => {
 
 			const res = await logicFunctionCommands._validatePaths({ paths });
 
-			expect(res).to.eql(undefined);
+			expect(res).to.eql(true);
 
 		});
 	});

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -183,6 +183,17 @@ describe('LogicFunctionCommands', () => {
 		});
 	});
 
+	describe('_getLocalLFPathNames', async() => {
+		it('returns local file paths where the LF should be saved', () => {
+			const slugName = slugify(name);
+			const { dirPath, jsonPath, jsPath } = logicFunctionCommands._getLocalLFPathNames('LF1');
+
+			expect(dirPath).to.eql(path.join(process.cwd(), slugName));
+			expect(jsonPath).to.eql(path.join(process.cwd(), slugName, `${slugName}.logic.json`));
+			expect(jsPath).to.eql(path.join(process.cwd(), slugName, `${slugName}.js`));
+		});
+	});
+
 	describe('create', () => {
 		it('creates a logic function locally for Sandbox account', async () => {
 			nock('https://api.particle.io/v1', )
@@ -578,6 +589,7 @@ describe('LogicFunctionCommands', () => {
 			nock('https://api.particle.io/v1',)
 				.intercept('/logic/functions', 'GET')
 				.reply(200, { logic_functions: logicFunctions });
+			logicFunctionCommands.logicFuncList = logicFunctions;
 		});
 
 		it('checks for confirmation before deleting', async() => {


### PR DESCRIPTION
## Description

Implements `disable` and `delete` commands for Logic Functions.

## How to Test

The commands are:
```
npm start -- lf delete
npm start -- lf disable
```

## Related Issues / Discussions

https://app.shortcut.com/particle/story/123399/implement-disable-command
https://app.shortcut.com/particle/story/123400/implement-delete-command


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

