### PR TITLE
Add Error Handling for Device Mode Checks

### DIFF
--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -7,7 +7,8 @@ const {
 	openDeviceById,
 	NotFoundError,
 	NotAllowedError,
-	TimeoutError
+	TimeoutError,
+	DeviceProtectionError
 } = require('../lib/require-optional')('particle-usb');
 
 // Timeout when reopening a USB device after an update via control requests. This timeout should be
@@ -35,6 +36,8 @@ async function _getDeviceInfo(device) {
 	} catch (err) {
 		if (err instanceof TimeoutError) {
 			return { id, mode: 'UNKNOWN' };
+		} else if (err instanceof DeviceProtectionError) {
+			throw new Error('Operation could not be completed due to device protection.');
 		} else {
 			throw new Error(`Unable to get device mode: ${err.message}`);
 		}
@@ -362,5 +365,6 @@ module.exports = {
 	reopenInNormalMode,
 	reopenDevice,
 	UsbPermissionsError,
-	TimeoutError
+	TimeoutError,
+	DeviceProtectionError
 };

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -37,7 +37,7 @@ async function _getDeviceInfo(device) {
 		if (err instanceof TimeoutError) {
 			return { id, mode: 'UNKNOWN' };
 		} else if (err instanceof DeviceProtectionError) {
-			throw new Error('Operation could not be completed due to device protection.');
+			return { id, mode: 'PROTECTED' };
 		} else {
 			throw new Error(`Unable to get device mode: ${err.message}`);
 		}
@@ -242,6 +242,11 @@ async function getOneUsbDevice({ idOrName, api, auth, ui, flashMode, platformId 
 		usbDevice = devices[0].value;
 	}
 
+	const devInfo = await _getDeviceInfo(usbDevice);
+	if (devInfo.mode === 'PROTECTED') {
+		ui.write(`Attempted to flash device ${devInfo.id}`);
+		throw new Error('Operation could not be completed due to device protection.');
+	}
 
 	try {
 		await usbDevice.open();

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -49,7 +49,7 @@ module.exports = class UsbCommand {
 											if (error instanceof TimeoutError) {
 												return 'UNKNOWN';
 											} else if (error instanceof DeviceProtectionError) {
-												return;
+												return 'PROTECTED';
 											}
 											throw error;
 										})

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -1,7 +1,7 @@
 const { spin } = require('../app/ui');
 const { delay, asyncMapSeries, buildDeviceFilter } = require('../lib/utilities');
 const { getDevice, formatDeviceInfo } = require('./device-util');
-const { getUsbDevices, openUsbDevice, openUsbDeviceByIdOrName, TimeoutError } = require('./usb-util');
+const { getUsbDevices, openUsbDevice, openUsbDeviceByIdOrName, TimeoutError, DeviceProtectionError } = require('./usb-util');
 const { systemSupportsUdev, udevRulesInstalled, installUdevRules } = require('./udev');
 const { platformForId, isKnownPlatformId } = require('../lib/platform');
 const ParticleApi = require('./api');
@@ -46,8 +46,10 @@ module.exports = class UsbCommand {
 								info.push(
 									usbDevice.getDeviceMode({ timeout: 10 * 1000 })
 										.catch(error => {
-											if (error instanceof TimeoutError){
+											if (error instanceof TimeoutError) {
 												return 'UNKNOWN';
+											} else if (error instanceof DeviceProtectionError) {
+												return;
 											}
 											throw error;
 										})


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description

This was the issue:
```
particle.js usb list
DeviceProtectionError
    at errorForRequest (/home/monkbroc/Programming/cli/node_modules/particle-usb/src/result.js:144:10)
    at /home/monkbroc/Programming/cli/node_modules/particle-usb/src/device.js:917:11
    at async klass.getDeviceMode (/home/monkbroc/Programming/cli/node_modules/particle-usb/src/device.js:352:13)
    at async Promise.all (index 2)
    at async /home/monkbroc/Programming/cli/src/lib/utilities.js:153:18
    at async CLI.runCommand (/home/monkbroc/Programming/cli/src/app/cli.js:148:4)
    at async CLI.run (/home/monkbroc/Programming/cli/src/app/cli.js:175:11) {
  result: 'Device is protected'
}
```

Propagate device protection error gracefully from the particle-usb


## How to Test

Run `npm start -- usb list` on a bunch of devices with at least one protected device among them
Run `npm start -- flash --local tinker`


## Related Issues / Discussions

N/A


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

