### PR TITLE
Remove `--private` and `--public` args from `publish`

### DIFF
--- a/src/cli/publish.js
+++ b/src/cli/publish.js
@@ -2,15 +2,6 @@ module.exports = ({ commandProcessor, root }) => {
 	commandProcessor.createCommand(root, 'publish', 'Publish an event to the cloud', {
 		params: '<event> [data]',
 		options: {
-			'private': {
-				boolean: true,
-				default: true,
-				description: 'Publish to the private stream'
-			},
-			'public': {
-				boolean: true,
-				description: 'Publish to the public stream'
-			},
 			'product': {
 				description: 'Publish to the given Product ID or Slug\'s stream'
 			}

--- a/src/cli/publish.test.js
+++ b/src/cli/publish.test.js
@@ -25,11 +25,9 @@ describe('Publish Command-Line Interface', () => {
 		});
 
 		it('Parses options', () => {
-			const argv = commandProcessor.parse(root, ['publish', 'my-event', '--private', '--public', '--product', '12345']);
+			const argv = commandProcessor.parse(root, ['publish', 'my-event', '--product', '12345']);
 			expect(argv.clierror).to.equal(undefined);
 			expect(argv.params).to.eql({ event: 'my-event', data: undefined });
-			expect(argv.private).to.equal(true);
-			expect(argv.public).to.equal(true);
 			expect(argv.product).to.equal('12345');
 		});
 
@@ -56,8 +54,6 @@ describe('Publish Command-Line Interface', () => {
 					'Usage: particle publish [options] <event> [data]',
 					'',
 					'Options:',
-					'  --private  Publish to the private stream  [boolean] [default: true]',
-					'  --public   Publish to the public stream  [boolean]',
 					'  --product  Publish to the given Product ID or Slug\'s stream  [string]',
 					'',
 					'Examples:',

--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -209,13 +209,13 @@ module.exports = class ParticleApi {
 		);
 	}
 
-	publishEvent(name, data, isPrivate, product){
+	publishEvent(name, data, product){
 		return this._wrap(
 			this.api.publishEvent({
 				name,
 				data,
 				product,
-				isPrivate,
+				isPrivate: true,
 				auth: this.accessToken
 			})
 		);

--- a/src/cmd/publish.js
+++ b/src/cmd/publish.js
@@ -11,16 +11,14 @@ module.exports = class PublishCommand extends CLICommandBase {
 		super(...args);
 	}
 
-	publishEvent({ private: isPrivate, public: isPublic, product, params: { event, data } }){
-		isPrivate = (isPublic && !product) ? false : isPrivate; // `isPrivate: true` by default see: src/cli/publish.js
-		const visibility = isPrivate ? 'private' : 'public';
-		let epilogue = `${visibility} event: ${event}`;
+	publishEvent({ product, params: { event, data } }){
+		let epilogue = `private event: ${event}`;
 
 		if (product){
 			epilogue += ` to product: ${product}`;
 		}
 
-		const publishEvent = createAPI().publishEvent(event, data, isPrivate, product);
+		const publishEvent = createAPI().publishEvent(event, data, product);
 		return this.ui.showBusySpinnerUntilResolved(`Publishing ${epilogue}`, publishEvent)
 			.then(() => this.ui.stdout.write(`Published ${epilogue}${os.EOL}${os.EOL}`))
 			.catch(error => {

--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -946,7 +946,7 @@ module.exports = class ApiClient {
 		});
 	}
 
-	publishEvent(eventName, data, setPrivate){
+	publishEvent(eventName, data){
 		const { request, _access_token: token } = this;
 		let self = this;
 
@@ -959,7 +959,7 @@ module.exports = class ApiClient {
 					name: eventName,
 					data: data,
 					access_token: token,
-					private: setPrivate
+					private: true
 				}
 			};
 
@@ -977,11 +977,7 @@ module.exports = class ApiClient {
 					return reject(body);
 				}
 
-				console.log(
-					`Published ${setPrivate ? 'private' : 'public'}`,
-					'event:',
-					eventName
-				);
+				console.log(`Published private event: ${eventName}`);
 				console.log('');
 				resolve(body);
 			});

--- a/test/e2e/publish.e2e.js
+++ b/test/e2e/publish.e2e.js
@@ -15,7 +15,7 @@ describe('Publish Commands', () => {
 		'  -q, --quiet    Decreases how much logging to display  [count]',
 		'',
 		'Options:',
-		'  --private  Publish to the private stream  [boolean] [default: true]',
+		'  --product  Publish to the given Product ID or Slug\'s stream  [string]',
 		'',
 		'Examples:',
 		'  particle publish temp 25.0                  Publish a temp event to your private event stream',

--- a/test/e2e/publish.e2e.js
+++ b/test/e2e/publish.e2e.js
@@ -16,8 +16,6 @@ describe('Publish Commands', () => {
 		'',
 		'Options:',
 		'  --private  Publish to the private stream  [boolean] [default: true]',
-		'  --public   Publish to the public stream  [boolean]',
-		'  --product  Publish to the given Product ID or Slug\'s stream  [string]',
 		'',
 		'Examples:',
 		'  particle publish temp 25.0                  Publish a temp event to your private event stream',
@@ -66,24 +64,6 @@ describe('Publish Commands', () => {
 		expect(exitCode).to.equal(0);
 	});
 
-	it('Publishes a private event', async () => {
-		const args = ['publish', eventName, '--private'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.include(`Published private event: ${eventName}${os.EOL}`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Publishes a public event', async () => {
-		const args = ['publish', eventName, '--public'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.include(`Published public event: ${eventName}${os.EOL}`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
 	it('Publishes a product event', async () => {
 		const args = ['publish', eventName, '--product', PRODUCT_01_ID];
 		const { stdout, stderr, exitCode } = await cli.run(args);
@@ -94,16 +74,7 @@ describe('Publish Commands', () => {
 	});
 
 	it('Publishes a private product event', async () => {
-		const args = ['publish', eventName, '--product', PRODUCT_01_ID, '--private'];
-		const { stdout, stderr, exitCode } = await cli.run(args);
-
-		expect(stdout).to.include(`Published private event: ${eventName} to product: ${PRODUCT_01_ID}${os.EOL}`);
-		expect(stderr).to.equal('');
-		expect(exitCode).to.equal(0);
-	});
-
-	it('Ignores `--public` flag when publishing a product event', async () => {
-		const args = ['publish', eventName, '--product', PRODUCT_01_ID, '--public'];
+		const args = ['publish', eventName, '--product', PRODUCT_01_ID];
 		const { stdout, stderr, exitCode } = await cli.run(args);
 
 		expect(stdout).to.include(`Published private event: ${eventName} to product: ${PRODUCT_01_ID}${os.EOL}`);


### PR DESCRIPTION
## Description

Particle publishes are now default to private events. This update removes `--private` and `--public` args.

## How to Test



## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

