### PR TITLE
Fix wifi configuration on serial

### DIFF
--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -19,7 +19,7 @@ const { ensureError } = require('../lib/utilities');
 const FlashCommand = require('./flash');
 const usbUtils = require('./usb-util');
 const { platformForId } = require('../lib/platform');
-const { FirmwareModuleDisplayNames } = require('../lib/require-optional')('particle-usb');
+const { FirmwareModuleDisplayNames } = require('particle-usb');
 const WifiControlRequest = require('../lib/wifi-control-request');
 const semver = require('semver');
 

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -21,7 +21,6 @@ const usbUtils = require('./usb-util');
 const { platformForId } = require('../lib/platform');
 const { FirmwareModuleDisplayNames } = require('../lib/require-optional')('particle-usb');
 const WifiControlRequest = require('../lib/wifi-control-request');
-const semver = require('semver');
 
 const IDENTIFY_COMMAND_TIMEOUT = 20000;
 
@@ -759,7 +758,6 @@ module.exports = class SerialCommand extends CLICommandBase {
 					});
 			});
 
-
 			serialTrigger.addTrigger('EAP Type 0=PEAP/MSCHAPv2, 1=EAP-TLS:', (cb) => {
 				resetTimeout();
 
@@ -812,7 +810,6 @@ module.exports = class SerialCommand extends CLICommandBase {
 						});
 				}
 			});
-
 
 			serialTrigger.addTrigger('Outer identity (optional):', (cb) => {
 				resetTimeout();
@@ -913,7 +910,6 @@ module.exports = class SerialCommand extends CLICommandBase {
 						});
 				}
 			});
-
 
 			serialTrigger.addTrigger('Password:', (cb) => {
 				resetTimeout();


### PR DESCRIPTION
## Description

Run serial wifi configuration via control requests for gen3 and above. Use serial commands for gen2.

## How to Test

1. Setup this branch
2. Connect a single or multiple devices
3. Run the following commands
`npm start -- serial wifi`
`npm start -- serial wifi --file creds.json`
where creds.json looks like
```
{
  "network": "my_ssid",
  "security": "WPA2_AES",
  "password": "my_password"
}

```

## Related Issues / Discussions



## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

