### PR TITLE
Get network configuration of a device

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -28,7 +28,7 @@
         "particle-api-js": "^10.3.0",
         "particle-commands": "^1.0.1",
         "particle-library-manager": "^0.1.15",
-        "particle-usb": "^2.8.0",
+        "particle-usb": "^2.9.0",
         "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
         "safe-buffer": "^5.2.0",
         "semver": "^7.5.2",
@@ -6515,9 +6515,10 @@
       }
     },
     "node_modules/particle-usb": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.8.0.tgz",
-      "integrity": "sha512-J8pXbNYbHJmunBCau+OC0eqaTwx6/j8dIiVy9Z/QZ0d1q/2bCuqrxieHbEVhM7dENeSs5WqM4mpTbPnjlvJo8A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.9.0.tgz",
+      "integrity": "sha512-5fw30BNXhV8hPc1eznIbWxHng9ISY61D+mSN3H/wt85tXDPY9kSAO5frz7/Oepntf9OiHEPkCD3tQrehvVRN9A==",
+      "optional": true,
       "dependencies": {
         "@particle/device-os-protobuf": "^2.4.2",
         "ip-address": "^9.0.5",
@@ -14551,9 +14552,10 @@
       }
     },
     "particle-usb": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.8.0.tgz",
-      "integrity": "sha512-J8pXbNYbHJmunBCau+OC0eqaTwx6/j8dIiVy9Z/QZ0d1q/2bCuqrxieHbEVhM7dENeSs5WqM4mpTbPnjlvJo8A==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.9.0.tgz",
+      "integrity": "sha512-5fw30BNXhV8hPc1eznIbWxHng9ISY61D+mSN3H/wt85tXDPY9kSAO5frz7/Oepntf9OiHEPkCD3tQrehvVRN9A==",
+      "optional": true,
       "requires": {
         "@particle/device-os-protobuf": "^2.4.2",
         "ip-address": "^9.0.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6518,7 +6518,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.9.0.tgz",
       "integrity": "sha512-5fw30BNXhV8hPc1eznIbWxHng9ISY61D+mSN3H/wt85tXDPY9kSAO5frz7/Oepntf9OiHEPkCD3tQrehvVRN9A==",
-      "optional": true,
       "dependencies": {
         "@particle/device-os-protobuf": "^2.4.2",
         "ip-address": "^9.0.5",
@@ -14555,7 +14554,6 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-2.9.0.tgz",
       "integrity": "sha512-5fw30BNXhV8hPc1eznIbWxHng9ISY61D+mSN3H/wt85tXDPY9kSAO5frz7/Oepntf9OiHEPkCD3tQrehvVRN9A==",
-      "optional": true,
       "requires": {
         "@particle/device-os-protobuf": "^2.4.2",
         "ip-address": "^9.0.5",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "particle-api-js": "^10.3.0",
     "particle-commands": "^1.0.1",
     "particle-library-manager": "^0.1.15",
-    "particle-usb": "^2.8.0",
+    "particle-usb": "^2.9.0",
     "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
     "safe-buffer": "^5.2.0",
     "semver": "^7.5.2",

--- a/src/cli/usb.js
+++ b/src/cli/usb.js
@@ -154,6 +154,19 @@ module.exports = ({ commandProcessor, root }) => {
 		}
 	});
 
+	commandProcessor.createCommand(usb, 'network-interfaces', 'Gets the network configuration of the device', {
+		params: '[devices...]',
+		options: commonOptions,
+		examples: {
+			'$0 $command': 'Gets the network configuration of the device',
+			'$0 $command --all': 'Gets the network configuration of all the devices connected over USB',
+			'$0 $command my_device': 'Gets the network configuration of the device named "my_device"'
+		},
+		handler: (args) => {
+			return usbCommand().getNetworkIfaces(args);
+		}
+	});
+
 	return usb;
 };
 

