### PR TITLE
Feature/sc 124023/execute refactor

### DIFF
--- a/src/cli/logic-function.js
+++ b/src/cli/logic-function.js
@@ -152,8 +152,11 @@ module.exports = ({ commandProcessor, root }) => {
 			return new LogicFunctionsCmd().deploy(args);
 		},
 		examples: {
-			'$0 $command --data <data>': 'executes and deploys a Logic Function. Executes using the data',
-			'$0 $command --dataPath <filePath>': 'executes and deploys a Logic Function. Executes using the data from the dataPath',
+			'$0 $command --data <data>': 'executes and deploys the local Logic Function with the data',
+			'$0 $command --productId <productId>': 'executes and deploys the local Logic Function for an specific product',
+			'$0 $command --deviceId <deviceId>': 'executes and deploys the local Logic Function for an specific device',
+			'$0 $command --payload { "event": { "product_id": <productId>, "device_id": "<deviceId>", "event_data": "<test data>", "event_name":"<event_test_name>"}}' : 'executes and deploys the local Logic Function with the payload',
+			'$0 $command --payload /path/payload.json' : 'executes and deploys the local Logic Function with the payload',
 		}
 	});
 

--- a/src/cli/logic-function.js
+++ b/src/cli/logic-function.js
@@ -78,6 +78,12 @@ module.exports = ({ commandProcessor, root }) => {
 				description: 'Specify the organization',
 				hidden: true
 			},
+			'name': {
+				description: 'Name of the logic function'
+			},
+			'id': {
+				description: 'Id of the logic function'
+			},
 			'data': {
 				description: 'Sample test data file to verify the logic function'
 			},

--- a/src/cli/logic-function.js
+++ b/src/cli/logic-function.js
@@ -120,11 +120,26 @@ module.exports = ({ commandProcessor, root }) => {
 				description: 'Specify the organization',
 				hidden: true
 			},
+			'name': {
+				description: 'Name of the logic function'
+			},
+			'id': {
+				description: 'Id of the logic function'
+			},
 			'data': {
 				description: 'Sample test data file to verify the logic function'
 			},
