### PR TITLE
fix: [sc-127227] Support renamed assets

### DIFF
--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -329,7 +329,7 @@ async function createFlashSteps({ modules, isInDfuMode, factory, platformId }) {
 
 function _skipAsset(module, existingAssets) {
 	const hashAssetToBeFlashed = _get256Hash(module);
-	return existingAssets.some((asset) => hashAssetToBeFlashed === asset.hash);
+	return existingAssets.some((asset) => hashAssetToBeFlashed === asset.hash && module.filename === asset.name);
 }
 
 function _get256Hash(module) {

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -19,22 +19,26 @@ const FLASH_TIMEOUT = 4 * 60000;
 async function flashFiles({ device, flashSteps, resetAfterFlash = true, ui }) {
 	const progress = _createFlashProgress({ flashSteps, ui });
 	let success = false;
+	let lastStepDfu = false;
 	try {
 		for (const step of flashSteps) {
 			device = await prepareDeviceForFlash({ device, mode: step.flashMode, progress });
 			if (step.flashMode === 'normal') {
 				device = await _flashDeviceInNormalMode(device, step.data, { name: step.name, progress: progress, checkSkip: step.checkSkip });
+				lastStepDfu = false;
 			} else {
 				// CLI always flashes to internal flash which is the DFU alt setting 0
 				const altSetting = 0;
 				device = await _flashDeviceInDfuMode(device, step.data, { name: step.name, altSetting: altSetting, startAddr: step.address, progress: progress });
+				lastStepDfu = true;
 			}
 		}
 		success = true;
 	} finally {
 		progress({ event: 'finish', success });
 		if (device.isOpen) {
-			if (resetAfterFlash) {
+			// only reset the device if the last step was in DFU mode
+			if (resetAfterFlash && lastStepDfu) {
 				try {
 					await device.reset();
 				} catch (error) {


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/127227

If an asset is renamed but not otherwise modified, the CLI won't flash the newly named asset to the device, leading to the device being in safe mode.

Steps to test:
- Compile a project with one asset `test.txt`
- `particle flash --local app.zip`
- Rename the asset `test2.txt` and recompile
- `particle flash --local app.zip`
- Check that `test2.txt` is properly flashed.

I made an additional change to avoid resetting the device an additional when flashing assets in normal mode. The 2 scenarios are either that the asset is flashed, then the device reboots on its own, or the asset is skipped so an addtional reset causes the application to restart one more time than necessary.

**Hugo, can you think of a downside to this change?**