### PR TITLE
Feature/sc 129083/when flashing device os modules to a protected

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -19,6 +19,7 @@ const {
 	createFlashSteps,
 	filterModulesToFlash,
 	parseModulesToFlash,
+	validateModulesForProtection,
 	flashFiles,
 	validateDFUSupport,
 	getFileFlashInfo
@@ -87,6 +88,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 				platformId: device.platformId,
 				platformName
 			});
+			await validateModulesForProtection({ modules: modulesToFlash, device });
 			const flashSteps = await createFlashSteps({
 				modules: modulesToFlash,
 				isInDfuMode: device.isInDfuMode,
@@ -156,6 +158,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 		let modulesToFlash = [...fileModules, ...deviceOsModules];
 		modulesToFlash = filterModulesToFlash({ modules: modulesToFlash, platformId });
 
+		await validateModulesForProtection({ modules: modulesToFlash, device });
 		const flashSteps = await createFlashSteps({
 			modules: modulesToFlash,
 			isInDfuMode: device.isInDfuMode,

--- a/src/cmd/update.js
+++ b/src/cmd/update.js
@@ -6,7 +6,7 @@ const semver = require('semver');
 const usbUtils = require('./usb-util');
 const deviceOsUtils = require('../lib/device-os-version-util');
 const CLICommandBase = require('./base');
-const { parseModulesToFlash, filterModulesToFlash, createFlashSteps, flashFiles, validateDFUSupport } = require('../lib/flash-helper');
+const { parseModulesToFlash, filterModulesToFlash, validateModulesForProtection, createFlashSteps, flashFiles, validateDFUSupport } = require('../lib/flash-helper');
 const createApiCache = require('../lib/api-cache');
 
 module.exports = class UpdateCommand extends CLICommandBase {
@@ -41,6 +41,7 @@ module.exports = class UpdateCommand extends CLICommandBase {
 		});
 		const deviceOsModules = await parseModulesToFlash({ files: deviceOsBinaries });
 		const modulesToFlash = filterModulesToFlash({ modules: deviceOsModules, platformId: device.platformId, allowAll: true });
+		await validateModulesForProtection({ modules: modulesToFlash, device });
 		const flashSteps = await createFlashSteps({ modules: modulesToFlash, isInDfuMode: device.isInDfuMode , platformId: device.platformId });
 		await flashFiles({ device, flashSteps, ui: this.ui });
 		this.ui.write('Update success!');

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -380,10 +380,11 @@ async function validateModulesForProtection({ modules, device }) {
 	}
 
 	for (const module of modules) {
-		const oldSystem = module.moduleFunction === ModuleInfo.FunctionType.SYSTEM_PART &&
-			module.moduleVersion < PROTECTED_MINIMUM_SYSTEM_VERSION;
-		const oldBootloader = module.moduleFunction === ModuleInfo.FunctionType.BOOTLOADER &&
-			module.moduleIndex === 0 && module.moduleVersion < PROTECTED_MINIMUM_BOOTLOADER_VERSION;
+		const { moduleFunction, moduleIndex, moduleVersion } = module.prefixInfo;
+		const oldSystem = moduleFunction === ModuleInfo.FunctionType.SYSTEM_PART &&
+			moduleVersion < PROTECTED_MINIMUM_SYSTEM_VERSION;
+		const oldBootloader = moduleFunction === ModuleInfo.FunctionType.BOOTLOADER &&
+			moduleIndex === 0 && moduleVersion < PROTECTED_MINIMUM_BOOTLOADER_VERSION;
 
 		if (oldSystem || oldBootloader) {
 			throw new Error(`Cannot downgrade Device OS below version ${PROTECTED_MINIMUM_VERSION} on a Protected Device`);

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -358,6 +358,9 @@ function validateDFUSupport({ device, ui }) {
 	}
 }
 
+function validateModulesForProtection({ modules, device }) {
+
+}
 
 module.exports = {
 	flashFiles,
@@ -366,6 +369,7 @@ module.exports = {
 	createFlashSteps,
 	prepareDeviceForFlash,
 	validateDFUSupport,
+	validateModulesForProtection,
 	getFileFlashInfo,
 	_get256Hash,
 	_skipAsset

--- a/src/lib/flash-helper.test.js
+++ b/src/lib/flash-helper.test.js
@@ -689,29 +689,29 @@ describe('flash-helper', () => {
 
 		beforeEach(() => {
 			device = {
-				getProtectedState: sinon.stub(),
+				getProtectionState: sinon.stub(),
 			};
 		});
 
 		describe('device is not protected', () => {
 			beforeEach(() => {
-				device.getProtectedState.returns({ protected: false, overriden: false });
+				device.getProtectionState.returns({ protected: false, overridden: false });
 			});
 
-			it('does does not reject old modules', () => {
+			it('does does not reject old modules', async () => {
 				let error;
 				try {
-					validateModulesForProtection({ device, modules: modulesOldBootloader });
+					await validateModulesForProtection({ device, modules: modulesOldBootloader });
 				} catch (_error) {
 					error = _error;
 				}
 				expect(error).to.be.undefined;
 			});
 
-			it('does does not reject new modules', () => {
+			it('does does not reject new modules', async () => {
 				let error;
 				try {
-					validateModulesForProtection({ device, modules: modulesNew });
+					await validateModulesForProtection({ device, modules: modulesNew });
 				} catch (_error) {
 					error = _error;
 				}
@@ -719,35 +719,35 @@ describe('flash-helper', () => {
 			});
 		});
 
-		describe('device is protected', () => {
+		describe('device is protected',  () => {
 			beforeEach(() => {
-				device.getProtectedState.returns({ protected: true, overriden: false });
+				device.getProtectionState.returns({ protected: true, overridden: false });
 			});
 
-			it('throws an exception if the bootloader is too old', () => {
+			it('throws an exception if the bootloader is too old', async () => {
 				let error;
 				try {
-					validateModulesForProtection({ device, modules: modulesOldBootloader });
+					await validateModulesForProtection({ device, modules: modulesOldBootloader });
 				} catch (_error) {
 					error = _error;
 				}
 				expect(error).to.have.property('message').that.eql('Cannot downgrade Device OS below version 6.0.0 on a Protected Device');
 			});
 
-			it('throws an exception if the system part is too old', () => {
+			it('throws an exception if the system part is too old', async () => {
 				let error;
 				try {
-					validateModulesForProtection({ device, modules: modulesOldSystem });
+					await validateModulesForProtection({ device, modules: modulesOldSystem });
 				} catch (_error) {
 					error = _error;
 				}
 				expect(error).to.have.property('message').that.eql('Cannot downgrade Device OS below version 6.0.0 on a Protected Device');
 			});
 
-			it('does does not reject new modules', () => {
+			it('does does not reject new modules', async () => {
 				let error;
 				try {
-					validateModulesForProtection({ device, modules: modulesNew });
+					await validateModulesForProtection({ device, modules: modulesNew });
 				} catch (_error) {
 					error = _error;
 				}
@@ -757,23 +757,23 @@ describe('flash-helper', () => {
 
 		describe('device does not support protection', () => {
 			beforeEach(() => {
-				device.getProtectedState.throws(new Error('Not supported'));
+				device.getProtectionState.throws(new Error('Not supported'));
 			});
 
-			it('does does not reject old modules', () => {
+			it('does does not reject old modules', async () => {
 				let error;
 				try {
-					validateModulesForProtection({ device, modules: modulesOldBootloader });
+					await validateModulesForProtection({ device, modules: modulesOldBootloader });
 				} catch (_error) {
 					error = _error;
 				}
 				expect(error).to.be.undefined;
 			});
 
-			it('does does not reject new modules', () => {
+			it('does does not reject new modules', async () => {
 				let error;
 				try {
-					validateModulesForProtection({ device, modules: modulesNew });
+					await validateModulesForProtection({ device, modules: modulesNew });
 				} catch (_error) {
 					error = _error;
 				}

--- a/src/lib/flash-helper.test.js
+++ b/src/lib/flash-helper.test.js
@@ -664,27 +664,35 @@ describe('flash-helper', () => {
 	describe('validateModulesForProtection', () => {
 		let device;
 		const modulesOldBootloader = [{
-			moduleFunction: ModuleInfo.FunctionType.BOOTLOADER,
-			platformId: 12,
-			moduleIndex: 0,
-			moduleVersion: 1200,
+			prefixInfo: {
+				moduleFunction: ModuleInfo.FunctionType.BOOTLOADER,
+				platformId: 12,
+				moduleIndex: 0,
+				moduleVersion: 1200
+			}
 		}];
 		const modulesOldSystem = [{
-			moduleFunction: ModuleInfo.FunctionType.SYSTEM_PART,
-			platformId: 12,
-			moduleIndex: 0,
-			moduleVersion: 5800,
+			prefixInfo: {
+				moduleFunction: ModuleInfo.FunctionType.SYSTEM_PART,
+				platformId: 12,
+				moduleIndex: 0,
+				moduleVersion: 5800
+			}
 		}];
 		const modulesNew = [{
-			moduleFunction: ModuleInfo.FunctionType.BOOTLOADER,
-			platformId: 12,
-			moduleIndex: 0,
-			moduleVersion: 3000,
+			prefixInfo: {
+				moduleFunction: ModuleInfo.FunctionType.BOOTLOADER,
+				platformId: 12,
+				moduleIndex: 0,
+				moduleVersion: 3000
+			}
 		}, {
-			moduleFunction: ModuleInfo.FunctionType.SYSTEM_PART,
-			platformId: 12,
-			moduleIndex: 0,
-			moduleVersion: 6000,
+			prefixInfo: {
+				moduleFunction: ModuleInfo.FunctionType.SYSTEM_PART,
+				platformId: 12,
+				moduleIndex: 0,
+				moduleVersion: 6000
+			}
 		}];
 
 		beforeEach(() => {


### PR DESCRIPTION
## Description

Prevent downgrading Device OS below a minimum version of 6.0.0 for Protected Devices.

## How to Test

1. Put a Protected Device in Service Mode
2. The following commands should give the error "Cannot downgrade Device OS below version 6.0.0 on a Protected Device"
  * `particle update --target 5.8.0`
  * `particle flash --usb argon-system-part1@5.8.0.bin`
  * `particle flash --local argon-system-part1@5.8.0.bin`
  * `particle flash --local --target 5.8.0`

## Related Issues / Discussions

[Story](https://app.shortcut.com/particle/story/129083/when-flashing-device-os-modules-to-a-protected-device-reject-flashing-versions-older-than-the-minimum)

## Completeness

- [ ] Update particle-usb to get device protection state while in DFU. <- this will be done in another PR