-			'dataPath': {
-				description: 'Sample test data file to verify the logic function'
+			'event_name': {
+				description: 'Name of the event to execute'
+			},
+			'product_id': {
+				description: 'Product ID of the device'
+			},
+			'device_id': {
+				description: 'Device ID of the device'
+			},
+			'payload': {
+				description: 'Payload to send to the device could be a string or a file path'
 			},
 			'force': {
 				boolean: true,

--- a/src/cli/logic-function.js
+++ b/src/cli/logic-function.js
@@ -81,9 +81,18 @@ module.exports = ({ commandProcessor, root }) => {
 			'data': {
 				description: 'Sample test data file to verify the logic function'
 			},
-			'dataPath': {
-				description: 'Sample test data file to verify the logic function'
+			'event_name': {
+				description: 'Name of the event to execute'
 			},
+			'product_id': {
+				description: 'Product ID of the device'
+			},
+			'device_id': {
+				description: 'Device ID of the device'
+			},
+			'payload': {
+				description: 'Payload to send to the device could be a string or a file path'
+			}
 		},
 		handler: (args) => {
 			const LogicFunctionsCmd = require('../cmd/logic-function');
@@ -91,7 +100,10 @@ module.exports = ({ commandProcessor, root }) => {
 		},
 		examples: {
 			'$0 $command --data <data>': 'executes the local Logic Function with the data',
-			'$0 $command --dataPath <filePath>': 'executes the local Logic Function with the data from the file',
+			'$0 $command --productId <productId>': 'executes the local Logic Function for an specific product',
+			'$0 $command --deviceId <deviceId>': 'executes the local Logic Function for an specific device',
+			'$0 $command --payload { "event": { "product_id": <productId>, "device_id": "<deviceId>", "event_data": "<test data>", "event_name":"<event_test_name>"}}' : 'executes the local Logic Function with the payload',
+			'$0 $command --payload /path/payload.json' : 'executes the local Logic Function with the payload',
 		}
 	});
 

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -272,7 +272,7 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 
 	_printMalformedLogicFunctionsFromDisk(malformedLogicFunctions) {
 		if (malformedLogicFunctions.length) {
-			this.ui.stdout.write(`The following Logic Functions are not valid:${os.EOL}`);
+			this.ui.stdout.write(this.ui.chalk.red(`The following Logic Functions are not valid:${os.EOL}`));
 			malformedLogicFunctions.forEach((item) => {
 				this.ui.stdout.write(`- ${item.name}: ${item.error}${os.EOL}`);
 			});

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -229,9 +229,9 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 		return exists;
 	}
 
-	async execute({ org, product_id: productId, event_name: eventName, device_id: deviceId, data, payload, params: { filepath } }) {
+	async execute({ org, name, id, product_id: productId, event_name: eventName, device_id: deviceId, data, payload, params: { filepath } }) {
 		this._setOrg(org);
-		const logicFunction = await this._pickLogicFunctionFromDisk({ filepath });
+		const logicFunction = await this._pickLogicFunctionFromDisk({ filepath, name, id });
 		const eventData = await this._getExecuteData({
 			productId,
 			deviceId,
@@ -244,11 +244,14 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 		this._printExecuteOutput({ logs, error, status });
 	}
 
-	async _pickLogicFunctionFromDisk({ filepath }) {
-		const logicFunctions = await LogicFunction.listFromDisk({ filepath, api: this.api, org: this.org });
+	async _pickLogicFunctionFromDisk({ filepath, name, id }) {
+		let logicFunctions = await LogicFunction.listFromDisk({ filepath, api: this.api, org: this.org });
 		if (logicFunctions.length === 0) {
 			this._printListHelperOutput({ fromFile: true });
 			throw new Error('No Logic Functions found');
+		}
+		if (name || id) {
+			logicFunctions = logicFunctions.filter(lf => lf.name === name || lf.id === id);
 		}
 		if (logicFunctions.length === 1) {
 			return logicFunctions[0];

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -245,13 +245,13 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 	}
 
 	async _pickLogicFunctionFromDisk({ filepath, name, id }) {
-		let logicFunctions = await LogicFunction.listFromDisk({ filepath, api: this.api, org: this.org });
+		let { logicFunctions } = await LogicFunction.listFromDisk({ filepath, api: this.api, org: this.org });
+		if (name || id) {
+			logicFunctions = logicFunctions.filter(lf => lf.name === name || lf.id === id);
+		}
 		if (logicFunctions.length === 0) {
 			this._printListHelperOutput({ fromFile: true });
 			throw new Error('No Logic Functions found');
-		}
-		if (name || id) {
-			logicFunctions = logicFunctions.filter(lf => lf.name === name || lf.id === id);
 		}
 		if (logicFunctions.length === 1) {
 			return logicFunctions[0];

--- a/src/cmd/logic-function.js
+++ b/src/cmd/logic-function.js
@@ -229,10 +229,16 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 		return exists;
 	}
 
-	async execute({ org, productId, eventName, deviceId, data, payload, params: { filepath } }) {
+	async execute({ org, product_id: productId, event_name: eventName, device_id: deviceId, data, payload, params: { filepath } }) {
 		this._setOrg(org);
 		const logicFunction = await this._pickLogicFunctionFromDisk({ filepath });
-		const eventData = await this._getEventData({ productId, deviceId, data, eventName, payload });
+		const eventData = await this._getExecuteData({
+			productId,
+			deviceId,
+			data,
+			eventName,
+			payload
+		});
 		const { status, logs, error } = await logicFunction.execute(eventData);
 		this.ui.stdout.write(`Executing Logic Function ${this.ui.chalk.bold(logicFunction.name)} for ${getOrgName(this.org)}...${os.EOL}`);
 		this._printExecuteOutput({ logs, error, status });
@@ -257,19 +263,21 @@ module.exports = class LogicFunctionsCommand extends CLICommandBase {
 		return logicFunctions.find(lf => lf.name === answer.logicFunction);
 	}
 
-	async _getEventData({ productId, deviceId, eventName, data, payload }) {
+	async _getExecuteData({ productId, deviceId, eventName, data, payload }) {
 		if (payload) {
-			return this._getEventDataFromPayload(payload);
+			return this._getExecuteDataFromPayload(payload);
 		}
 		return {
-			event_name: eventName || 'test_event',
-			product_id: productId || 0,
-			device_id: deviceId || '',
-			event_data: data || ''
+			event:  {
+				event_name: eventName || 'test_event',
+				product_id: productId || 0,
+				device_id: deviceId || '',
+				event_data: data || ''
+			}
 		};
 	}
 
-	async _getEventDataFromPayload(payload) {
+	async _getExecuteDataFromPayload(payload) {
 		const parsedAsJson = await this._parseEventFromPayload(payload);
 		if (!parsedAsJson.error) {
 			return parsedAsJson.eventData;

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -70,8 +70,8 @@ describe('LogicFunctionCommands', () => {
 			await logicFunctionCommands.list({});
 			expect(logicListStub.calledWith({ api: logicFunctionCommands.api, org: undefined })).to.be.true;
 			expect(logicListStub.calledOnce).to.be.true;
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`Logic Functions deployed in your Sandbox:${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`- LF1 (disabled)${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Logic Functions deployed in your Sandbox:${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`- LF1 (disabled)${os.EOL}`);
 		});
 
 		it('lists logic functions in an org', async () => {
@@ -79,8 +79,8 @@ describe('LogicFunctionCommands', () => {
 			await logicFunctionCommands.list({ org: 'particle' });
 			expect(logicListStub.calledWith({ api: logicFunctionCommands.api, org: 'particle' })).to.be.true;
 			expect(logicListStub.calledOnce).to.be.true;
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`Logic Functions deployed in particle:${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`- LF1 (disabled)${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Logic Functions deployed in particle:${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`- LF1 (disabled)${os.EOL}`);
 		});
 
 		it('shows help if no logic functions are found', async () => {
@@ -88,7 +88,7 @@ describe('LogicFunctionCommands', () => {
 			await logicFunctionCommands.list({});
 			expect(logicListStub.calledWith({ api: logicFunctionCommands.api, org: undefined })).to.be.true;
 			expect(logicListStub.calledOnce).to.be.true;
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`No Logic Functions deployed in your Sandbox.${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`No Logic Functions deployed in your Sandbox.${os.EOL}`);
 		});
 
 		it('shows help if no logic functions are found', async () => {
@@ -96,7 +96,7 @@ describe('LogicFunctionCommands', () => {
 			await logicFunctionCommands.list({ api: logicFunctionCommands.api, org: 'particle' });
 			expect(logicListStub.calledWith({ api: logicFunctionCommands.api, org: 'particle' })).to.be.true;
 			expect(logicListStub.calledOnce).to.be.true;
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`No Logic Functions deployed in particle.${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`No Logic Functions deployed in particle.${os.EOL}`);
 		});
 
 	});
@@ -125,8 +125,8 @@ describe('LogicFunctionCommands', () => {
 			expect(logicGetStub.calledOnce).to.be.true;
 			expect(lf.saveToDisk.calledOnce).to.be.true;
 			expect(logicFunctionCommands.ui.stdout.write.callCount).to.equal(6);
-			expect(logicFunctionCommands.ui.stdout.write.getCall(2).args[0]).to.equal(` - ${lf.files.configuration.name}${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.getCall(3).args[0]).to.equal(` - ${lf.files.sourceCode.name}${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(` - ${lf.files.configuration.name}${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(` - ${lf.files.sourceCode.name}${os.EOL}`);
 		});
 		it('gets a logic function with an specific id from Sandbox account', async () => {
 			const logicGetStub = sinon.stub(LogicFunction, 'getByIdOrName').resolves(lf);
@@ -137,8 +137,8 @@ describe('LogicFunctionCommands', () => {
 			expect(logicGetStub.calledOnce).to.be.true;
 			expect(lf.saveToDisk.calledOnce).to.be.true;
 			expect(logicFunctionCommands.ui.stdout.write.callCount).to.equal(6);
-			expect(logicFunctionCommands.ui.stdout.write.getCall(2).args[0]).to.equal(` - ${lf.files.configuration.name}${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.getCall(3).args[0]).to.equal(` - ${lf.files.sourceCode.name}${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(` - ${lf.files.configuration.name}${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(` - ${lf.files.sourceCode.name}${os.EOL}`);
 
 		});
 		it('shows error if logic function is not found', async () => {
@@ -165,8 +165,8 @@ describe('LogicFunctionCommands', () => {
 			expect(logicGetStub.calledOnce).to.be.true;
 			expect(lf.saveToDisk.calledOnce).to.be.true;
 			expect(logicFunctionCommands.ui.stdout.write.callCount).to.equal(6);
-			expect(logicFunctionCommands.ui.stdout.write.getCall(2).args[0]).to.equal(` - ${lf.files.configuration.name}${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.getCall(3).args[0]).to.equal(` - ${lf.files.sourceCode.name}${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(` - ${lf.files.configuration.name}${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(` - ${lf.files.sourceCode.name}${os.EOL}`);
 		});
 	});
 
@@ -323,8 +323,8 @@ describe('LogicFunctionCommands', () => {
 			await logicFunctionCommands.create({ params: { filepath: PATH_TMP_DIR } });
 			expect(initFromTemplateStub.calledOnce).to.be.true;
 			expect(saveToDiskStub.calledOnce).to.be.true;
-			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`Creating Logic Function logic func 1 for your Sandbox...${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.thirdCall.args[0]).to.equal(`Successfully created logic func 1 locally in ${PATH_TMP_DIR}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Creating Logic Function logic func 1 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Successfully created logic func 1 locally in ${PATH_TMP_DIR}`);
 		});
 
 		it('ask to overwrite if files already exist', async () => {
@@ -337,8 +337,8 @@ describe('LogicFunctionCommands', () => {
 			expect(initFromTemplateStub.calledOnce).to.be.true;
 			expect(saveToDiskStub.calledOnce).to.be.true;
 			expect(logicFunctionCommands.ui.prompt.callCount).to.equal(3);
-			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`Creating Logic Function logic func 1 for your Sandbox...${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.thirdCall.args[0]).to.equal(`Successfully created logic func 1 locally in ${PATH_TMP_DIR}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Creating Logic Function logic func 1 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Successfully created logic func 1 locally in ${PATH_TMP_DIR}`);
 		});
 
 	});
@@ -351,7 +351,10 @@ describe('LogicFunctionCommands', () => {
 				id: '0021e8f4-64ee-416d-83f3-898aa909fb1b',
 				type: 'JavaScript',
 			});
-			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([logicFunction]);
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves({
+				malformedLogicFunctions: [],
+				logicFunctions: [logicFunction]
+			});
 			const executeStub = sinon.stub(logicFunction, 'execute').resolves({
 				status: 'Success',
 				logs: ['log1', 'log2']
@@ -361,13 +364,16 @@ describe('LogicFunctionCommands', () => {
 			expect(logicStub.calledOnce).to.be.true;
 			expect(executeStub.calledOnce).to.be.true;
 			expect(logicFunctionCommands.ui.prompt.callCount).to.equal(0);
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`Executing Logic Function LF1 for your Sandbox...${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`Execution Status: Success${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.thirdCall.args[0]).to.equal(`Logs from Execution:${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Executing Logic Function LF1 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Execution Status: Success${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Logs from Execution:${os.EOL}`);
 		});
 
 		it('throws an error if there is no logic function in the directory', async () => {
-			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([]);
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves({
+				malformedLogicFunctions: [],
+				logicFunctions: []
+			});
 			let error;
 			try {
 				await logicFunctionCommands.execute({ data: '{"eventData": "someData"}' , params: {} });
@@ -375,7 +381,7 @@ describe('LogicFunctionCommands', () => {
 				error = _error;
 			}
 			expect(logicStub.calledOnce).to.be.true;
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`No Logic Functions found in your directory.${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`No Logic Functions found in your directory.${os.EOL}`);
 			expect(error.message).to.equal('No Logic Functions found');
 		});
 
@@ -387,7 +393,10 @@ describe('LogicFunctionCommands', () => {
 				id: '0021e8f4-64ee-416d-83f3-898aa909fb1b',
 				type: 'JavaScript',
 			});
-			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([logicFunction]);
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves({
+				malformedLogicFunctions: [],
+				logicFunctions: [logicFunction]
+			});
 			sinon.stub(logicFunction, 'execute').resolves({
 				status: 'Success',
 				logs: ['log1', 'log2']
@@ -404,7 +413,10 @@ describe('LogicFunctionCommands', () => {
 				id: '0021e8f4-64ee-416d-83f3-898aa909fb1b',
 				type: 'JavaScript',
 			});
-			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([logicFunction]);
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves({
+				malformedLogicFunctions: [],
+				logicFunctions: [logicFunction]
+			});
 			sinon.stub(logicFunction, 'execute').resolves({
 				status: 'Exception',
 				error: 'Some error'
@@ -413,9 +425,9 @@ describe('LogicFunctionCommands', () => {
 			await logicFunctionCommands.execute({ data: '{"eventData": "someData"}' , params: {} });
 
 			expect(logicStub.calledOnce).to.be.true;
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`Executing Logic Function LF1 for your Sandbox...${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`Execution Status: Exception${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.thirdCall.args[0]).to.equal(`Error during Execution:${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Executing Logic Function LF1 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Execution Status: Exception${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Error during Execution:${os.EOL}`);
 		});
 
 		it('prompts if found multiple logic functions', async () => {
@@ -431,7 +443,10 @@ describe('LogicFunctionCommands', () => {
 				id: '0021e8f4-64ee-416d-83f3-898aa909fb1c',
 				type: 'JavaScript',
 			});
-			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([logicFunction1, logicFunction2]);
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves({
+				malformedLogicFunctions: [],
+				logicFunctions: [logicFunction1, logicFunction2]
+			});
 			sinon.stub(logicFunction1, 'execute').resolves({
 				status: 'Success',
 				logs: ['log1', 'log2']
@@ -460,7 +475,10 @@ describe('LogicFunctionCommands', () => {
 				type: 'JavaScript',
 			});
 			logicFunctionCommands.ui.prompt = sinon.stub().resolves({ logicFunction: 'LF1' });
-			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([lf1, lf2]);
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves({
+				malformedLogicFunctions: [],
+				logicFunctions: [lf1, lf2]
+			});
 
 			const executeStub = sinon.stub(lf1, 'execute').resolves({
 				status: 'Success',
@@ -471,9 +489,9 @@ describe('LogicFunctionCommands', () => {
 			expect(logicStub.calledOnce).to.be.true;
 			expect(executeStub.calledOnce).to.be.true;
 			expect(logicFunctionCommands.ui.prompt.callCount).to.equal(0);
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`Executing Logic Function LF1 for your Sandbox...${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`Execution Status: Success${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.thirdCall.args[0]).to.equal(`Logs from Execution:${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Executing Logic Function LF1 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Execution Status: Success${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Logs from Execution:${os.EOL}`);
 		});
 		it('executes a logic function with provided logic function id', async () => {
 			const lf1 = new LogicFunction({
@@ -489,7 +507,10 @@ describe('LogicFunctionCommands', () => {
 				type: 'JavaScript',
 			});
 			logicFunctionCommands.ui.prompt = sinon.stub().resolves({ logicFunction: 'LF1' });
-			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([lf1, lf2]);
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves({
+				malformedLogicFunctions: [],
+				logicFunctions: [lf1, lf2]
+			});
 
 			const executeStub = sinon.stub(lf2, 'execute').resolves({
 				status: 'Success',
@@ -500,9 +521,38 @@ describe('LogicFunctionCommands', () => {
 			expect(logicStub.calledOnce).to.be.true;
 			expect(executeStub.calledOnce).to.be.true;
 			expect(logicFunctionCommands.ui.prompt.callCount).to.equal(0);
-			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`Executing Logic Function LF2 for your Sandbox...${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`Execution Status: Success${os.EOL}`);
-			expect(logicFunctionCommands.ui.stdout.write.thirdCall.args[0]).to.equal(`Logs from Execution:${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Executing Logic Function LF2 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Execution Status: Success${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Logs from Execution:${os.EOL}`);
+		});
+
+		it('prints out malformed logic functions in case there are any', async () => {
+			const lf1 = new LogicFunction({
+				name: 'LF1',
+				description: 'Logic Function 1',
+				id: '0021e8f4-64ee-416d-83f3-898aa909fb1b',
+				type: 'JavaScript',
+			});
+			logicFunctionCommands.ui.prompt = sinon.stub().resolves({ logicFunction: 'LF1' });
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves({
+				malformedLogicFunctions: [{ name: 'lf1', error: 'file lf1.js does not exist'}],
+				logicFunctions: [lf1]
+			});
+
+			const executeStub = sinon.stub(lf1, 'execute').resolves({
+				status: 'Success',
+				logs: ['log1', 'log2']
+			});
+
+			await logicFunctionCommands.execute({ name: 'LF1', params: {} });
+			expect(logicStub.calledOnce).to.be.true;
+			expect(executeStub.calledOnce).to.be.true;
+			expect(logicFunctionCommands.ui.prompt.callCount).to.equal(0);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Executing Logic Function LF1 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Execution Status: Success${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Logs from Execution:${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Malformed Logic Functions:${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`- lf1: file lf1.js does not exist${os.EOL}`);
 		});
 	});
 
@@ -816,7 +866,7 @@ describe('LogicFunctionCommands', () => {
 			await logicFunctionCommands.delete({ name: 'LF1' });
 
 			expect(logicFunctionCommands.ui.stdout.write.callCount).to.equal(1);
-			expect(logicFunctionCommands.ui.stdout.write.lastCall.lastArg).to.equal(`Aborted.${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write).calledWith(`Aborted.${os.EOL}`);
 		});
 
 		it('throws an error if deletion fails', async() => {

--- a/src/cmd/logic-function.test.js
+++ b/src/cmd/logic-function.test.js
@@ -446,6 +446,64 @@ describe('LogicFunctionCommands', () => {
 			expect(logicFunctionCommands.ui.prompt.callCount).to.equal(1);
 		});
 
+		it('executes a logic function with provided logic function name', async () => {
+			const lf1 = new LogicFunction({
+				name: 'LF1',
+				description: 'Logic Function 1',
+				id: '0021e8f4-64ee-416d-83f3-898aa909fb1b',
+				type: 'JavaScript',
+			});
+			const lf2 = new LogicFunction({
+				name: 'LF2',
+				description: 'Logic Function 2',
+				id: '0021e8f4-64ee-416d-83f3-898aa909fb1c',
+				type: 'JavaScript',
+			});
+			logicFunctionCommands.ui.prompt = sinon.stub().resolves({ logicFunction: 'LF1' });
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([lf1, lf2]);
+
+			const executeStub = sinon.stub(lf1, 'execute').resolves({
+				status: 'Success',
+				logs: ['log1', 'log2']
+			});
+
+			await logicFunctionCommands.execute({ name: 'LF1', params: {} });
+			expect(logicStub.calledOnce).to.be.true;
+			expect(executeStub.calledOnce).to.be.true;
+			expect(logicFunctionCommands.ui.prompt.callCount).to.equal(0);
+			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`Executing Logic Function LF1 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`Execution Status: Success${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write.thirdCall.args[0]).to.equal(`Logs from Execution:${os.EOL}`);
+		});
+		it('executes a logic function with provided logic function id', async () => {
+			const lf1 = new LogicFunction({
+				name: 'LF1',
+				description: 'Logic Function 1',
+				id: '0021e8f4-64ee-416d-83f3-898aa909fb1b',
+				type: 'JavaScript',
+			});
+			const lf2 = new LogicFunction({
+				name: 'LF2',
+				description: 'Logic Function 2',
+				id: '0021e8f4-64ee-416d-83f3-898aa909fb1c',
+				type: 'JavaScript',
+			});
+			logicFunctionCommands.ui.prompt = sinon.stub().resolves({ logicFunction: 'LF1' });
+			const logicStub = sinon.stub(LogicFunction, 'listFromDisk').resolves([lf1, lf2]);
+
+			const executeStub = sinon.stub(lf2, 'execute').resolves({
+				status: 'Success',
+				logs: ['log1', 'log2']
+			});
+
+			await logicFunctionCommands.execute({ id: '0021e8f4-64ee-416d-83f3-898aa909fb1c', params: {} });
+			expect(logicStub.calledOnce).to.be.true;
+			expect(executeStub.calledOnce).to.be.true;
+			expect(logicFunctionCommands.ui.prompt.callCount).to.equal(0);
+			expect(logicFunctionCommands.ui.stdout.write.firstCall.args[0]).to.equal(`Executing Logic Function LF2 for your Sandbox...${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write.secondCall.args[0]).to.equal(`Execution Status: Success${os.EOL}`);
+			expect(logicFunctionCommands.ui.stdout.write.thirdCall.args[0]).to.equal(`Logs from Execution:${os.EOL}`);
+		});
 	});
 
 	describe('_validatePaths', () => {

--- a/src/lib/logic-function.js
+++ b/src/lib/logic-function.js
@@ -131,7 +131,7 @@ class LogicFunction {
 		logicFunction.files.sourceCode.name = codeFile;
 		logicFunction.files.configuration.content = configuration;
 		logicFunction.files.sourceCode.content = code;
-		logicFunction.path = path;
+		logicFunction.path = basePath;
 		logicFunction._deserializeConfiguration();
 		return logicFunction;
 

--- a/src/lib/logic-function.js
+++ b/src/lib/logic-function.js
@@ -55,7 +55,7 @@ class LogicFunction {
 	}
 
 	static async listFromDisk({ path, org, api = createAPI() } = {}) {
-		return [];
+		throw new Error(`Not implemented for ${path} ${org} ${api}` );
 	}
 
 	// should return an instance of LogicFunction

--- a/src/lib/logic-function.js
+++ b/src/lib/logic-function.js
@@ -54,6 +54,10 @@ class LogicFunction {
 		}
 	}
 
+	static async listFromDisk({ path, org, api = createAPI() } = {}) {
+		return [];
+	}
+
 	// should return an instance of LogicFunction
 	static async getByIdOrName({ id, name, list }) {
 		const logicFunctionData = list.find(lf => lf.id === id || lf.name === name);
@@ -61,6 +65,27 @@ class LogicFunction {
 			throw new Error('Logic function not found');
 		}
 		return logicFunctionData;
+	}
+
+	async execute({ event } = {}) {
+		const logicEvent = {
+			event,
+			source: {
+				type: this.type,
+				code: this.files.sourceCode.content
+			}
+		};
+		try {
+			const response =
+				await this.api.executeLogicFunction({ org: this.org, id: this.id, logicEvent });
+			return {
+				logs: response.logs,
+				error: response.error,
+				status: response.status,
+			};
+		} catch (e) {
+			throw createAPIErrorResult({ error: e, message: 'Error executing logic function' });
+		}
 	}
 
 	async initFromTemplate({ templatePath }) {

--- a/src/lib/logic-function.js
+++ b/src/lib/logic-function.js
@@ -169,6 +169,51 @@ class LogicFunction {
 		}
 	}
 
+	async deploy() {
+		const logicFunctionRequestData = {
+			name: this.name,
+			description: this.description,
+			enabled: this.enabled,
+			source: {
+				type: this.type,
+				code: this.files.sourceCode.content
+			},
+			logic_triggers: this.triggers
+		};
+		if (this.id) {
+			return this.updateToCloud(logicFunctionRequestData);
+		} else {
+			return this.createToCloud(logicFunctionRequestData);
+		}
+	}
+
+	async createToCloud(logicFunctionData) {
+		try {
+			const result = await this.api.createLogicFunction({
+				org: this.org,
+				logicFunction: logicFunctionData,
+			});
+			this.id = result.id;
+			this.version = result.version;
+		} catch (e) {
+			throw createAPIErrorResult({ error: e, message: 'Error deploying logic function' });
+		}
+
+	}
+
+	async updateToCloud(logicFunctionData) {
+		try {
+			const result = await this.api.updateLogicFunction({
+				org: this.org,
+				id: this.id,
+				logicFunctionData: logicFunctionData,
+			});
+			this.version = result.version;
+		} catch (e) {
+			throw createAPIErrorResult({ error: e, message: 'Error deploying logic function' });
+		}
+	}
+
 	async initFromTemplate({ templatePath }) {
 		const contentReplacements = {
 			name: this.name,

--- a/src/lib/logic-function.test.js
+++ b/src/lib/logic-function.test.js
@@ -5,7 +5,6 @@ const logicFunc1 = require('../../test/__fixtures__/logic_functions/logicFunc1.j
 const { PATH_TMP_DIR } = require('../../test/lib/env');
 const path = require('path');
 const templateProcessor = require('./template-processor');
-const LOGIC_FUNCTION_FIXTURES = path.join(__dirname, '../', '../', 'test', '__fixtures__', 'logic_functions');
 const fs = require('fs-extra');
 
 describe('LogicFunction', () => {
@@ -13,6 +12,18 @@ describe('LogicFunction', () => {
 		nock.cleanAll();
 		fs.emptyDirSync(PATH_TMP_DIR);
 	});
+	async function createLogicFunction({ name, description }) {
+		const lfPath = path.join(PATH_TMP_DIR, 'logic_functions');
+		const code = 'import Particle from \'particle:core\';\nexport default function main({ event }) {\n   console.log(\'Hello from logic function!\'); \n}';
+		const logicFunction = new LogicFunction({
+			name,
+			description,
+			_path: lfPath,
+		});
+		logicFunction.files.sourceCode.content = code;
+		await logicFunction.saveToDisk();
+		return logicFunction;
+	}
 	describe('list', () => {
 		it('returns an empty array if there are no logic functions', async () => {
 			nock('https://api.particle.io/v1/', )
@@ -171,32 +182,20 @@ describe('LogicFunction', () => {
 			}
 		});
 	});
-
 	describe('listFromDisk', () => {
 		afterEach(() => {
 			sinon.restore();
 			fs.emptyDirSync(PATH_TMP_DIR);
 		});
-		async function createLogicFunction({ name, description }) {
-			const lfPath = path.join(PATH_TMP_DIR, 'logic_functions');
-			const code = 'import Particle from \'particle:core\';\nexport default function main({ event }) {\n   console.log(\'Hello from logic function!\'); \n}';
-			const logicFunction = new LogicFunction({
-				name,
-				description,
-				_path: lfPath,
-			});
-			logicFunction.files.sourceCode.content = code;
-			await logicFunction.saveToDisk();
-		}
 		it('returns a list of logic functions', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
-			const logicFunctions = await LogicFunction.listFromDisk({  path: path.join(PATH_TMP_DIR, 'logic_functions') });
+			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
 		it('returns a list of logic functions with org', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
-			const logicFunctions = await LogicFunction.listFromDisk({ path: path.join(PATH_TMP_DIR, 'logic_functions'), org: 'my-org' });
+			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions'), org: 'my-org' });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 			expect(logicFunctions[0]).to.have.property('org', 'my-org');
@@ -204,27 +203,110 @@ describe('LogicFunction', () => {
 		it('returns a list of more than one logic functions', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
 			await createLogicFunction({ name: 'lf2', description: 'Logic Function 2 on SandBox' });
-			const logicFunctions = await LogicFunction.listFromDisk({ path: path.join(PATH_TMP_DIR, 'logic_functions') });
+			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
 			expect(logicFunctions).to.have.lengthOf(2);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
 		it('filter out files that are not logic functions', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
 			await fs.writeFile(path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.json'), '{}');
-			const logicFunctions = await LogicFunction.listFromDisk({ path: path.join(PATH_TMP_DIR, 'logic_functions') });
+			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
 		it('filter out no well formed logic functions', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
 			await fs.writeFile(path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.logic.json'), '{ "name": "lf2", "description": "Logic Function 2 on SandBox" }');
-			const logicFunctions = await LogicFunction.listFromDisk({ path: path.join(PATH_TMP_DIR, 'logic_functions') });
+			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
-		it('returns an empty list if there are no logic functions', async () => {
-			const logicFunctions = await LogicFunction.listFromDisk({ path: LOGIC_FUNCTION_FIXTURES });
+		it('returns a list of one element if the path is a file and it is a logic function', async () => {
+			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
+			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions', 'lf1.js') });
+			expect(logicFunctions).to.have.lengthOf(1);
+			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
+		});
+		it ('returns an empty list if the path is a file and it is not a logic function', async () => {
+			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
+			await fs.writeFile(path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.js'), '{ "name": "lf2", "description": "Logic Function 2 on SandBox" }');
+			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.js') });
 			expect(logicFunctions).to.have.lengthOf(0);
+		});
+		it('returns an empty list if there are no logic functions', async () => {
+			const logicFunctions = await LogicFunction.listFromDisk({ filepath: PATH_TMP_DIR });
+			expect(logicFunctions).to.have.lengthOf(0);
+		});
+		it('fails if the path does not exist', async () => {
+			try {
+				await LogicFunction.listFromDisk({ filepath: '/path/does/not/exist' });
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error.message).to.equal('Path does not exist');
+			}
+		});
+	});
+	describe('execute', () => {
+		afterEach(() => {
+			sinon.restore();
+			fs.emptyDirSync(PATH_TMP_DIR);
+		});
+		it('executes a logic function', async () => {
+			nock('https://api.particle.io/v1/', )
+				.intercept('/logic/execute', 'POST')
+				.reply(200, { result: { status: 'Success', logs: ['abc1'] } });
+			const trigger = {
+				event: {
+					event_name: 'my-event',
+					event_data: 'my-event-data',
+					product_id: 1,
+					device_id: 'my-device-id',
+				}
+			};
+			const lf1 = await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
+			const executeResult = await lf1.execute(trigger);
+			expect(executeResult).to.have.property('status', 'Success');
+			expect(executeResult).to.have.property('logs');
+			expect(executeResult.logs).to.deep.equal(['abc1']);
+		});
+		it('returns status as exception and errors if the execution fails', async () => {
+			nock('https://api.particle.io/v1/', )
+				.intercept('/logic/execute', 'POST')
+				.reply(200, { result: { status: 'Exception', err: 'Error', logs: [] } });
+			const trigger = {
+				event: {
+					event_name: 'my-event',
+					event_data: 'my-event-data',
+					product_id: 1,
+					device_id: 'my-device-id',
+				}
+			};
+			const lf1 = await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
+			const executeResult = await lf1.execute(trigger);
+			expect(executeResult).to.have.property('status', 'Exception');
+			expect(executeResult).to.have.property('error', 'Error');
+			expect(executeResult).to.have.property('logs');
+			expect(executeResult.logs).to.deep.equal([]);
+		});
+		it('propagates errors', async () => {
+			nock('https://api.particle.io/v1/', )
+				.intercept('/logic/execute', 'POST')
+				.reply(500, { error: 'Internal Server Error' } );
+			const trigger = {
+				event: {
+					event_name: 'my-event',
+					event_data: 'my-event-data',
+					product_id: 1,
+					device_id: 'my-device-id',
+				}
+			};
+			const lf1 = await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
+			try {
+				await lf1.execute(trigger);
+				expect.fail('Should have thrown an error');
+			} catch (error) {
+				expect(error.message).to.equal('Error executing logic function: Internal Server Error');
+			}
 		});
 	});
 });

--- a/src/lib/logic-function.test.js
+++ b/src/lib/logic-function.test.js
@@ -189,13 +189,13 @@ describe('LogicFunction', () => {
 		});
 		it('returns a list of logic functions', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
-			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
+			const { logicFunctions } = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
 		it('returns a list of logic functions with org', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
-			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions'), org: 'my-org' });
+			const { logicFunctions } = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions'), org: 'my-org' });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 			expect(logicFunctions[0]).to.have.property('org', 'my-org');
@@ -203,39 +203,49 @@ describe('LogicFunction', () => {
 		it('returns a list of more than one logic functions', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
 			await createLogicFunction({ name: 'lf2', description: 'Logic Function 2 on SandBox' });
-			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
+			const { logicFunctions } = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
 			expect(logicFunctions).to.have.lengthOf(2);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
 		it('filter out files that are not logic functions', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
 			await fs.writeFile(path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.json'), '{}');
-			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
+			const { logicFunctions } = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
 		it('filter out no well formed logic functions', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
 			await fs.writeFile(path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.logic.json'), '{ "name": "lf2", "description": "Logic Function 2 on SandBox" }');
-			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
+			const { logicFunctions } = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
 		it('returns a list of one element if the path is a file and it is a logic function', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
-			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions', 'lf1.js') });
+			const { logicFunctions } = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions', 'lf1.js') });
 			expect(logicFunctions).to.have.lengthOf(1);
 			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
 		});
 		it ('returns an empty list if the path is a file and it is not a logic function', async () => {
 			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
 			await fs.writeFile(path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.js'), '{ "name": "lf2", "description": "Logic Function 2 on SandBox" }');
-			const logicFunctions = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.js') });
+			const { logicFunctions } = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.js') });
 			expect(logicFunctions).to.have.lengthOf(0);
 		});
 		it('returns an empty list if there are no logic functions', async () => {
-			const logicFunctions = await LogicFunction.listFromDisk({ filepath: PATH_TMP_DIR });
+			const { logicFunctions } = await LogicFunction.listFromDisk({ filepath: PATH_TMP_DIR });
 			expect(logicFunctions).to.have.lengthOf(0);
+		});
+
+		it('returns a list of logic functions and a list of malformed logic functions', async () => {
+			await createLogicFunction({ name: 'lf1', description: 'Logic Function 1 on SandBox' });
+			await fs.writeFile(path.join(PATH_TMP_DIR, 'logic_functions', 'lf2.logic.json'), '{ "name": "lf2", "description": "Logic Function 2 on SandBox" }');
+			const { logicFunctions, malformedLogicFunctions } = await LogicFunction.listFromDisk({ filepath: path.join(PATH_TMP_DIR, 'logic_functions') });
+			expect(logicFunctions).to.have.lengthOf(1);
+			expect(logicFunctions[0]).to.be.an.instanceof(LogicFunction);
+			expect(malformedLogicFunctions).to.have.lengthOf(1);
+			expect(malformedLogicFunctions[0].name).to.equal('lf2');
 		});
 		it('fails if the path does not exist', async () => {
 			try {

--- a/test/e2e/logic-function.e2e.js
+++ b/test/e2e/logic-function.e2e.js
@@ -54,7 +54,7 @@ describe('Logic Function Commands', () => {
 	];
 
 	const executeOutput = [
-		'Executing Logic Function newlf.js for cyberdyne-systems...',
+		'Executing Logic Function newlf for cyberdyne-systems...',
 		'',
 		'Execution Status: Success',
 		'Logs from Execution:',
@@ -63,7 +63,7 @@ describe('Logic Function Commands', () => {
 	];
 
 	const deployOutput = [
-		'Executing Logic Function newlf.js for cyberdyne-systems...',
+		'Executing Logic Function newlf for cyberdyne-systems...',
 		'',
 		'Execution Status: Success',
 		'Logs from Execution:',


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
This PR will re-define the accepted params for `execute` and `deploy` and also use `class` pattern for logic function `deploy` and `execute` commands

## How to Test
* Pull down the branch: `git pull && git checkout feature/sc-124023/execute-refactor`
* Install dependencies: `npm i`
* Run tests: `npm run test:ci` & `npm run test:e2e -- --grep "Logic Function Commands"`
* Run over the follow suggested tests:
### Suggested tests:
#### Execute LF without params:
Having a current Logic function (you can use `npm start -- lf create` to create a fresh one) run:
* `npm start -- lf execute /my/logic/function/path`
* `npm start -- lf execute /my/logic/function/path/file.js`
* `npm start -- lf execute /my/logic/function/path/file.logic.js`

**outcome**
* In every case you will be able to execute your logic function succesfully.

#### Execute LF using `--name` `--id`
Having a current Logic function (you can use `npm start -- lf create` to create a fresh one) run:
In case of the `--id` use the command `npm start -- lf get --name <logic-function-name>` in order to download an existent LF
* `npm start -- lf execute /my/logic/function/path --name <logic-function-name>`
* `npm start -- lf execute /my/logic/function/path --name "wrong name"`
* `npm start -- lf execute /my/logic/function/path --id <logic-function-id>`

**outcome**
* With the right name the logic function will be executed
* With the wrong name it will show a message indicating that the logic function was not found
* With the id, in case the `logic.json` file contains `id` then it will be executed successfully

#### Execute LF using a path with several LF inside
Having a several Logic functions (you can use `npm start -- lf create` to create fresh ones) run:
* `npm start -- lf execute /my/logic/function/path`

**outcome** 
* You will be prompted to pick one logic function from the list

#### Execute LF using a path with several LF inside with malformed ones
Having a several Logic functions (you can use `npm start -- lf create` to create fresh ones) run:
* Pick one logic function file pack and delete the `.js` 
* `npm start -- lf execute /my/logic/function/path`

**outcome**
You will see a message indicating that there is a malformed logic function and the related error (in this case: `.js` doesn't exist)


#### Common cases
* Attempt to use the follow params:
    * `device_id`
    * `product_id`
    * `data`
    * `payload`

#### Deploy logic functions
Suggest to use the same tests than before just with `deploy` command instead

<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/124023

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