--- a/src/cli/usb.test.js
+++ b/src/cli/usb.test.js
@@ -38,6 +38,7 @@ describe('USB Command-Line Interface', () => {
 					'  setup-done       Set the setup done flag',
 					'  configure        Update the system USB configuration',
 					'  cloud-status     Check a device\'s cloud connection state',
+					'  network-interfaces         Gets the network configuration of the device',
 					''
 				].join('\n'));
 			});
@@ -376,6 +377,28 @@ describe('USB Command-Line Interface', () => {
 			expect(argv.params).to.eql({ device: 'my-device' });
 			expect(argv.until).to.equal('NOPE');
 			expect(argv.timeout).to.equal(60000);
+		});
+
+		describe('Handles `usb network-interfaces` Command', () => {
+			it('Parses arguments', () => {
+				const argv = commandProcessor.parse(root, ['usb', 'network-interfaces']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.all).to.equal(false);
+			});
+	
+			it('Includes help with examples', () => {
+				commandProcessor.parse(root, ['usb', 'network-interfaces', '--help'], termWidth);
+				commandProcessor.showHelp((helpText) => {
+					expect(helpText).to.equal([
+						'Gets the network configuration of the device',
+						'Usage: particle usb network-interfaces',
+						'',
+						'Examples:',
+						'  particle usb network-interfaces  Gets the network configuration of the device',
+						''
+					].join('\n'));
+				});
+			});
 		});
 
 		it('Includes help with examples', () => {

--- a/src/cli/usb.test.js
+++ b/src/cli/usb.test.js
@@ -28,17 +28,17 @@ describe('USB Command-Line Interface', () => {
 					'Help:  particle help usb <command>',
 					'',
 					'Commands:',
-					'  list             List the devices connected to the host computer',
-					'  start-listening  Put a device into the listening mode',
-					'  listen           alias for start-listening',
-					'  stop-listening   Make a device exit the listening mode',
-					'  safe-mode        Put a device into the safe mode',
-					'  dfu              Put a device into the DFU mode',
-					'  reset            Reset a device',
-					'  setup-done       Set the setup done flag',
-					'  configure        Update the system USB configuration',
-					'  cloud-status     Check a device\'s cloud connection state',
-					'  network-interfaces         Gets the network configuration of the device',
+					'  list                List the devices connected to the host computer',
+					'  start-listening     Put a device into the listening mode',
+					'  listen              alias for start-listening',
+					'  stop-listening      Make a device exit the listening mode',
+					'  safe-mode           Put a device into the safe mode',
+					'  dfu                 Put a device into the DFU mode',
+					'  reset               Reset a device',
+					'  setup-done          Set the setup done flag',
+					'  configure           Update the system USB configuration',
+					'  cloud-status        Check a device\'s cloud connection state',
+					'  network-interfaces  Gets the network configuration of the device',
 					''
 				].join('\n'));
 			});
@@ -385,16 +385,21 @@ describe('USB Command-Line Interface', () => {
 				expect(argv.clierror).to.equal(undefined);
 				expect(argv.all).to.equal(false);
 			});
