### PR TITLE
Put a Protected Device automatically in Service Mode to run CLI commands

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -27,7 +27,7 @@
         "particle-api-js": "^10.5.1",
         "particle-commands": "^1.0.1",
         "particle-library-manager": "^0.1.15",
-        "particle-usb": "^3.4.0",
+        "particle-usb": "^3.5.0",
         "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
         "safe-buffer": "^5.2.0",
         "semver": "^7.5.2",
@@ -6376,9 +6376,9 @@
       }
     },
     "node_modules/particle-usb": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.4.0.tgz",
-      "integrity": "sha512-5yDR8LssjnfwT2a5OCcsogQe3VjDz2ZzC0KjXt9raqXRSWuySoWt6SRR5g06jT1WiNAll3VUhIV/8SuTL1RyAA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.5.0.tgz",
+      "integrity": "sha512-G/CO7YrRRXq9cwMk+teohoiPEHTCwf37xEjcyMYRTn4aSvkEM7s6DW+6wat2PvptoIFA4IuEZvljl6iyVuKfNQ==",
       "dependencies": {
         "@particle/device-os-protobuf": "^2.6.1",
         "ip-address": "^9.0.5",
@@ -14266,9 +14266,9 @@
       }
     },
     "particle-usb": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.4.0.tgz",
