### PR TITLE
bug/sc-129396/particle-login-sso-is-partially-borken-on

### DIFF
--- a/src/lib/openurl.js
+++ b/src/lib/openurl.js
@@ -1,18 +1,23 @@
 // Copy of https://github.com/rauschma/openurl with additional error handling
 const spawn = require('child_process').spawn;
+const path = require('path');
 
 let command;
 
 switch (process.platform) {
-	case 'darwin':
+	case 'darwin':{
 		command = 'open';
 		break;
-	case 'win32':
-		command = 'explorer.exe';
+	}
+	case 'win32':{
+		const binPath = `${process.env.SYSTEMROOT || process.env.windir || 'C:\\Windows'}`;
+		command = path.join(binPath, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell');
 		break;
-	case 'linux':
+	}
+	case 'linux': {
 		command = 'xdg-open';
 		break;
+	}
 	default:
 		throw new Error('Unsupported platform: ' + process.platform);
 }
@@ -25,7 +30,8 @@ switch (process.platform) {
  */
 
 function open(url, callback) {
-	const child = spawn(command, [url]);
+	const args = process.platform === 'win32' ? ['Start', url] : [url];
+	const child = spawn(command, args);
 	child.on('error', (error) => {
 		callback(error);
 	});


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
This PR adds a fix for `login --sso` when using `windows` platform
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
On windows platform: 
1. Run login --sso:`npm start -- login --sso`

**outcome**
The Web explorer should open with sso token 
<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/129396
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