-	
+
 			it('Includes help with examples', () => {
 				commandProcessor.parse(root, ['usb', 'network-interfaces', '--help'], termWidth);
 				commandProcessor.showHelp((helpText) => {
 					expect(helpText).to.equal([
 						'Gets the network configuration of the device',
-						'Usage: particle usb network-interfaces',
+						'Usage: particle usb network-interfaces [options] [devices...]',
+						'',
+						'Options:',
+						'  --all  Send the command to all devices connected to the host computer  [boolean]',
 						'',
 						'Examples:',
-						'  particle usb network-interfaces  Gets the network configuration of the device',
+						'  particle usb network-interfaces            Gets the network configuration of the device',
+						'  particle usb network-interfaces --all      Gets the network configuration of all the devices connected over USB',
+						'  particle usb network-interfaces my_device  Gets the network configuration of the device named "my_device"',
 						''
 					].join('\n'));
 				});

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -94,7 +94,7 @@ module.exports = class UsbCommand extends CLICommandBase {
 					devices.forEach(device => console.log(device.id));
 				} else {
 					if (devices.length === 0) {
-						console.log(`No devices found.${os.EOL}`);
+						console.log('No devices found.');
 					} else {
 						devices = devices.sort((a, b) => a.name.localeCompare(b.name)); // Sort devices by name
 
@@ -237,22 +237,19 @@ module.exports = class UsbCommand extends CLICommandBase {
 
 	_forEachUsbDevice(args, func, { dfuMode = false } = {}){
 		const msg = 'Getting device information...';
-		let deviceId;
 		const operation = this._openUsbDevices(args, { dfuMode });
 		let lastError = null;
 		return spin(operation, msg)
 			.then(usbDevices => {
 				const p = usbDevices.map(usbDevice => {
-					deviceId = usbDevice.id;
 					return Promise.resolve()
 						.then(() => func(usbDevice))
 						.catch(e => lastError = e)
 						.finally(() => usbDevice.close());
 				});
-				return spin(Promise.all(p), `Sending a command to the device ${deviceId}...`);
+				return spin(Promise.all(p), `Sending a command to the device...`);
 			})
 			.then(() => {
-				this.stopSpin();
 				if (lastError){
 					throw lastError;
 				}
@@ -295,6 +292,7 @@ module.exports = class UsbCommand extends CLICommandBase {
 			});
 	}
 
+	// Helper function to convert CIDR notation to netmask to imitate the 'ifconfig' output
 	_cidrToNetmask(cidr) {
 		let mask = [];
 

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -1,4 +1,3 @@
-const os = require('os');
 const { spin } = require('../app/ui');
 const { delay, asyncMapSeries, buildDeviceFilter } = require('../lib/utilities');
 const { getDevice, formatDeviceInfo } = require('./device-util');
@@ -247,7 +246,7 @@ module.exports = class UsbCommand extends CLICommandBase {
 						.catch(e => lastError = e)
 						.finally(() => usbDevice.close());
 				});
-				return spin(Promise.all(p), `Sending a command to the device...`);
+				return spin(Promise.all(p), 'Sending a command to the device...');
 			})
 			.then(() => {
 				if (lastError){

--- a/src/cmd/usb.js
+++ b/src/cmd/usb.js
@@ -11,7 +11,7 @@ const CLICommandBase = require('./base');
 const chalk = require('chalk');
 
 
-module.exports = class UsbCommand  extends CLICommandBase {
+module.exports = class UsbCommand extends CLICommandBase {
 	constructor(settings) {
 		super();
 		spinnerMixin(this);
@@ -302,23 +302,23 @@ module.exports = class UsbCommand  extends CLICommandBase {
 		for (let i = 0; i < Math.floor(cidr / 8); i++) {
 			mask.push(255);
 		}
-	
+
 		// Calculate remaining bits in the next octet
 		if (mask.length < 4) {
 			mask.push((256 - Math.pow(2, 8 - cidr % 8)) & 255);
 		}
-	
+
 		// Fill the remaining octets with '0' if any
 		while (mask.length < 4) {
 			mask.push(0);
 		}
-		
+
 		return mask.join('.');
 	}
 
 	async getNetworkIfaces(args) {
 		// define output array with logs to prevent interleaving with the spinner
-		let output = []; 
+		let output = [];
 
 		await this._forEachUsbDevice(args, usbDevice => {
 			const platform = platformForId(usbDevice.platformId);
@@ -329,9 +329,9 @@ module.exports = class UsbCommand  extends CLICommandBase {
 				return;
 			}
 			return this.getNetworkIface(usbDevice)
-			.then((outputData) => {
-				output = output.concat(outputData);
-			});
+				.then((outputData) => {
+					output = output.concat(outputData);
+				});
 		});
 
 		if (output.length === 0) {

--- a/src/cmd/usb.test.js
+++ b/src/cmd/usb.test.js
@@ -8,7 +8,7 @@ describe('USB Commands', () => {
 
 
 	describe('_formatNetworkIfaceOutput', () => {
-		it('formats the interface information to imitate linux `ifconfig` command', async () => {
+		it('formats the interface information to imitate linux `ifconfig` command', () => {
 			const nwInfo = [
 				{
 					'index': 5,
@@ -104,7 +104,7 @@ describe('USB Commands', () => {
 					access_token: '1234'
 				},
 			});
-			const res = await usbCommands._formatNetworkIfaceOutput(nwInfo, 'p2', '0123456789abcdef');
+			const res = usbCommands._formatNetworkIfaceOutput(nwInfo, 'p2', '0123456789abcdef');
 
 			expect(res).to.eql(expectedOutput);
 		});

--- a/src/cmd/usb.test.js
+++ b/src/cmd/usb.test.js
@@ -88,7 +88,7 @@ describe('USB Commands', () => {
 			];
 
 			const expectedOutput = [
-				'Device ID: \u001b[36m0123456789abcdef\u001b[39m (\u001b[36mp2\u001b[39m)',
+				'Device ID: 0123456789abcdef (p2)',
 				'\twl4(WIFI): flags=98371<UP,BROADCAST,LOWER_UP,LOWER_UP,MULTICAST,NOND6> mtu 1500',
 				'\t\tinet 10.2.3.4 netmask 255.255.255.255',
 				'\t\tether 94:94:4a:04:af:80',

--- a/src/cmd/usb.test.js
+++ b/src/cmd/usb.test.js
@@ -1,0 +1,112 @@
+const { expect } = require('../../test/setup');
+const UsbCommands = require('./usb');
+
+
+describe('USB Commands', () => {
+	afterEach(() => {
+	});
+
+
+	describe('_formatNetworkIfaceOutput', () => {
+		it('formats the interface information to imitate linux `ifconfig` command', async () => {
+			const nwInfo = [
+				{
+					'index': 5,
+					'name': 'wl4',
+					'type': 'WIFI',
+					'hwAddress': '94:94:4a:04:af:80',
+					'mtu': 1500,
+					'flagsVal': 98371,
+					'extFlags': 1114112,
+					'flagsStrings': ['UP', 'BROADCAST', 'LOWER_UP', 'LOWER_UP', 'MULTICAST', 'NOND6'],
+					'metric': 0,
+					'profile': Buffer.alloc(0),
+					'ipv4Config': {
+						'addresses': ['10.2.3.4/32'],
+						'gateway': null,
+						'peer': null,
+						'dns': [],
+						'source': 'NONE'
+					},
+					'ipv6Config': {
+						'addresses': [],
+						'gateway': null,
+						'dns': [],
+						'source': 'NONE'
+					}
+				},
+				{
+					'index': 4,
+					'name': 'pp3',
+					'type': 'PPP',
+					'hwAddress': '',
+					'mtu': 1500,
+					'flagsVal': 81,
+					'extFlags': 1048576,
+					'flagsStrings': ['UP', 'POINTOPOINT', 'LOWER_UP', 'LOWER_UP'],
+					'metric': 0,
+					'profile': Buffer.alloc(0),
+					'ipv4Config': {
+						'addresses': ['10.20.30.40/32'],
+						'gateway': null,
+						'peer': null,
+						'dns': [],
+						'source': 'NONE'
+					},
+					'ipv6Config': {
+						'addresses': [],
+						'gateway': null,
+						'dns': [],
+						'source': 'NONE'
+					}
+				},
+				{
+					'index': 1,
+					'name': 'lo0',
+					'type': 'LOOPBACK',
+					'hwAddress': '',
+					'mtu': 0,
+					'flagsVal': 73,
+					'extFlags': 0,
+					'flagsStrings': ['UP', 'LOOPBACK', 'LOWER_UP', 'LOWER_UP'],
+					'metric': 0,
+					'profile': Buffer.alloc(0),
+					'ipv4Config': {
+						'addresses': ['10.11.12.13/32'],
+						'gateway': null,
+						'peer': null,
+						'dns': [],
+						'source': 'NONE'
+					},
+					'ipv6Config': {
+						'addresses': ['0000:0000:0000:0000:0000:0000:0000:0001/64'],
+						'gateway': null,
+						'dns': [],
+						'source': 'NONE'
+					}
+				}
+			];
+
+			const expectedOutput = [
+				'Device ID: \u001b[36m0123456789abcdef\u001b[39m (\u001b[36mp2\u001b[39m)',
+				'\twl4(WIFI): flags=98371<UP,BROADCAST,LOWER_UP,LOWER_UP,MULTICAST,NOND6> mtu 1500',
+				'\t\tinet 10.2.3.4 netmask 255.255.255.255',
+				'\t\tether 94:94:4a:04:af:80',
+				'\tpp3(PPP): flags=81<UP,POINTOPOINT,LOWER_UP,LOWER_UP> mtu 1500',
+				'\t\tinet 10.20.30.40 netmask 255.255.255.255',
+				'\tlo0(LOOPBACK): flags=73<UP,LOOPBACK,LOWER_UP,LOWER_UP> mtu 0',
+				'\t\tinet 10.11.12.13 netmask 255.255.255.255',
+				'\t\tinet6 0000:0000:0000:0000:0000:0000:0000:0001 prefixlen 64'
+			];
+
+			const usbCommands = new UsbCommands({
+				settings: {
+					access_token: '1234'
+				},
+			});
+			const res = await usbCommands._formatNetworkIfaceOutput(nwInfo, 'p2', '0123456789abcdef');
+
+			expect(res).to.eql(expectedOutput);
+		});
+	});
+});

--- a/test/e2e/help.e2e.js
+++ b/test/e2e/help.e2e.js
@@ -67,7 +67,7 @@ describe('Help & Unknown Command / Argument Handling', () => {
 		'token create', 'token', 'udp send', 'udp listen', 'udp', 'update',
 		'update-cli', 'usb list', 'usb start-listening', 'usb listen',
 		'usb stop-listening', 'usb safe-mode', 'usb dfu', 'usb reset',
-		'usb setup-done', 'usb configure', 'usb cloud-status', 'usb',
+		'usb setup-done', 'usb configure', 'usb cloud-status', 'usb network-interfaces', 'usb',
 		'variable list', 'variable get', 'variable monitor', 'variable',
 		'webhook create', 'webhook list', 'webhook delete', 'webhook POST',
 		'webhook GET', 'webhook', 'whoami'];

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -28,6 +28,7 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 		'  setup-done       Set the setup done flag',
 		'  configure        Update the system USB configuration',
 		'  cloud-status     Check a device\'s cloud connection state',
+		'  network-interfaces         Gets the network configuration of the device',
 		'',
 		'Global Options:',
 		'  -v, --verbose  Increases how much logging to display  [count]',
@@ -318,6 +319,23 @@ describe('USB Commands [@device]', function cliUSBCommands(){
 			expect(stdout).to.equal('timed-out waiting for status...');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(1);
+		});
+	});
+
+	describe('USB network-interfaces Subcommand', () => {
+		after(async () => {
+			await cli.resetDevice();
+			await cli.waitUntilOnline();
+		});
+
+		it('provides network interfaces', async () => {
+			const ifacePattern = /\w+\(\w+\): flags=\d+<[\w,]+> mtu \d+/;
+
+			const { stdout, stderr, exitCode } = await cli.run(['usb', 'network-interfaces']);
+
+			expect(stdout).to.match(ifacePattern);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
 		});
 	});
 });


### PR DESCRIPTION
## Description

Implements a command which resembles the linux `ifconfig` command that shows information about the network interfaces and their states

This is only possible on Gen2 because the USB control requests to request this information are guarded by `HAL_PLATFORM_IFAPI` which is enabled only for Gen3 and above.

## How to Test

Check out this branch and from the particle-cli root directory, run `npm start -- usb network-interfaces`

1. Connect a single device
2. Or Connect muitple devices

## Expected Outcome

![Screenshot 2024-05-14 at 12 27 31 PM](https://github.com/particle-iot/particle-cli/assets/48732259/dcc87566-0067-422e-9ebe-933077b4fb7d)



## Related Issues / Discussions

https://github.com/particle-iot/particle-usb/pull/102


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

