### PR TITLE
CLI Logic Functions - Deploy 

### DIFF
--- a/src/cli/logic-function.js
+++ b/src/cli/logic-function.js
@@ -76,7 +76,13 @@ module.exports = ({ commandProcessor, root }) => {
 			'org': {
 				description: 'Specify the organization',
 				hidden: true
-			}
+			},
+			'data': {
+				description: 'Sample test data file to verify the logic function'
+			},
+			'dataPath': {
+				description: 'Sample test data file to verify the logic function'
+			},
 		},
 		handler: (args) => {
 			const LogicFunctionsCmd = require('../cmd/logic-function');

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -274,7 +274,7 @@ module.exports = class ParticleApi {
 		}));
 	}
 
-	createLogicFunction({org, logicFunction}) {
+	createLogicFunction({ org, logicFunction }) {
 		return this._wrap(this.api.createLogicFunction({
 			auth: this.accessToken,
 			org,

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -274,6 +274,14 @@ module.exports = class ParticleApi {
 		}));
 	}
 
+	createLogicFunction({org, logicFunction}) {
+		return this._wrap(this.api.createLogicFunction({
+			auth: this.accessToken,
+			org,
+			logicFunction
+		}));
+	}
+
 	_wrap(promise){
 		return Promise.resolve(promise)
 			.then(result => result.body || result)

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -48,9 +48,7 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 			// We assume at least one trigger
 			this.ui.stdout.write(`- ${item.name} (${item.enabled ? this.ui.chalk.cyanBright('enabled') : this.ui.chalk.cyan('disabled')})${os.EOL}`);
 			this.ui.stdout.write(`	- ID: ${item.id}${os.EOL}`);
-			if (item.logic_triggers[0] && item.logic_triggers[0].type) {
-				this.ui.stdout.write(`	- ${item.logic_triggers[0].type} based trigger ${os.EOL}`);
-			}
+			this.ui.stdout.write(`	- ${item.logic_triggers[0].type} based trigger ${os.EOL}`);
 		});
 		this.ui.stdout.write(`${os.EOL}To view a Logic Function's code, see ${this.ui.chalk.yellow('particle logic-function get')}.${os.EOL}`);
 	}
@@ -365,7 +363,7 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 		logicConfigContent.logic_function.enabled = true;
 		logicConfigContent.logic_function.source.code = logicCodeContent;
 
