### PR TITLE
Add new control request to set wifi creds

### DIFF
--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -534,6 +534,7 @@ module.exports = class SerialCommand extends CLICommandBase {
 
 		// if device's firmware version is less than 6.0.0, use the old way
 		const fwVer = device.firmwareVersion;
+		// FIXME: get the correct version number
 		if (semver.lt(fwVer, '6.0.0')) {
 			// configure serial
 			if (file){

--- a/src/lib/wifi-control-request.js
+++ b/src/lib/wifi-control-request.js
@@ -209,7 +209,7 @@ module.exports = class WiFiControlRequest {
 	async setWifiCredentials({ ssid, password }) {
 		// open device by id
 		let retries = RETRY_COUNT;
-		const spin = this.newSpin(`Setting Wi-Fi credentials for '${ssid}'`).start();
+		this.newSpin(`Setting Wi-Fi credentials for '${ssid}'`).start();
 		let lastError;
 		while (retries > 0) {
 			try {


### PR DESCRIPTION
## Description

Device-OS added a new control request to set network credentials without needing for a connection attempt. This PR adds support to use this control request to configure wifi network. If device is of device-os version which does not support this control request (which is 6.x TBD), wifi is configured via serial commands

## How to Test

1. Flash your wifi devices with https://github.com/particle-iot/device-os/pull/2763
2. Connect this CLI to this particle-usb PR https://github.com/particle-iot/particle-usb/pull/103
3. Most important! Correct this line in this PR to always use control requests - https://github.com/particle-iot/particle-cli/compare/feature/wifi-configuration?expand=1#diff-cd875ddf040ba04907a08a3fd03ef7fa0039f29267b30aca435178386162ec24R538
4. Run `npm start -- serial wifi`


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