-      "integrity": "sha512-5yDR8LssjnfwT2a5OCcsogQe3VjDz2ZzC0KjXt9raqXRSWuySoWt6SRR5g06jT1WiNAll3VUhIV/8SuTL1RyAA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.5.0.tgz",
+      "integrity": "sha512-G/CO7YrRRXq9cwMk+teohoiPEHTCwf37xEjcyMYRTn4aSvkEM7s6DW+6wat2PvptoIFA4IuEZvljl6iyVuKfNQ==",
       "requires": {
         "@particle/device-os-protobuf": "^2.6.1",
         "ip-address": "^9.0.5",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "particle-api-js": "^10.5.1",
     "particle-commands": "^1.0.1",
     "particle-library-manager": "^0.1.15",
-    "particle-usb": "^3.4.0",
+    "particle-usb": "^3.5.0",
     "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
     "safe-buffer": "^5.2.0",
     "semver": "^7.5.2",

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -23,6 +23,10 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 		this.device = null;
 		this.ui = ui || this.ui;
 		this.productId = null;
+		this.status = {
+			protected: null,
+			overridden: null
+		}
 	}
 
 	/**
@@ -43,8 +47,8 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 			await this._withDevice({ spinner: 'Getting device status', putDeviceBackInDfuMode: true }, async () => {
 				let res;
 				let helper;
-				s = await DeviceProtectionHelper.getProtectionStatus(this.device);
 
+				const s = this.status;
 				if (s.overridden) {
 					res = 'Protected Device (Service Mode)';
 					helper = `Run ${chalk.yellow('particle device-protection enable')} to take the device out of Service Mode.`;
@@ -69,9 +73,6 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 			addToOutput.forEach((line) => {
 				this.ui.stdout.write(line);
 			});
-			if (this.device && this.device.isOpen) {
-				await this.device.close();
-			}
 		}
 		return s;
 	}
@@ -90,11 +91,11 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	async disableProtection() {
 		let addToOutput = [];
 
-		await this._withDevice({ spinner: 'Disabling device protection', putDeviceBackInDfuMode: true }, async () => {
+		await this._withDevice({ spinner: 'Disabling device protection', putDeviceBackInDfuMode: true, supportSafeMode: true }, async () => {
 			try {
 				const deviceStr = await this._getDeviceString();
-				let s = await DeviceProtectionHelper.getProtectionStatus(this.device);
 
+				const s = this.status;
 				if (!s.protected && !s.overridden) {
 					addToOutput.push(`${deviceStr} is not a Protected Device.${os.EOL}`);
 					return;
@@ -132,11 +133,11 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	 */
 	async enableProtection({ file } = {}) {
 		let addToOutput = [];
-		try {
-			await this._withDevice({ spinner: 'Enabling device protection', putDeviceBackInDfuMode: false }, async () => {
+		await this._withDevice({ spinner: 'Enabling device protection', putDeviceBackInDfuMode: false, supportSafeMode: true }, async () => {
+			try {
 				const deviceStr = await this._getDeviceString();
-				const s = await DeviceProtectionHelper.getProtectionStatus(this.device);
-
+				
+				const s = this.status;
 				// Protected (Service Mode) Device
 				if (s.overridden) {
 					await DeviceProtectionHelper.turnOffServiceMode(this.device);
@@ -178,13 +179,13 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 						);
 					}
 				}
-			});
-		} catch (error) {
-			if (error.message === 'Not supported') {
-				throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
+			} catch (error) {
+				if (error.message === 'Not supported') {
+					throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
+				}
+				throw new Error(`Failed to enable device protection: ${error.message}${os.EOL}`);
 			}
-			throw new Error(`Failed to enable device protection: ${error.message}${os.EOL}`);
-		}
+		});
 
 		addToOutput.forEach((line) => {
 			this.ui.stdout.write(line);
@@ -289,8 +290,11 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	}
 
 	/**
-	 * Executes a function with the device, ensuring it is in the correct mode.
+	 * Executes a function with the device (Open / Protected / Protected (Service Mode)), ensuring it is in the correct mode.
+	 * Checks the protection status of the device which is needed for all the commands
 	 * If it is in DFU mode, the device is reset and re-opened expecting it to be in normal mode.
+	 * DFU device is queried for protection status and if the device is not a Protected Device, then the device is put
+	 * into safe mode to send it a control request to get the exact status.
 	 *
 	 * @async
 	 * @param {Object} options
@@ -299,12 +303,16 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	 * @param {Function} fn - The function to execute with the device.
 	 * @returns {Promise<*>} The result of the function execution.
 	 */
-	async _withDevice({ putDeviceBackInDfuMode, spinner }, fn) {
+	async _withDevice({ putDeviceBackInDfuMode, spinner, supportSafeMode }, fn) {
 		await this._getUsbDevice(this.device);
 		await this.ui.showBusySpinnerUntilResolved(spinner, (async () => {
+			this.status = await DeviceProtectionHelper.getProtectionStatus(this.device);
 			const deviceWasInDfuMode = this.device.isInDfuMode;
 			if (deviceWasInDfuMode) {
-				await this._putDeviceInSafeMode();
+				if (!this.status.protected || supportSafeMode) {
+					await this._putDeviceInSafeMode();
+					this.status = await DeviceProtectionHelper.getProtectionStatus(this.device);
+				}
 			}
 			putDeviceBackInDfuMode = putDeviceBackInDfuMode && deviceWasInDfuMode;
 			return await fn();
@@ -367,7 +375,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 				throw new Error(`Unable to run this command in DFU mode on this Device-OS version. Take your device out of DFU mode and try again.${os.EOL}Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
 			}
 		}
-		// device.enterSafeMode() is ineffective for device-os < 6.1.3 (TBD).
+		// device.enterSafeMode() is ineffective for device-os < 6.1.3 (TBD). However, it does not throw an error.
 		// If device is still in dfu mode, it likely means that this is an older device-os version
 		// and it cannot be put into safe mode. In this case, we can only tell if the device is
 		// Protected or not (we cannot distinguish between Protected and Protected (Service Mode) / Open).
@@ -376,6 +384,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 		// Alternative considerations:
 		// 1. Provide a general response about Protection status (less precise but more permissive)
 		// 2. Implement version-specific handling for a more tailored user experience
+		//		(but firmware version is not available in the device class for dfu devices)
 		this.device = await usbUtils.reopenDevice({ id: this.deviceId });
 		if (this.device.isInDfuMode) {
 			throw new Error('Device Protection commands unavailable in DFU mode for this Device-OS version. Take the device out of DFU mode and try again.');

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -12,7 +12,6 @@ const FlashCommand = require('./flash');
 const { platformForId } = require('../lib/platform');
 const BinaryCommand = require('./binary');
 const DeviceProtectionHelper = require('../lib/device-protection-helper');
-const { waitForDeviceToReboot } = require('./device-util');
 
 module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	constructor({ ui } = {}) {
@@ -312,17 +311,13 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 			})());
 		} finally {
 			if (putDeviceBackInDfuMode) {
-				await this._waitForDeviceToReboot();
+				await usbUtils.waitForDeviceToReboot();
 				await this.device.enterDfuMode();
 			}
 			if (this.device && this.device.isOpen) {
 				await this.device.close();
 			}
 		}
-	}
-
-	async _waitForDeviceToReboot() {
-		await waitForDeviceToReboot(this.deviceId);
 	}
 
 	/**

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -12,7 +12,7 @@ const FlashCommand = require('./flash');
 const { platformForId } = require('../lib/platform');
 const BinaryCommand = require('./binary');
 const DeviceProtectionHelper = require('../lib/device-protection-helper');
-const FlashHelper = require('../lib/flash-helper');
+const { waitForDeviceToReboot } = require('./device-util');
 
 module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	constructor({ ui } = {}) {
@@ -312,13 +312,17 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 			})());
 		} finally {
 			if (putDeviceBackInDfuMode) {
-				await FlashHelper.waitForDeviceToReboot(this.deviceId);
+				await this._waitForDeviceToReboot();
 				await this.device.enterDfuMode();
 			}
 			if (this.device && this.device.isOpen) {
 				await this.device.close();
 			}
 		}
+	}
+
+	async _waitForDeviceToReboot() {
+		await waitForDeviceToReboot(this.deviceId);
 	}
 
 	/**

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -341,10 +341,6 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 		}
 	}
 
-	async _delay(ms){
-		return new Promise((resolve) => setTimeout(resolve, ms));
-	}
-
 	/**
 	 * Attempts to enter Safe Mode to enable operations on Protected Devices in DFU mode.
 	 *

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -353,7 +353,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	}
 
 	/**
-	 * Resets the device and waits for it to restart.
+	 * Attempts to enter Safe Mode to enable operations on Protected Devices in DFU mode.
 	 *
 	 * @async
 	 * @param {Object} device - The device to reset.

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -32,9 +32,8 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	/**
 	 * Retrieves and displays the protection status of the device.
 	 *
-	 * This method assumes the device is in normal mode and not in DFU mode. It retrieves the current protection status and
-	 * constructs a message indicating whether the device is Protected, in Service Mode, or Open
-	 * The device protection status is then displayed in the console.
+	 * It retrieves the current protection status and constructs a message
+	 * indicating whether the device is Protected, in Service Mode, or Open.
 	 *
 	 * @async
 	 * @returns {Promise<Object>} The protection state of the device.
@@ -100,7 +99,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 					addToOutput.push(`${deviceStr} is not a Protected Device.${os.EOL}`);
 					return;
 				}
-				
+
 				if (this.device.isInDfuMode) {
 					await this._putDeviceInSafeMode();
 				}
@@ -299,13 +298,9 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	/**
 	 * Executes a function with the device (Open / Protected / Protected (Service Mode)), ensuring it is in the correct mode.
 	 * Checks the protection status of the device which is needed for all the commands
-	 * If it is in DFU mode, the device is reset and re-opened expecting it to be in normal mode.
-	 * DFU device is queried for protection status and if the device is not a Protected Device, then the device is put
-	 * into safe mode to send it a control request to get the exact status.
 	 *
 	 * @async
 	 * @param {Object} options
-	 * @param {boolean} options.putDeviceBackInDfuMode - Checks if device should be put back into dfy mode if the device was in dfu mode at the start of the operation
 	 * @param {Function} options.spinner - The text to display in a spinner until the operation completes
 	 * @param {Function} fn - The function to execute with the device.
 	 * @returns {Promise<*>} The result of the function execution.

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -26,7 +26,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 		this.status = {
 			protected: null,
 			overridden: null
-		}
+		};
 	}
 
 	/**
@@ -48,7 +48,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 				let res;
 				let helper;
 
-				const s = this.status;
+				s = this.status;
 				if (s.overridden) {
 					res = 'Protected Device (Service Mode)';
 					helper = `Run ${chalk.yellow('particle device-protection enable')} to take the device out of Service Mode.`;
@@ -136,7 +136,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 		await this._withDevice({ spinner: 'Enabling device protection', putDeviceBackInDfuMode: false, supportSafeMode: true }, async () => {
 			try {
 				const deviceStr = await this._getDeviceString();
-				
+
 				const s = this.status;
 				// Protected (Service Mode) Device
 				if (s.overridden) {

--- a/src/cmd/device-protection.test.js
+++ b/src/cmd/device-protection.test.js
@@ -317,12 +317,10 @@ describe('DeviceProtectionCommands', () => {
 			deviceProtectionCommands.device.isInDfuMode = true;
 			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: true });
 			sinon.stub(deviceProtectionCommands, '_putDeviceInSafeMode').resolves();
-			sinon.stub(usbUtils, 'waitForDeviceToReboot').resolves();
 
 			await deviceProtectionCommands._withDevice({ putDeviceBackInDfuMode: true }, fn);
 
 			expect(deviceProtectionCommands._putDeviceInSafeMode).to.not.have.been.calledOnce;
-			expect(usbUtils.waitForDeviceToReboot).to.not.have.been.called;
 			expect(fn).to.have.been.calledOnce;
 		});
 
@@ -330,11 +328,9 @@ describe('DeviceProtectionCommands', () => {
 			const fn = sinon.stub().resolves();
 			deviceProtectionCommands.device.isInDfuMode = true;
 			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: false });
-			sinon.stub(usbUtils, 'waitForDeviceToReboot').resolves();
 
 			await deviceProtectionCommands._withDevice({ putDeviceBackInDfuMode: true }, fn);
 
-			expect(usbUtils.waitForDeviceToReboot).to.not.have.been.called;
 			expect(fn).to.have.been.calledOnce;
 		});
 

--- a/src/cmd/device-protection.test.js
+++ b/src/cmd/device-protection.test.js
@@ -1,7 +1,6 @@
 const DeviceProtectionCommands = require('./device-protection');
 const { expect, sinon } = require('../../test/setup');
 const deviceProtectionHelper = require('../lib/device-protection-helper');
-const flashHelper = require('../lib/flash-helper');
 
 describe('DeviceProtectionCommands', () => {
 	let deviceProtectionCommands;
@@ -314,12 +313,12 @@ describe('DeviceProtectionCommands', () => {
 			const fn = sinon.stub().resolves();
 			deviceProtectionCommands.device.isInDfuMode = true;
 			sinon.stub(deviceProtectionCommands, '_putDeviceInSafeMode').resolves();
-			sinon.stub(flashHelper, 'waitForDeviceToReboot').resolves();
+			sinon.stub(deviceProtectionCommands, '_waitForDeviceToReboot').resolves();
 
 			await deviceProtectionCommands._withDevice({ putDeviceBackInDfuMode: true }, fn);
 
 			expect(deviceProtectionCommands._putDeviceInSafeMode).to.have.been.calledOnce;
-			expect(flashHelper.waitForDeviceToReboot).to.have.been.called;
+			expect(deviceProtectionCommands._waitForDeviceToReboot).to.have.been.called;
 			expect(fn).to.have.been.calledOnce;
 		});
 

--- a/src/cmd/device-protection.test.js
+++ b/src/cmd/device-protection.test.js
@@ -1,6 +1,7 @@
 const DeviceProtectionCommands = require('./device-protection');
 const { expect, sinon } = require('../../test/setup');
 const deviceProtectionHelper = require('../lib/device-protection-helper');
+const usbUtils = require('./usb-util');
 
 describe('DeviceProtectionCommands', () => {
 	let deviceProtectionCommands;
@@ -313,12 +314,12 @@ describe('DeviceProtectionCommands', () => {
 			const fn = sinon.stub().resolves();
 			deviceProtectionCommands.device.isInDfuMode = true;
 			sinon.stub(deviceProtectionCommands, '_putDeviceInSafeMode').resolves();
-			sinon.stub(deviceProtectionCommands, '_waitForDeviceToReboot').resolves();
+			sinon.stub(usbUtils, 'waitForDeviceToReboot').resolves();
 
 			await deviceProtectionCommands._withDevice({ putDeviceBackInDfuMode: true }, fn);
 
 			expect(deviceProtectionCommands._putDeviceInSafeMode).to.have.been.calledOnce;
-			expect(deviceProtectionCommands._waitForDeviceToReboot).to.have.been.called;
+			expect(usbUtils.waitForDeviceToReboot).to.have.been.called;
 			expect(fn).to.have.been.calledOnce;
 		});
 

--- a/src/cmd/device-protection.test.js
+++ b/src/cmd/device-protection.test.js
@@ -1,7 +1,6 @@
 const DeviceProtectionCommands = require('./device-protection');
 const { expect, sinon } = require('../../test/setup');
 const deviceProtectionHelper = require('../lib/device-protection-helper');
-const usbUtils = require('./usb-util');
 
 describe('DeviceProtectionCommands', () => {
 	let deviceProtectionCommands;

--- a/src/cmd/device-protection.test.js
+++ b/src/cmd/device-protection.test.js
@@ -330,12 +330,10 @@ describe('DeviceProtectionCommands', () => {
 			const fn = sinon.stub().resolves();
 			deviceProtectionCommands.device.isInDfuMode = true;
 			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: false });
-			sinon.stub(deviceProtectionCommands, '_putDeviceInSafeMode').resolves();
 			sinon.stub(usbUtils, 'waitForDeviceToReboot').resolves();
 
 			await deviceProtectionCommands._withDevice({ putDeviceBackInDfuMode: true }, fn);
 
-			expect(deviceProtectionCommands._putDeviceInSafeMode).to.have.been.calledOnce;
 			expect(usbUtils.waitForDeviceToReboot).to.not.have.been.called;
 			expect(fn).to.have.been.calledOnce;
 		});

--- a/src/cmd/device-util.js
+++ b/src/cmd/device-util.js
@@ -47,22 +47,3 @@ module.exports.getDevice = ({ id, api, auth, displayName = null, dontThrow = fal
 			throw error;
 		});
 };
-
-module.exports.manageDeviceProtection = async (device) => {
-	try {
-		const s = await getProtectionStatus(device);
-		if (s.protected && !s.overridden) { // protected device
-			await disableDeviceProtection(device);
-			return true;
-		}
-	} catch (error) {
-		if (!error.message.includes('Not supported') && !error.message.includes('Request Error')) {
-			throw new Error(error);
-		}
-	}
-	return false;
-};
-
-module.exports.protectDevice = async (device) => {
-	await turnOffServiceMode(device);
-};

--- a/src/cmd/device-util.js
+++ b/src/cmd/device-util.js
@@ -1,3 +1,5 @@
+const { getProtectionStatus, disableDeviceProtection, turnOffServiceMode } = require('../lib/device-protection-helper');
+
 /**
  * Check if the string can represent a valid device ID.
  *
@@ -46,3 +48,21 @@ module.exports.getDevice = ({ id, api, auth, displayName = null, dontThrow = fal
 		});
 };
 
+module.exports.manageDeviceProtection = async (device) => {
+	try {
+		const s = await getProtectionStatus(device);
+		if (s.protected && !s.overridden) { // protected device
+			await disableDeviceProtection(device);
+			return true;
+		}
+	} catch (error) {
+		if (!error.message.includes('Not supported') && !error.message.includes('Request Error')) {
+			throw new Error(error);
+		}
+	}
+	return false;
+};
+
+module.exports.protectDevice = async (device) => {
+	await turnOffServiceMode(device);
+};

--- a/src/cmd/device-util.js
+++ b/src/cmd/device-util.js
@@ -1,4 +1,3 @@
-const usbUtils = require('./usb-util');
 /**
  * Check if the string can represent a valid device ID.
  *
@@ -46,28 +45,3 @@ module.exports.getDevice = ({ id, api, auth, displayName = null, dontThrow = fal
 			throw error;
 		});
 };
-
-/**
-* Waits for the device to reboot to reboot by checking if the device is ready to accept control requests.
-* It waits for a maximum of 60 seconds with a 1-second interval.
-*/
-module.exports.waitForDeviceToReboot = async (deviceId) => {
-	const REBOOT_TIME_MSEC = 60000;
-	const REBOOT_INTERVAL_MSEC = 1000;
-	const start = Date.now();
-	while (Date.now() - start < REBOOT_TIME_MSEC) {
-		try {
-			await _delay(REBOOT_INTERVAL_MSEC);
-			const device = await usbUtils.reopenDevice({ id: deviceId });
-			// Waiting for any control request to work to ensure the device is ready
-			await device.getDeviceId();
-			return device;
-		} catch (error) {
-			// ignore error
-		}
-	}
-};
-
-async function _delay(ms){
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}

--- a/src/cmd/device-util.js
+++ b/src/cmd/device-util.js
@@ -1,3 +1,4 @@
+const usbUtils = require('./usb-util');
 /**
  * Check if the string can represent a valid device ID.
  *
@@ -45,3 +46,28 @@ module.exports.getDevice = ({ id, api, auth, displayName = null, dontThrow = fal
 			throw error;
 		});
 };
+
+/**
+* Waits for the device to reboot to reboot by checking if the device is ready to accept control requests.
+* It waits for a maximum of 60 seconds with a 1-second interval.
+*/
+module.exports.waitForDeviceToReboot = async (deviceId) => {
+	const REBOOT_TIME_MSEC = 60000;
+	const REBOOT_INTERVAL_MSEC = 1000;
+	const start = Date.now();
+	while (Date.now() - start < REBOOT_TIME_MSEC) {
+		try {
+			await _delay(REBOOT_INTERVAL_MSEC);
+			const device = await usbUtils.reopenDevice({ id: deviceId });
+			// Waiting for any control request to work to ensure the device is ready
+			await device.getDeviceId();
+			return device;
+		} catch (error) {
+			// ignore error
+		}
+	}
+};
+
+async function _delay(ms){
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/cmd/device-util.js
+++ b/src/cmd/device-util.js
@@ -1,5 +1,3 @@
-const { getProtectionStatus, disableDeviceProtection, turnOffServiceMode } = require('../lib/device-protection-helper');
-
 /**
  * Check if the string can represent a valid device ID.
  *

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -487,10 +487,6 @@ async function openUsbDevices(args, { dfuMode = false } = {}){
 		});
 }
 
-async function _delay(ms){
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 async function handleUsbError(err){
 	if (err instanceof NotAllowedError) {
 		err = new UsbPermissionsError('Missing permissions to access the USB device');

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -12,8 +12,6 @@ const {
 	DeviceProtectionError
 } = require('particle-usb');
 const deviceProtectionHelper = require('../lib/device-protection-helper');
-const semver = require('semver');
-const chalk = require('chalk');
 
 // Timeout when reopening a USB device after an update via control requests. This timeout should be
 // long enough to allow the bootloader apply the update
@@ -78,7 +76,6 @@ class UsbPermissionsError extends Error {
 
 /**
  * Executes a function with a USB device, handling device protection and DFU mode.
- * Given limitations from Device-OS, we currently ask the user to exit DFU mode if the device is protected.
  *
  * @param {Object} options - The options for executing with the USB device.
  * @param {Object} options.args - The arguments to identify and configure the USB device.
@@ -120,7 +117,7 @@ async function executeWithUsbDevice({ args, func, dfuMode = false } = {}) {
 			device = await reopenInDfuMode(device);
 		}
 	}
-	
+
 	let res;
 	try {
 		res = await func(device);
@@ -150,7 +147,7 @@ async function _putDeviceInSafeMode(dev) {
 	} catch (error) {
 		// ignore errors
 	}
-	return usbUtils.reopenInNormalMode({ id: this.deviceId });
+	return reopenInNormalMode({ id: this.deviceId });
 }
 
 /**
@@ -438,7 +435,7 @@ async function forEachUsbDevice(args, func, { dfuMode = false } = {}){
 							args: { idOrName : usbDevice.id },
 							func,
 							dfuMode
-						})
+						});
 					})
 					.catch(e => lastError = e);
 			});

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -458,7 +458,7 @@ async function forEachUsbDevice(args, func, { dfuMode = false } = {}){
 						if (deviceIsProtected) {
 							// if device goes into DFU mode, we need to reopen it
 							usbDevice = await reopenDevice({ id : deviceId });
-							// XXX: Cannot turn off Service Mode with device-os < 6.1.3 if the device is in DFU mode
+							// XXX: Cannot turn off Service Mode with device-os < 6.1.3 (TBD) if the device is in DFU mode
 							if (usbDevice.isInDfuMode && semver.lt(firmwareVersion, '6.1.3')) {
 								outputMsg.push(`Your device may be in Service Mode. Re-enable Device Protection by running ${chalk.yellow('particle device-protection enable')}`);
 							} else {

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -404,6 +404,32 @@ async function openUsbDevices(args, { dfuMode = false } = {}){
 		});
 }
 
+
+/**
+* Waits for the device to reboot to reboot by checking if the device is ready to accept control requests.
+* It waits for a maximum of 60 seconds with a 1-second interval.
+*/
+async function waitForDeviceToReboot(deviceId) {
+	const REBOOT_TIME_MSEC = 60000;
+	const REBOOT_INTERVAL_MSEC = 1000;
+	const start = Date.now();
+	while (Date.now() - start < REBOOT_TIME_MSEC) {
+		try {
+			await _delay(REBOOT_INTERVAL_MSEC);
+			const device = await reopenDevice({ id: deviceId });
+			// Waiting for any control request to work to ensure the device is ready
+			await device.getDeviceId();
+			return device;
+		} catch (error) {
+			// ignore error
+		}
+	}
+}
+
+async function _delay(ms){
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function handleUsbError(err){
 	if (err instanceof NotAllowedError) {
 		err = new UsbPermissionsError('Missing permissions to access the USB device');
@@ -431,5 +457,6 @@ module.exports = {
 	TimeoutError,
 	DeviceProtectionError,
 	forEachUsbDevice,
-	openUsbDevices
+	openUsbDevices,
+	waitForDeviceToReboot
 };

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -442,9 +442,7 @@ async function forEachUsbDevice(args, func, { dfuMode = false } = {}){
 					.finally(async () => {
 						if (deviceIsProtected) {
 							// if device goes into DFU mode, we need to reopen it
-							if (!usbDevice.isOpen){
-								usbDevice = await reopenDevice({ id : deviceId });
-							}
+							usbDevice = await reopenDevice({ id : deviceId });
 							// XXX: This will fail with device-os < 6.1.3 if the device is in DFU mode
 							if (usbDevice.isInDfuMode && semver.lt(firmwareVersion, '6.1.3')) {
 								// FIXME: Use ui

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -487,28 +487,6 @@ async function openUsbDevices(args, { dfuMode = false } = {}){
 		});
 }
 
-
-/**
-* Waits for the device to reboot to reboot by checking if the device is ready to accept control requests.
-* It waits for a maximum of 60 seconds with a 1-second interval.
-*/
-async function waitForDeviceToReboot(deviceId) {
-	const REBOOT_TIME_MSEC = 60000;
-	const REBOOT_INTERVAL_MSEC = 1000;
-	const start = Date.now();
-	while (Date.now() - start < REBOOT_TIME_MSEC) {
-		try {
-			await _delay(REBOOT_INTERVAL_MSEC);
-			const device = await reopenDevice({ id: deviceId });
-			// Check device readiness
-			await device.getDeviceId();
-			return device;
-		} catch (error) {
-			// ignore error
-		}
-	}
-}
-
 async function _delay(ms){
 	return new Promise((resolve) => setTimeout(resolve, ms));
 }
@@ -541,6 +519,5 @@ module.exports = {
 	DeviceProtectionError,
 	forEachUsbDevice,
 	openUsbDevices,
-	waitForDeviceToReboot,
 	executeWithUsbDevice
 };

--- a/src/lib/device-protection-helper.js
+++ b/src/lib/device-protection-helper.js
@@ -1,0 +1,51 @@
+// This helper module is written mainly for the device protection module to not mess with the flash module directly
+// and vice versa. This acts as a bridge between the two modules.
+const settings = require('../../settings');
+const ParticleApi = require('../cmd/api');
+const createApiCache = require('../lib/api-cache');
+
+async function getProtectionStatus(device) {
+	const s = await device.getProtectionState();
+	return s;
+}
+
+async function disableDeviceProtection(device) {
+	const { api, auth } = _particleApi();
+	const deviceId = device.id;
+	let r = await api.unprotectDevice({ deviceId, action: 'prepare', auth });
+	const serverNonce = Buffer.from(r.server_nonce, 'base64');
+
+	const { deviceNonce, deviceSignature, devicePublicKeyFingerprint } = await device.unprotectDevice({ action: 'prepare', serverNonce });
+
+	r = await api.unprotectDevice({
+		deviceId,
+		action: 'confirm',
+		serverNonce: serverNonce.toString('base64'),
+		deviceNonce: deviceNonce.toString('base64'),
+		deviceSignature: deviceSignature.toString('base64'),
+		devicePublicKeyFingerprint: devicePublicKeyFingerprint.toString('base64'),
+		auth
+	});
+
+	const serverSignature = Buffer.from(r.server_signature, 'base64');
+	const serverPublicKeyFingerprint = Buffer.from(r.server_public_key_fingerprint, 'base64');
+
+	await device.unprotectDevice({ action: 'confirm', serverSignature, serverPublicKeyFingerprint });
+}
+
+async function turnOffServiceMode(device) {
+	await device.unprotectDevice({ action: 'reset' });
+}
+
+function _particleApi() {
+	const auth = settings.access_token;
+	const api = new ParticleApi(settings.apiUrl, { accessToken: auth } );
+	const apiCache = createApiCache(api);
+	return { api: apiCache, auth };
+}
+
+module.exports = {
+	getProtectionStatus,
+	disableDeviceProtection,
+	turnOffServiceMode
+};

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -11,6 +11,7 @@ const os = require('os');
 const semver = require('semver');
 const { DeviceProtectionError } = require('particle-usb');
 const utilities = require('./utilities');
+const { getProtectionStatus } = require('./device-protection-helper');
 const ensureError = utilities.ensureError;
 
 // Flashing an NCP firmware can take a few minutes
@@ -365,7 +366,7 @@ function validateDFUSupport({ device, ui }) {
 
 async function maintainDeviceProtection({ modules, device }) {
 	try {
-		const s = await device.getProtectionState();
+		const s = await getProtectionStatus(device);
 
 		if (!s.protected && !s.overridden) {
 			// Device is not protected -> Don't enforce Device OS version

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -401,6 +401,31 @@ async function maintainDeviceProtection({ modules, device }) {
 	}
 }
 
+/**
+* Waits for the device to reboot to reboot by checking if the device is ready to accept control requests.
+* It waits for a maximum of 60 seconds with a 1-second interval.
+*/
+async function waitForDeviceToReboot(deviceId) {
+	const REBOOT_TIME_MSEC = 60000;
+	const REBOOT_INTERVAL_MSEC = 1000;
+	const start = Date.now();
+	while (Date.now() - start < REBOOT_TIME_MSEC) {
+		try {
+			await _delay(REBOOT_INTERVAL_MSEC);
+			const device = await usbUtils.reopenDevice({ id: deviceId });
+			// Waiting for any control request to work to ensure the device is ready
+			await device.getDeviceId();
+			return device;
+		} catch (error) {
+			// ignore error
+		}
+	}
+}
+
+async function _delay(ms){
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 module.exports = {
 	flashFiles,
 	filterModulesToFlash,
@@ -411,5 +436,6 @@ module.exports = {
 	maintainDeviceProtection,
 	getFileFlashInfo,
 	_get256Hash,
-	_skipAsset
+	_skipAsset,
+	waitForDeviceToReboot
 };

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -401,31 +401,6 @@ async function maintainDeviceProtection({ modules, device }) {
 	}
 }
 
-/**
-* Waits for the device to reboot to reboot by checking if the device is ready to accept control requests.
-* It waits for a maximum of 60 seconds with a 1-second interval.
-*/
-async function waitForDeviceToReboot(deviceId) {
-	const REBOOT_TIME_MSEC = 60000;
-	const REBOOT_INTERVAL_MSEC = 1000;
-	const start = Date.now();
-	while (Date.now() - start < REBOOT_TIME_MSEC) {
-		try {
-			await _delay(REBOOT_INTERVAL_MSEC);
-			const device = await usbUtils.reopenDevice({ id: deviceId });
-			// Waiting for any control request to work to ensure the device is ready
-			await device.getDeviceId();
-			return device;
-		} catch (error) {
-			// ignore error
-		}
-	}
-}
-
-async function _delay(ms){
-	return new Promise((resolve) => setTimeout(resolve, ms));
-}
-
 module.exports = {
 	flashFiles,
 	filterModulesToFlash,
@@ -436,6 +411,5 @@ module.exports = {
 	maintainDeviceProtection,
 	getFileFlashInfo,
 	_get256Hash,
-	_skipAsset,
-	waitForDeviceToReboot
+	_skipAsset
 };

--- a/test/README.md
+++ b/test/README.md
@@ -105,7 +105,8 @@ The e2e tests run in two modes: with a device connected, and without. Since the 
 ### Running device protection tests
 
 1. Ensure the device `E2E_PRODUCT_01_DEVICE_01_ID` in product `E2E_PRODUCT_01_ID` is an Open Device in a product with device protection active at the start of the tests.
-2. run `npm run test:e2e:device-protection`
+2. Ensure the device is not in DFU mode.
+3. run `npm run test:e2e:device-protection`
 
 ## Adding Tests
 


### PR DESCRIPTION
This is the base PR.

This PR adds a helper module `device-protection-helper.js` that can be used by multiple modules and prevent circular dependency issues. It also adds a new method that checks if a device is ready for use (ie rebooted after a certain reset operation was done)

## How to Test

See this [test plan](https://www.notion.so/particle/Test-Plan-for-CLI-commands-Protected-Open-23954df3eff94cad9b3002722f926fa9)

## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