-		const logicFuncNameDeployed = await this._validateLFName({ name});
+		const logicFuncNameDeployed = await this._validateLFName({ name });
 		if (logicFuncNameDeployed) {
 			try {
 				const confirm = await this._prompt({
@@ -523,7 +521,7 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 		const logicFunctionConfigData = data.logic_function;
 		delete logicFunctionConfigData.source.code;
 
-		return { logicFunctionConfigData: { "logic_function": logicFunctionConfigData }, logicFunctionCode };
+		return { logicFunctionConfigData: { 'logic_function': logicFunctionConfigData }, logicFunctionCode };
 	}
 
 	async _generateFiles({ logicFunctionConfigData, logicFunctionCode, name }) {

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -735,11 +735,9 @@ describe('LogicFunctionCommands', () => {
 	describe('deploy', () => {
 
 		beforeEach(() => {
-
 		});
 
 		afterEach(() => {
-
 		});
 
 		it('deploys a new logic function', async() => {

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -168,29 +168,27 @@ describe('LogicFunctionCommands', () => {
 			const data = { logic_function : logicFunc1.logic_functions[0] };
 			const logicFunctionCode = data.logic_function.source.code;
 			const logicFunctionConfigData = data.logic_function;
-			delete logicFunctionConfigData.source;
 			sinon.stub(logicFunctionCommands, '_validatePaths').resolves(true);
 			const name = 'LF1';
 			const slugName = slugify(name);
 
-			const { dirPath, jsonPath, jsPath } = await logicFunctionCommands._generateFiles({ logicFunctionConfigData, logicFunctionCode, name: 'LF1' });
+			const { jsonPath, jsPath } = await logicFunctionCommands._generateFiles({ logicFunctionConfigData, logicFunctionCode, name: 'LF1' });
 
-			expect(dirPath).to.eql(path.join(process.cwd(), slugName));
-			expect(jsonPath).to.eql(path.join(process.cwd(), slugName, `${slugName}.logic.json`));
-			expect(jsPath).to.eql(path.join(process.cwd(), slugName, `${slugName}.js`));
+			expect(jsonPath).to.eql(path.join(process.cwd(), `${slugName}.logic.json`));
+			expect(jsPath).to.eql(path.join(process.cwd(), `${slugName}.js`));
 
-			await fs.remove(dirPath);
+			await fs.remove(jsonPath);
+			await fs.remove(jsPath);
 		});
 	});
 
 	describe('_getLocalLFPathNames', async() => {
 		it('returns local file paths where the LF should be saved', () => {
 			const slugName = slugify('LF1');
-			const { dirPath, jsonPath, jsPath } = logicFunctionCommands._getLocalLFPathNames('LF1');
+			const { jsonPath, jsPath } = logicFunctionCommands._getLocalLFPathNames('LF1');
 
-			expect(dirPath).to.eql(path.join(process.cwd(), slugName));
-			expect(jsonPath).to.eql(path.join(process.cwd(), slugName, `${slugName}.logic.json`));
-			expect(jsPath).to.eql(path.join(process.cwd(), slugName, `${slugName}.js`));
+			expect(jsonPath).to.eql(path.join(process.cwd(), `${slugName}.logic.json`));
+			expect(jsPath).to.eql(path.join(process.cwd(), `${slugName}.js`));
 		});
 	});
 
@@ -340,7 +338,7 @@ describe('LogicFunctionCommands', () => {
 
 			const paths = ['dir/', 'dir/path/to/file'];
 
-			const res = await logicFunctionCommands._validatePaths({ dirPath: paths[0], jsonPath: paths[1], _exit: sinon.stub() });
+			const res = await logicFunctionCommands._validatePaths({ jsonPath: paths[1], _exit: sinon.stub() });
 
 			expect(res).to.eql(false);
 
@@ -352,7 +350,7 @@ describe('LogicFunctionCommands', () => {
 			sinon.stub(logicFunctionCommands, '_promptOverwrite').resolves(false);
 			const paths = ['dir/', 'dir/path/to/file'];
 
-			await logicFunctionCommands._validatePaths({ dirPath: paths[0], jsonPath: paths[1], _exit: exitStub });
+			await logicFunctionCommands._validatePaths({ jsonPath: paths[1], _exit: exitStub });
 
 			expect(logicFunctionCommands._promptOverwrite.callCount).to.eql(1);
 			expect(exitStub.callCount).to.eql(1);
@@ -741,6 +739,8 @@ describe('LogicFunctionCommands', () => {
 		});
 
 		afterEach(() => {
+			fs.rmSync('lf1', { recursive: true, force: true });
+			nock.cleanAll();
 		});
 
 		it('deploys a new logic function', async() => {

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -336,9 +336,7 @@ describe('LogicFunctionCommands', () => {
 		it('returns if paths do not exist', async () => {
 			sinon.stub(fs, 'pathExists').resolves(false);
 
-			const paths = ['dir/', 'dir/path/to/file'];
-
-			const res = await logicFunctionCommands._validatePaths({ jsonPath: paths[1], _exit: sinon.stub() });
+			const res = await logicFunctionCommands._validatePaths({ jsonPath: 'dir/path/to/file', _exit: sinon.stub() });
 
 			expect(res).to.eql(false);
 
@@ -348,9 +346,8 @@ describe('LogicFunctionCommands', () => {
 			const exitStub = sinon.stub();
 			sinon.stub(fs, 'pathExists').resolves(true);
 			sinon.stub(logicFunctionCommands, '_promptOverwrite').resolves(false);
-			const paths = ['dir/', 'dir/path/to/file'];
 
-			await logicFunctionCommands._validatePaths({ jsonPath: paths[1], _exit: exitStub });
+			await logicFunctionCommands._validatePaths({ jsonPath: 'dir/path/to/file', _exit: exitStub });
 
 			expect(logicFunctionCommands._promptOverwrite.callCount).to.eql(1);
 			expect(exitStub.callCount).to.eql(1);

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -731,4 +731,27 @@ describe('LogicFunctionCommands', () => {
 			expect(logicFunctionCommands._printDisableOutput).to.not.have.been.called;
 		});
 	});
+
+	describe('deploy', () => {
+
+		beforeEach(() => {
+
+		});
+
+		afterEach(() => {
+
+		});
+
+		it('deploys a new logic function', async() => {
+
+		});
+
+		it('re-deploys an old logic function', async() => {
+
+		});
+
+		it('throws an error if deployement fails', async() => {
+
+		});
+	});
 });


### PR DESCRIPTION
## Description

Implements the `deploy` functionality.

Removes saving the Logic Function to a logic-function-directory and saves them directly in the CWD.
    - Does NOT do `current-working-directory/LF/LF.json`
    - Does `current-working-directory/LF.json`

## How to Test

- Create a Logic Function using `particle lf create`
- Deploy the Logic Function using `particle lf deploy`

## Related Issues / Discussions

https://app.shortcut.com/particle/story/123398/implement-deploy-command

## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

