### PR TITLE
Rework device protection e2e tests

### DIFF
--- a/src/cli/device-protection.js
+++ b/src/cli/device-protection.js
@@ -20,7 +20,7 @@ module.exports = ({ commandProcessor, root }) => {
 		examples: {
 			'$0 $command': 'Puts a Protected Device to Service Mode',
 		},
-		epilogue: 'A Protected Device in Service Mode allows any command to be performed on it that can be performed on an open device like flashing firmware or serial monitor.'
+		epilogue: 'A Protected Device in Service Mode allows any command to be performed on it that can be performed on an Open Device like flashing firmware or serial monitor.'
 	});
 
 	commandProcessor.createCommand(deviceProtection, 'enable', 'Enables device protection', {

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -31,7 +31,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	 * Retrieves and displays the protection status of the device.
 	 *
 	 * This method assumes the device is in normal mode and not in DFU mode. It retrieves the current protection status and
-	 * constructs a message indicating whether the device is protected, in service mode, or not protected.
+	 * constructs a message indicating whether the device is Protected, in Service Mode, or Open
 	 * The device protection status is then displayed in the console.
 	 *
 	 * @async
@@ -49,11 +49,11 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 				let helper;
 
 				if (s.overridden) {
-					res = 'Protected device (service mode)';
-					helper = `Run ${chalk.yellow('particle device-protection enable')} to take the device out of service mode.`;
+					res = 'Protected Device (Service Mode)';
+					helper = `Run ${chalk.yellow('particle device-protection enable')} to take the device out of Service Mode.`;
 				} else if (s.protected) {
-					res = 'Protected device';
-					helper = `Run ${chalk.yellow('particle device-protection disable')} to put the device in service mode.`;
+					res = 'Protected Device';
+					helper = `Run ${chalk.yellow('particle device-protection disable')} to put the device in Service Mode.`;
 				} else {
 					res = 'Open device';
 					helper = `Run ${chalk.yellow('particle device-protection enable')} to protect the device.`;
@@ -77,14 +77,11 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	/**
 	 * Disables protection on the device.
 	 *
-	 * This method checks the current protection status of the device and proceeds to disable protection
-	 * if the device is protected. If the device is not protected or is already in service mode,
-	 * appropriate messages are logged to the console. If the `open` parameter is true, the device will be
-	 * flashed with an unprotected bootloader and marked as a development device to prevent re-enabling protection.
+	 * This method checks the current protection status of the device and proceeds to put the device in Service Mode
+	 * if the device is protected. If the device is not protected or is already in Service Mode,
+	 * appropriate messages are logged to the console.
 	 *
 	 * @async
-	 * @param {Object} [options={}] - Options for disabling protection.
-	 * @param {boolean} [options.open] - If true, flashes an unprotected bootloader and marks the device as a development device to make it an open device.
 	 * @returns {Promise<void>}
 	 * @throws {Error} - Throws an error if any of the async operations fail.
 	 */
@@ -122,7 +119,6 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 				await this.device.unprotectDevice({ action: 'confirm', serverSignature, serverPublicKeyFingerprint });
 
 				addToOutput.push(`${deviceStr} is now in Service Mode.${os.EOL}A Protected Device stays in Service Mode for a total of 20 reboots or 24 hours.${os.EOL}`);
-
 			} catch (error) {
 				throw new Error(`Failed to disable device protection: ${error.message}${os.EOL}`);
 			}
@@ -157,12 +153,12 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 
 				if (s.overridden) {
 					await this.device.unprotectDevice({ action: 'reset' });
-					addToOutput.push(`${deviceStr} is now a protected device.${os.EOL}`);
+					addToOutput.push(`${deviceStr} is now a Protected Device.${os.EOL}`);
 					return;
 				}
 
 				if (s.protected) {
-					addToOutput.push(`${deviceStr} is already a protected device.${os.EOL}`);
+					addToOutput.push(`${deviceStr} is already a Protected Device.${os.EOL}`);
 					return;
 				}
 
@@ -179,7 +175,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 				}
 
 				await this._flashBootloader(protectedBinary);
-				addToOutput.push(`${deviceStr} is now a protected device.${os.EOL}`);
+				addToOutput.push(`${deviceStr} is now a Protected Device.${os.EOL}`);
 
 				const success = await this._markAsDevelopmentDevice(false);
 				addToOutput.push(success ?

--- a/src/cmd/device-protection.test.js
+++ b/src/cmd/device-protection.test.js
@@ -71,7 +71,7 @@ describe('DeviceProtectionCommands', () => {
 			expect(deviceProtectionCommands.api.unprotectDevice).to.have.been.calledTwice;
 		});
 
-		it('handles already open devices', async () => {
+		it('handles already Open Devices', async () => {
 			sinon.stub(deviceProtectionCommands, '_getDeviceProtection')
 				.onFirstCall().resolves({ protected: false, overridden: false });
 			sinon.stub(deviceProtectionCommands, '_getDeviceString').resolves('[123456789abcdef] (Product 12345)');
@@ -105,7 +105,7 @@ describe('DeviceProtectionCommands', () => {
 		});
 
 
-		it('handles already protected devices', async () => {
+		it('handles already Protected Devices', async () => {
 			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').resolves({
 				protected: true,
 				overridden: false
@@ -119,7 +119,7 @@ describe('DeviceProtectionCommands', () => {
 			expect(deviceProtectionCommands._isDeviceProtectionActiveInProduct).to.not.have.been.called;
 		});
 
-		it('protects a service mode device', async () => {
+		it('protects a Service Mode device', async () => {
 			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').resolves({
 				protected: true,
 				overridden: true
@@ -134,7 +134,7 @@ describe('DeviceProtectionCommands', () => {
 			expect(deviceProtectionCommands._isDeviceProtectionActiveInProduct).to.not.have.been.called;
 		});
 
-		it('does not protect an open device if it is not in a product', async () => {
+		it('does not protect an Open Device if it is not in a product', async () => {
 			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').resolves({
 				protected: false,
 				overridden: false

--- a/test/e2e/device-protection.e2e.js
+++ b/test/e2e/device-protection.e2e.js
@@ -4,11 +4,8 @@ const {
 	PRODUCT_01_DEVICE_01_ID,
 	PRODUCT_01_ID
 } = require('../lib/env');
-const { delay } = require('../../src/lib/utilities');
 
-const FLASH_TIME = 15000;
-
-describe('Device Protection Commands [@device,@device-protection]', () => {
+describe.only('Device Protection Commands [@device,@device-protection]', () => {
 	const help = [
 		'Manage device protection',
 		'Usage: particle device-protection <command>',
@@ -25,14 +22,8 @@ describe('Device Protection Commands [@device,@device-protection]', () => {
 		''
 	];
 
-
 	before(async () => {
 		await cli.setTestProfileAndLogin();
-		// Ensure device starts as an Open Device
-		await cli.run(['device-protection', 'disable', '--open']);
-
-		// give time to flash the device
-		await delay(FLASH_TIME);
 	});
 
 	after(async () => {
@@ -65,45 +56,29 @@ describe('Device Protection Commands [@device,@device-protection]', () => {
 	});
 
 	describe('DeviceProtection Commands', () => {
-		it('Gets the current device protection status', async () => {
-			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'status']);
-
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}): Open device\nRun particle device-protection enable to protect the device.`);
-			expect(stderr).to.equal('');
-			expect(exitCode).to.equal(0);
-		});
-
-		it('Attempts to disable protection status on an open device', async () => {
-			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'disable']);
-
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is not a protected device.`);
-			expect(stderr).to.equal('');
-			expect(exitCode).to.equal(0);
-		});
-
 		it('Enables protection status on the device', async () => {
+			// Put device in Service Mode
+			await cli.run(['device-protection', 'disable']);
+
 			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'enable']);
 
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is now a protected device.\nDevice removed from development mode to maintain current settings.`);
+			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is now a Protected Device.\nDevice removed from development mode to maintain current settings.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
-
-			// give time to flash the device
-			await delay(FLASH_TIME);
 		});
 
 		it('Gets the current status of a Protected Device', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'status']);
 
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}): Protected device\nRun particle device-protection disable to put the device in service mode.`);
+			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}): Protected Device\nRun particle device-protection disable to put the device in Service Mode.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});
 
-		it('Attempts to enable protection status on a protected device', async () => {
+		it('Attempts to enable protection status on a Protected Device', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'enable']);
 
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is already a protected device.`);
+			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is already a Protected Device.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});
@@ -111,26 +86,15 @@ describe('Device Protection Commands [@device,@device-protection]', () => {
 		it('Puts the device in service mode', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'disable']);
 
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is now in service mode.\nA protected device stays in service mode for a total of 20 reboots or 24 hours.`);
+			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is now in Service Mode.\nA Protected Device stays in Service Mode for a total of 20 reboots or 24 hours.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
-		});
-
-		it('Turns the device to an open device', async () => {
-			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'disable', '--open']);
-
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is now an open device.\nDevice placed in development mode to maintain current settings.`);
-			expect(stderr).to.equal('');
-			expect(exitCode).to.equal(0);
-
-			// give time to flash the device
-			await delay(FLASH_TIME);
 		});
 
 		it('Gets the current status of the device', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'status']);
 
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}): Open device\nRun particle device-protection enable to protect the device.`);
+			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}): Protected Device (Service Mode)\nRun particle device-protection enable to protect the device.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});

--- a/test/e2e/device-protection.e2e.js
+++ b/test/e2e/device-protection.e2e.js
@@ -5,7 +5,7 @@ const {
 	PRODUCT_01_ID
 } = require('../lib/env');
 
-describe.only('Device Protection Commands [@device,@device-protection]', () => {
+describe('Device Protection Commands [@device,@device-protection]', () => {
 	const help = [
 		'Manage device protection',
 		'Usage: particle device-protection <command>',
@@ -62,7 +62,7 @@ describe.only('Device Protection Commands [@device,@device-protection]', () => {
 
 			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'enable']);
 
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is now a Protected Device.\nDevice removed from development mode to maintain current settings.`);
+			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}) is now a Protected Device.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});
@@ -94,7 +94,7 @@ describe.only('Device Protection Commands [@device,@device-protection]', () => {
 		it('Gets the current status of the device', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(['device-protection', 'status']);
 
-			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}): Protected Device (Service Mode)\nRun particle device-protection enable to protect the device.`);
+			expect(stdout).to.include(`[${PRODUCT_01_DEVICE_01_ID}] (Product ${PRODUCT_01_ID}): Protected Device (Service Mode)\nRun particle device-protection enable to take the device out of Service Mode.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});


### PR DESCRIPTION
## Description

Reorder the E2E tests for device protection to account for the removal of disabling protection locally.

## Completeness

- [x] Device protection tests pass locally
