### PR TITLE
fix: [sc-122790] Invalid commands are not failing properly

### DIFF
--- a/src/app/cli.js
+++ b/src/app/cli.js
@@ -146,6 +146,8 @@ module.exports = class CLI {
 			throw argv.clierror;
 		} else if (argv.clicommand){
 			await argv.clicommand.exec(argv);
+		} else {
+			throw commandProcessor.errors.unknownCommandError(args, null);
 		}
 	}
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/122790

In case a multi-word command doesn't exist but one of the words exist like `particle tokens list`, the command processor would return no command and no error so the output would be blank. With this simple fix, it will say `No such command 'tokens list'` but show the help for `particle list`. It's not a perfect fix, but it's better than the current situation.
