### PR TITLE
Show Device Protection checks transparently when working with CLI commands

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -27,7 +27,7 @@
         "particle-api-js": "^10.5.1",
         "particle-commands": "^1.0.1",
         "particle-library-manager": "^0.1.15",
-        "particle-usb": "^3.4.0",
+        "particle-usb": "^3.5.0",
         "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
         "safe-buffer": "^5.2.0",
         "semver": "^7.5.2",
@@ -6376,9 +6376,9 @@
       }
     },
     "node_modules/particle-usb": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.4.0.tgz",
-      "integrity": "sha512-5yDR8LssjnfwT2a5OCcsogQe3VjDz2ZzC0KjXt9raqXRSWuySoWt6SRR5g06jT1WiNAll3VUhIV/8SuTL1RyAA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.5.0.tgz",
+      "integrity": "sha512-G/CO7YrRRXq9cwMk+teohoiPEHTCwf37xEjcyMYRTn4aSvkEM7s6DW+6wat2PvptoIFA4IuEZvljl6iyVuKfNQ==",
       "dependencies": {
         "@particle/device-os-protobuf": "^2.6.1",
         "ip-address": "^9.0.5",
@@ -14266,9 +14266,9 @@
       }
     },
     "particle-usb": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.4.0.tgz",
-      "integrity": "sha512-5yDR8LssjnfwT2a5OCcsogQe3VjDz2ZzC0KjXt9raqXRSWuySoWt6SRR5g06jT1WiNAll3VUhIV/8SuTL1RyAA==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.5.0.tgz",
+      "integrity": "sha512-G/CO7YrRRXq9cwMk+teohoiPEHTCwf37xEjcyMYRTn4aSvkEM7s6DW+6wat2PvptoIFA4IuEZvljl6iyVuKfNQ==",
       "requires": {
         "@particle/device-os-protobuf": "^2.6.1",
         "ip-address": "^9.0.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -27,7 +27,7 @@
         "particle-api-js": "^10.5.1",
         "particle-commands": "^1.0.1",
         "particle-library-manager": "^0.1.15",
-        "particle-usb": "^3.5.0",
+        "particle-usb": "^3.6.0",
         "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
         "safe-buffer": "^5.2.0",
         "semver": "^7.5.2",
@@ -6376,9 +6376,9 @@
       }
     },
     "node_modules/particle-usb": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.5.0.tgz",
-      "integrity": "sha512-G/CO7YrRRXq9cwMk+teohoiPEHTCwf37xEjcyMYRTn4aSvkEM7s6DW+6wat2PvptoIFA4IuEZvljl6iyVuKfNQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.6.0.tgz",
+      "integrity": "sha512-HmrYN5ZivHx8uEtaGr/VcvlgF8suXVO+wAtTz4m9VESDJQ3cjms+LhqY52TMgn3uVKdaD9clBzBRnUp4+IaTiw==",
       "dependencies": {
         "@particle/device-os-protobuf": "^2.6.1",
         "ip-address": "^9.0.5",
@@ -14266,9 +14266,9 @@
       }
     },
     "particle-usb": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.5.0.tgz",
-      "integrity": "sha512-G/CO7YrRRXq9cwMk+teohoiPEHTCwf37xEjcyMYRTn4aSvkEM7s6DW+6wat2PvptoIFA4IuEZvljl6iyVuKfNQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/particle-usb/-/particle-usb-3.6.0.tgz",
+      "integrity": "sha512-HmrYN5ZivHx8uEtaGr/VcvlgF8suXVO+wAtTz4m9VESDJQ3cjms+LhqY52TMgn3uVKdaD9clBzBRnUp4+IaTiw==",
       "requires": {
         "@particle/device-os-protobuf": "^2.6.1",
         "ip-address": "^9.0.5",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "particle-api-js": "^10.5.1",
     "particle-commands": "^1.0.1",
     "particle-library-manager": "^0.1.15",
-    "particle-usb": "^3.4.0",
+    "particle-usb": "^3.5.0",
     "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
     "safe-buffer": "^5.2.0",
     "semver": "^7.5.2",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "particle-api-js": "^10.5.1",
     "particle-commands": "^1.0.1",
     "particle-library-manager": "^0.1.15",
-    "particle-usb": "^3.5.0",
+    "particle-usb": "^3.6.0",
     "request": "https://github.com/particle-iot/request/releases/download/v2.75.1-relativepath.1/request-2.75.1-relativepath.1.tgz",
     "safe-buffer": "^5.2.0",
     "semver": "^7.5.2",

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -55,7 +55,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 					res = 'Protected Device';
 					helper = `Run ${chalk.yellow('particle device-protection disable')} to put the device in Service Mode.`;
 				} else {
-					res = 'Open device';
+					res = 'Open Device';
 					helper = `Run ${chalk.yellow('particle device-protection enable')} to protect the device.`;
 				}
 
@@ -65,7 +65,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 		} catch (error) {
 			// TODO: Log detailed and user-friendly error messages from the device or API instead of displaying the raw error message
 			if (error.message === 'Not supported') {
-				throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
+				throw new Error(`Device Protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
 			}
 			throw new Error(`Unable to get device status: ${error.message}${os.EOL}`);
 		} finally {
@@ -108,7 +108,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 				addToOutput.push(`${deviceStr} is now in Service Mode.${os.EOL}A Protected Device stays in Service Mode for a total of 20 reboots or 24 hours.${os.EOL}`);
 			} catch (error) {
 				if (error.message === 'Not supported') {
-					throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
+					throw new Error(`Device Protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
 				}
 				throw new Error(`Failed to disable device protection: ${error.message}${os.EOL}`);
 			}
@@ -187,7 +187,7 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 				}
 			} catch (error) {
 				if (error.message === 'Not supported') {
-					throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
+					throw new Error(`Device Protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
 				}
 				throw new Error(`Failed to enable device protection: ${error.message}${os.EOL}`);
 			}

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -11,9 +11,7 @@ const { downloadDeviceOsVersionBinaries } = require('../lib/device-os-version-ut
 const FlashCommand = require('./flash');
 const { platformForId } = require('../lib/platform');
 const BinaryCommand = require('./binary');
-
-const REBOOT_TIME_MSEC = 60000;
-const REBOOT_INTERVAL_MSEC = 1000;
+const DeviceProtectionHelper = require('../lib/device-protection-helper');
 
 module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	constructor({ ui } = {}) {
@@ -25,29 +23,31 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 		this.device = null;
 		this.ui = ui || this.ui;
 		this.productId = null;
+		this.status = {
+			protected: null,
+			overridden: null
+		};
 	}
 
 	/**
 	 * Retrieves and displays the protection status of the device.
 	 *
-	 * This method assumes the device is in normal mode and not in DFU mode. It retrieves the current protection status and
-	 * constructs a message indicating whether the device is Protected, in Service Mode, or Open
-	 * The device protection status is then displayed in the console.
+	 * It retrieves the current protection status and constructs a message
+	 * indicating whether the device is Protected, in Service Mode, or Open.
 	 *
 	 * @async
 	 * @returns {Promise<Object>} The protection state of the device.
 	 * @throws {Error} Throws an error if any of the async operations fail.
 	 */
 	async getStatus() {
-
 		let addToOutput = [];
 		let s;
 		try {
-			await this._withDevice({ spinner: 'Getting device status', putDeviceBackInDfuMode: true }, async () => {
-				s = await this._getDeviceProtection();
+			await this._withDevice({ spinner: 'Getting device status' }, async () => {
 				let res;
 				let helper;
 
+				s = this.status;
 				if (s.overridden) {
 					res = 'Protected Device (Service Mode)';
 					helper = `Run ${chalk.yellow('particle device-protection enable')} to take the device out of Service Mode.`;
@@ -64,13 +64,15 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 			});
 		} catch (error) {
 			// TODO: Log detailed and user-friendly error messages from the device or API instead of displaying the raw error message
+			if (error.message === 'Not supported') {
+				throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
+			}
 			throw new Error(`Unable to get device status: ${error.message}${os.EOL}`);
+		} finally {
+			addToOutput.forEach((line) => {
+				this.ui.stdout.write(line);
+			});
 		}
-
-		addToOutput.forEach((line) => {
-			this.ui.stdout.write(line);
-		});
-
 		return s;
 	}
 
@@ -88,38 +90,26 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	async disableProtection() {
 		let addToOutput = [];
 
-		await this._withDevice({ spinner: 'Disabling device protection', putDeviceBackInDfuMode: true }, async () => {
+		await this._withDevice({ spinner: 'Disabling device protection' }, async () => {
 			try {
 				const deviceStr = await this._getDeviceString();
-				let s = await this._getDeviceProtection();
 
+				const s = this.status;
 				if (!s.protected && !s.overridden) {
 					addToOutput.push(`${deviceStr} is not a Protected Device.${os.EOL}`);
 					return;
 				}
 
-				let r = await this.api.unprotectDevice({ deviceId: this.deviceId, action: 'prepare', auth: settings.access_token });
-				const serverNonce = Buffer.from(r.server_nonce, 'base64');
-
-				const { deviceNonce, deviceSignature, devicePublicKeyFingerprint } = await this.device.unprotectDevice({ action: 'prepare', serverNonce });
-
-				r = await this.api.unprotectDevice({
-					deviceId: this.deviceId,
-					action: 'confirm',
-					serverNonce: serverNonce.toString('base64'),
-					deviceNonce: deviceNonce.toString('base64'),
-					deviceSignature: deviceSignature.toString('base64'),
-					devicePublicKeyFingerprint: devicePublicKeyFingerprint.toString('base64'),
-					auth: settings.access_token
-				});
-
-				const serverSignature = Buffer.from(r.server_signature, 'base64');
-				const serverPublicKeyFingerprint = Buffer.from(r.server_public_key_fingerprint, 'base64');
-
-				await this.device.unprotectDevice({ action: 'confirm', serverSignature, serverPublicKeyFingerprint });
+				if (this.device.isInDfuMode) {
+					await this._putDeviceInSafeMode();
+				}
+				await DeviceProtectionHelper.disableDeviceProtection(this.device);
 
 				addToOutput.push(`${deviceStr} is now in Service Mode.${os.EOL}A Protected Device stays in Service Mode for a total of 20 reboots or 24 hours.${os.EOL}`);
 			} catch (error) {
+				if (error.message === 'Not supported') {
+					throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
+				}
 				throw new Error(`Failed to disable device protection: ${error.message}${os.EOL}`);
 			}
 		});
@@ -145,22 +135,29 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	 */
 	async enableProtection({ file } = {}) {
 		let addToOutput = [];
-		try {
-			await this._withDevice({ spinner: 'Enabling device protection', putDeviceBackInDfuMode: false }, async () => {
+		await this._withDevice({ spinner: 'Enabling device protection' }, async () => {
+			try {
 				const deviceStr = await this._getDeviceString();
-				const s = await this._getDeviceProtection();
 
+				const s = this.status;
+				// Protected (Service Mode) Device
 				if (s.overridden) {
-					await this.device.unprotectDevice({ action: 'reset' });
+					await DeviceProtectionHelper.turnOffServiceMode(this.device);
 					addToOutput.push(`${deviceStr} is now a Protected Device.${os.EOL}`);
 					return;
 				}
 
+				// Protected Device
 				if (s.protected) {
 					addToOutput.push(`${deviceStr} is already a Protected Device.${os.EOL}`);
 					return;
 				}
 
+				if (this.device.isInDfuMode) {
+					await this._putDeviceInSafeMode();
+				}
+
+				// Open Device
 				let localBootloaderPath = file;
 				// bypass checking the product and clearing development mode when the bootloader is provided to allow for enabling device protection offline
 				const onlineMode = !file;
@@ -188,10 +185,13 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 						);
 					}
 				}
-			});
-		} catch (error) {
-			throw new Error(`Failed to enable device protection: ${error.message}${os.EOL}`);
-		}
+			} catch (error) {
+				if (error.message === 'Not supported') {
+					throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
+				}
+				throw new Error(`Failed to enable device protection: ${error.message}${os.EOL}`);
+			}
+		});
 
 		addToOutput.forEach((line) => {
 			this.ui.stdout.write(line);
@@ -201,25 +201,6 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	async _getProtectedBinary({ file, verbose=true }) {
 		const res = await new BinaryCommand().createProtectedBinary({ file, verbose });
 		return res;
-	}
-
-	/**
-	 * Retrieves the current protection state of the device.
-	 *
-	 * @async
-	 * @returns {Promise<Object>} The protection state of the device.
-	 * @throws {Error} Throws an error if the device protection feature is not supported.
-	 */
-	async _getDeviceProtection() {
-		try {
-			const s = await this.device.getProtectionState();
-			return s;
-		} catch (error) {
-			if (error.message === 'Not supported') {
-				throw new Error(`Device protection feature is not supported on this device. Visit ${chalk.yellow('https://docs.particle.io')} for more information${os.EOL}`);
-			}
-			throw new Error(error);
-		}
 	}
 
 	/**
@@ -315,35 +296,23 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	}
 
 	/**
-	 * Executes a function with the device, ensuring it is in the correct mode.
-	 * If it is in DFU mode, the device is reset and re-opened expecting it to be in normal mode.
+	 * Executes a function with the device (Open / Protected / Protected (Service Mode)), ensuring it is in the correct mode.
+	 * Checks the protection status of the device which is needed for all the commands
 	 *
 	 * @async
 	 * @param {Object} options
-	 * @param {boolean} options.putDeviceBackInDfuMode - Checks if device should be put back into dfy mode if the device was in dfu mode at the start of the operation
 	 * @param {Function} options.spinner - The text to display in a spinner until the operation completes
 	 * @param {Function} fn - The function to execute with the device.
 	 * @returns {Promise<*>} The result of the function execution.
 	 */
-	async _withDevice({ putDeviceBackInDfuMode, spinner }, fn) {
-		try {
-			await this._getUsbDevice(this.device);
-			return await this.ui.showBusySpinnerUntilResolved(spinner, (async () => {
-				const deviceWasInDfuMode = this.device.isInDfuMode;
-				if (deviceWasInDfuMode) {
-					await this._putDeviceInSafeMode();
-				}
-				putDeviceBackInDfuMode = putDeviceBackInDfuMode && deviceWasInDfuMode;
-				return await fn();
-			})());
-		} finally {
-			if (putDeviceBackInDfuMode) {
-				await this._waitForDeviceToReboot();
-				await this.device.enterDfuMode();
-			}
-			if (this.device && this.device.isOpen) {
-				await this.device.close();
-			}
+	async _withDevice({ spinner }, fn) {
+		await this._getUsbDevice(this.device);
+		await this.ui.showBusySpinnerUntilResolved(spinner, (async () => {
+			this.status = await DeviceProtectionHelper.getProtectionStatus(this.device);
+			return await fn();
+		})());
+		if (this.device && this.device.isOpen) {
+			await this.device.close();
 		}
 	}
 
@@ -373,42 +342,19 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	}
 
 	/**
-	 * Waits for the device to reboot.
-	 * This method waits for the device to reboot by checking if the device is ready to accept control requests.
-	 * It waits for a maximum of 60 seconds with a 1-second interval.
-	 */
-	async _waitForDeviceToReboot() {
-		const start = Date.now();
-		while (Date.now() - start < REBOOT_TIME_MSEC) {
-			try {
-				await this._delay(REBOOT_INTERVAL_MSEC);
-				this.device = await usbUtils.reopenDevice({ id: this.deviceId });
-				// Waiting for any control request to work to ensure the device is ready
-				await this.device.getProtectionState();
-				break;
-			} catch (error) {
-				// ignore error
-			}
-		}
-	}
-
-	async _delay(ms){
-		return new Promise((resolve) => setTimeout(resolve, ms));
-	}
-
-	/**
-	 * Resets the device and waits for it to restart.
+	 * Attempts to enter Safe Mode to enable operations on Protected Devices in DFU mode.
 	 *
 	 * @async
 	 * @param {Object} device - The device to reset.
 	 * @returns {Promise<void>}
 	 */
 	async _putDeviceInSafeMode() {
-		if (this.device.isInDfuMode) {
+		try {
 			await this.device.enterSafeMode();
-			await this.device.close();
+		} catch (error) {
+			// ignore errors
 		}
-		this.device = await usbUtils.reopenInNormalMode( { id: this.deviceId });
+		this.device = await usbUtils.reopenInNormalMode({ id: this.deviceId });
 	}
 
 	/**

--- a/src/cmd/device-protection.test.js
+++ b/src/cmd/device-protection.test.js
@@ -1,5 +1,6 @@
 const DeviceProtectionCommands = require('./device-protection');
 const { expect, sinon } = require('../../test/setup');
+const deviceProtectionHelper = require('../lib/device-protection-helper');
 
 describe('DeviceProtectionCommands', () => {
 	let deviceProtectionCommands;
@@ -24,19 +25,19 @@ describe('DeviceProtectionCommands', () => {
 				protected: true,
 				overridden: false
 			};
-
-			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').resolves(expectedStatus);
+			deviceProtectionCommands.status = expectedStatus;
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves(expectedStatus);
 			sinon.stub(deviceProtectionCommands, '_getDeviceString').resolves('[123456789abcdef] (Product 12345)');
 
 			const result = await deviceProtectionCommands.getStatus();
 
-			expect(deviceProtectionCommands._getDeviceProtection).to.have.been.calledOnce;
+			expect(deviceProtectionHelper.getProtectionStatus).to.have.been.calledOnce;
 			expect(deviceProtectionCommands._getDeviceString).to.have.been.calledOnce;
 			expect(result).to.eql(expectedStatus);
 		});
 
 		it('throws an error while getting the protection status of the device', async () => {
-			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').rejects(new Error('random error'));
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').rejects(new Error('random error'));
 
 			let error;
 			try {
@@ -52,42 +53,30 @@ describe('DeviceProtectionCommands', () => {
 
 	describe('disableProtection', () => {
 		it('should disable protection on the device', async () => {
-			sinon.stub(deviceProtectionCommands, '_getDeviceProtection')
-				.onFirstCall().resolves({ protected: true, overridden: false })
-				.onSecondCall().resolves({ protected: true, overridden: false });
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: true, overridden: false });
 			sinon.stub(deviceProtectionCommands, '_getDeviceString').resolves('[123456789abcdef] (Product 12345)');
-			deviceProtectionCommands.device = {
-				unprotectDevice: sinon.stub().resolves({ protected: true, deviceNonce: '11111', deviceSignature: '22222', devicePublicKeyFingerprint: '33333' })
-			};
-			deviceProtectionCommands.api = {
-				unprotectDevice: sinon.stub().resolves({ server_nonce: '44444', server_signature: '55555', server_public_key_fingerprint: '66666' })
-			};
+			sinon.stub(deviceProtectionHelper, 'disableDeviceProtection').resolves();
 
 
 			await deviceProtectionCommands.disableProtection();
 
-			expect(deviceProtectionCommands._getDeviceProtection).to.have.been.calledOnce;
-			expect(deviceProtectionCommands.device.unprotectDevice).to.have.been.calledTwice;
-			expect(deviceProtectionCommands.api.unprotectDevice).to.have.been.calledTwice;
+			expect(deviceProtectionHelper.getProtectionStatus).to.have.been.calledOnce;
+			expect(deviceProtectionHelper.disableDeviceProtection).to.have.been.calledOnce;
 		});
 
 		it('handles already Open Devices', async () => {
-			sinon.stub(deviceProtectionCommands, '_getDeviceProtection')
-				.onFirstCall().resolves({ protected: false, overridden: false });
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: false, overridden: false });
 			sinon.stub(deviceProtectionCommands, '_getDeviceString').resolves('[123456789abcdef] (Product 12345)');
 
 			await deviceProtectionCommands.disableProtection();
 
-			expect(deviceProtectionCommands._getDeviceProtection).to.have.been.calledOnce;
+			expect(deviceProtectionHelper.getProtectionStatus).to.have.been.calledOnce;
 		});
 	});
 
 	describe('enableProtection', () => {
-		it('should enable protection on the device', async () => {
-			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').resolves({
-				protected: false,
-				overridden: false
-			});
+		it('turns an Open Device into Protected Device', async () => {
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: false, overridden: false });
 			sinon.stub(deviceProtectionCommands, '_getDeviceString').resolves('[123456789abcdef] (Product 12345)');
 			sinon.stub(deviceProtectionCommands, '_isDeviceProtectionActiveInProduct').resolves(true);
 			sinon.stub(deviceProtectionCommands,'_getProtectedBinary').resolves('/path/to/bootloader-protected.bin');
@@ -106,39 +95,32 @@ describe('DeviceProtectionCommands', () => {
 
 
 		it('handles already Protected Devices', async () => {
-			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').resolves({
-				protected: true,
-				overridden: false
-			});
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: true, overridden: false });
 			sinon.stub(deviceProtectionCommands, '_getDeviceString').resolves('[123456789abcdef] (Product 12345)');
 			sinon.stub(deviceProtectionCommands, '_isDeviceProtectionActiveInProduct').resolves();
 
 			await deviceProtectionCommands.enableProtection();
 
-			expect(deviceProtectionCommands._getDeviceProtection).to.have.been.calledOnce;
+			expect(deviceProtectionHelper.getProtectionStatus).to.have.been.calledOnce;
 			expect(deviceProtectionCommands._isDeviceProtectionActiveInProduct).to.not.have.been.called;
 		});
 
 		it('protects a Service Mode device', async () => {
-			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').resolves({
-				protected: true,
-				overridden: true
-			});
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: true, overridden: true });
 			sinon.stub(deviceProtectionCommands, '_getDeviceString').resolves('[123456789abcdef] (Product 12345)');
 			sinon.stub(deviceProtectionCommands, '_isDeviceProtectionActiveInProduct').resolves(true);
 			sinon.stub(deviceProtectionCommands, '_markAsDevelopmentDevice').resolves(true);
+			sinon.stub(deviceProtectionHelper, 'turnOffServiceMode').resolves();
 
 			await deviceProtectionCommands.enableProtection();
 
-			expect(deviceProtectionCommands._getDeviceProtection).to.have.been.calledOnce;
+			expect(deviceProtectionHelper.getProtectionStatus).to.have.been.calledOnce;
 			expect(deviceProtectionCommands._isDeviceProtectionActiveInProduct).to.not.have.been.called;
+			expect(deviceProtectionHelper.turnOffServiceMode).to.have.been.calledOnce;
 		});
 
 		it('does not protect an Open Device if it is not in a product', async () => {
-			sinon.stub(deviceProtectionCommands, '_getDeviceProtection').resolves({
-				protected: false,
-				overridden: false
-			});
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: false, overridden: false });
 			sinon.stub(deviceProtectionCommands, '_getDeviceString').resolves('[123456789abcdef] (Product 12345)');
 			sinon.stub(deviceProtectionCommands, '_isDeviceProtectionActiveInProduct').resolves(false);
 			sinon.stub(deviceProtectionCommands, '_markAsDevelopmentDevice').resolves(true);
@@ -146,59 +128,10 @@ describe('DeviceProtectionCommands', () => {
 
 			await deviceProtectionCommands.enableProtection();
 
-			expect(deviceProtectionCommands._getDeviceProtection).to.have.been.calledOnce;
+			expect(deviceProtectionHelper.getProtectionStatus).to.have.been.calledOnce;
 			expect(deviceProtectionCommands._isDeviceProtectionActiveInProduct).to.have.been.calledOnce;
 			expect(deviceProtectionCommands._markAsDevelopmentDevice).to.not.have.been.called;
 			expect(deviceProtectionCommands._flashBootloader).to.not.have.been.called;
-		});
-	});
-
-	describe('_getDeviceProtection', () => {
-		it('should retrieve the current protection state of the device', async () => {
-			const expectedState = {
-				protected: true,
-				overridden: false
-			};
-			deviceProtectionCommands.device = {
-				getProtectionState: sinon.stub().resolves(expectedState)
-			};
-
-			const result = await deviceProtectionCommands._getDeviceProtection();
-
-			expect(deviceProtectionCommands.device.getProtectionState).to.have.been.calledOnce;
-			expect(result).eql(expectedState);
-		});
-
-		it('should throw an error if the device protection feature is not supported', async () => {
-			deviceProtectionCommands.device = {
-				getProtectionState: sinon.stub().rejects(new Error('Not supported'))
-			};
-
-			let error;
-			try {
-				await deviceProtectionCommands._getDeviceProtection();
-			} catch (_e) {
-				error = _e;
-			}
-
-			expect(error).to.be.an.instanceOf(Error);
-			expect(error.message).to.include('Device protection feature is not supported on this device');
-		});
-
-		it('throws a random error', async () => {
-			deviceProtectionCommands.device = {
-				getProtectionState: sinon.stub().rejects(new Error('random error'))
-			};
-
-			let error;
-			try {
-				await deviceProtectionCommands._getDeviceProtection();
-			} catch (_e) {
-				error = _e;
-			}
-
-			expect(error).to.be.an.instanceOf(Error);
-			expect(error.message).to.include('random error');
 		});
 	});
 
@@ -370,6 +303,7 @@ describe('DeviceProtectionCommands', () => {
 	describe('_withDevice', () => {
 		it('should execute a function with the device in normal (non-dfu) mode', async () => {
 			const fn = sinon.stub().resolves();
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({});
 
 			await deviceProtectionCommands._withDevice({ putDeviceBackInDfuMode: true }, fn);
 
@@ -377,22 +311,32 @@ describe('DeviceProtectionCommands', () => {
 			expect(fn).to.have.been.calledOnce;
 		});
 
-		it('should execute a function with the device in dfu mode', async () => {
+		it('should execute a function with the Protected Device in dfu mode', async () => {
 			const fn = sinon.stub().resolves();
 			deviceProtectionCommands.device.isInDfuMode = true;
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: true });
 			sinon.stub(deviceProtectionCommands, '_putDeviceInSafeMode').resolves();
-			sinon.stub(deviceProtectionCommands, '_waitForDeviceToReboot').resolves();
 
 			await deviceProtectionCommands._withDevice({ putDeviceBackInDfuMode: true }, fn);
 
-			expect(deviceProtectionCommands._putDeviceInSafeMode).to.have.been.calledOnce;
-			expect(deviceProtectionCommands._waitForDeviceToReboot).to.have.been.calledOnce;
+			expect(deviceProtectionCommands._putDeviceInSafeMode).to.not.have.been.calledOnce;
+			expect(fn).to.have.been.calledOnce;
+		});
+
+		it('should execute a function with the Protected Device (SM) in dfu mode', async () => {
+			const fn = sinon.stub().resolves();
+			deviceProtectionCommands.device.isInDfuMode = true;
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: false });
+
+			await deviceProtectionCommands._withDevice({ putDeviceBackInDfuMode: true }, fn);
+
 			expect(fn).to.have.been.calledOnce;
 		});
 
 		it('shows the spinner', async () => {
 			const promise = Promise.resolve(1234);
 			const fn = sinon.stub().returns(promise);
+			sinon.stub(deviceProtectionHelper, 'getProtectionStatus').resolves({ protected: true });
 			sinon.stub(deviceProtectionCommands.ui, 'showBusySpinnerUntilResolved').resolves();
 
 			await deviceProtectionCommands._withDevice({ spinner: 'Long operation' }, fn);

--- a/src/cmd/device-util.js
+++ b/src/cmd/device-util.js
@@ -45,4 +45,3 @@ module.exports.getDevice = ({ id, api, auth, displayName = null, dontThrow = fal
 			throw error;
 		});
 };
-

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -97,7 +97,7 @@ class UsbPermissionsError extends Error {
 async function executeWithUsbDevice({ args, func, dfuMode = false } = {}) {
 	let device = await getOneUsbDevice(args, { dfuMode });
 	let deviceIsProtected = false;
-	
+
 	const platform = platformForId(device.platformId);
 	if (platform.generation > 2) { // Skipping device protection check for Gen2 platforms
 		try {

--- a/src/lib/device-protection-helper.js
+++ b/src/lib/device-protection-helper.js
@@ -1,0 +1,51 @@
+// This helper module is written mainly for the device protection module to not mess with the flash module directly
+// and vice versa. This acts as a bridge between the two modules.
+const settings = require('../../settings');
+const ParticleApi = require('../cmd/api');
+const createApiCache = require('../lib/api-cache');
+
+async function getProtectionStatus(device) {
+	const s = await device.getProtectionState();
+	return s;
+}
+
+async function disableDeviceProtection(device) {
+	const { api, auth } = _particleApi();
+	const deviceId = device.id;
+	let r = await api.unprotectDevice({ deviceId, action: 'prepare', auth });
+	const serverNonce = Buffer.from(r.server_nonce, 'base64');
+
+	const { deviceNonce, deviceSignature, devicePublicKeyFingerprint } = await device.unprotectDevice({ action: 'prepare', serverNonce });
+
+	r = await api.unprotectDevice({
+		deviceId,
+		action: 'confirm',
+		serverNonce: serverNonce.toString('base64'),
+		deviceNonce: deviceNonce.toString('base64'),
+		deviceSignature: deviceSignature.toString('base64'),
+		devicePublicKeyFingerprint: devicePublicKeyFingerprint.toString('base64'),
+		auth
+	});
+
+	const serverSignature = Buffer.from(r.server_signature, 'base64');
+	const serverPublicKeyFingerprint = Buffer.from(r.server_public_key_fingerprint, 'base64');
+
+	await device.unprotectDevice({ action: 'confirm', serverSignature, serverPublicKeyFingerprint });
+}
+
+async function turnOffServiceMode(device) {
+	await device.unprotectDevice({ action: 'reset' });
+}
+
+function _particleApi() {
+	const auth = settings.access_token;
+	const api = new ParticleApi(settings.apiUrl, { accessToken: auth } );
+	const apiCache = createApiCache(api);
+	return { api: apiCache, auth };
+}
+
+module.exports = {
+	getProtectionStatus,
+	disableDeviceProtection,
+	turnOffServiceMode
+};

--- a/src/lib/flash-helper.js
+++ b/src/lib/flash-helper.js
@@ -11,6 +11,7 @@ const os = require('os');
 const semver = require('semver');
 const { DeviceProtectionError } = require('particle-usb');
 const utilities = require('./utilities');
+const { getProtectionStatus } = require('./device-protection-helper');
 const ensureError = utilities.ensureError;
 
 // Flashing an NCP firmware can take a few minutes
@@ -365,7 +366,7 @@ function validateDFUSupport({ device, ui }) {
 
 async function maintainDeviceProtection({ modules, device }) {
 	try {
-		const s = await device.getProtectionState();
+		const s = await getProtectionStatus(device);
 
 		if (!s.protected && !s.overridden) {
 			// Device is not protected -> Don't enforce Device OS version

--- a/test/README.md
+++ b/test/README.md
@@ -105,7 +105,8 @@ The e2e tests run in two modes: with a device connected, and without. Since the 
 ### Running device protection tests
 
 1. Ensure the device `E2E_PRODUCT_01_DEVICE_01_ID` in product `E2E_PRODUCT_01_ID` is an Open Device in a product with device protection active at the start of the tests.
-2. run `npm run test:e2e:device-protection`
+2. Ensure the device is not in DFU mode.
+3. run `npm run test:e2e:device-protection`
 
 ## Adding Tests
 

--- a/test/e2e/usb-protected.e2e.js
+++ b/test/e2e/usb-protected.e2e.js
@@ -9,8 +9,7 @@ const {
 } = require('../lib/env');
 const stripAnsi = require('strip-ansi');
 
-
-describe.only('USB Commands [@device]', function cliUSBCommands(){
+describe('USB Commands for Protected Devices [@device]', function cliUSBCommands(){
 	this.timeout(5 * 60 * 1000);
 
 	const help = [
@@ -41,6 +40,7 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 	});
 
 	after(async () => {
+		await cli.setTestProfileAndLogin();
 		await cli.run(['usb', 'setup-done']);
 		await cli.waitUntilOnline();
 		await cli.logout();
@@ -75,6 +75,10 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 		const platform = capitalize(DEVICE_PLATFORM_NAME);
 		let args;
 
+		before(async () => {
+			await cli.setTestProfileAndLogin();
+		});
+
 		beforeEach(async () => {
 			args = ['usb', 'list'];
 			await cli.setTestProfileAndLogin();
@@ -87,7 +91,7 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 		it('Lists connected devices', async () => {
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
-			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, PROTECTED)`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});
@@ -105,7 +109,7 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 			args.push(DEVICE_PLATFORM_NAME);
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
-			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, PROTECTED)`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});
@@ -129,7 +133,7 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 			args.push(DEVICE_NAME);
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
-			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, PROTECTED)`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});
@@ -147,7 +151,7 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 			args.push(DEVICE_ID);
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
-			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, PROTECTED)`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});
@@ -166,7 +170,7 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 			args.push('online');
 			const { stdout, stderr, exitCode } = await cli.run(args);
 
-			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform})`);
+			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, PROTECTED)`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 		});
@@ -213,63 +217,105 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 	});
 
 	describe('USB Start-Listening Subcommand', () => {
+		before(async () => {
+			await cli.setTestProfileAndLogin();
+			await cli.waitUntilOnline();
+		});
+
+		beforeEach(async () => {
+			await cli.setTestProfileAndLogin();
+		});
+
 		afterEach(async () => {
 			await cli.run(['usb', 'stop-listening']);
-			await cli.waitUntilOnline();
+			await cli.run(['device-protection', 'enable']);
 		});
 
 		it('Starts listening', async () => {
 			await cli.run(['usb', 'start-listening']);
 			await delay(2000);
 
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout, stderr, exitCode } = await cli.run(['serial', 'identify']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stdout).to.include(`Your device id is ${DEVICE_ID}`);
 			expect(stdout).to.include('Your system firmware version is');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 	});
 
 	describe('USB Stop-Listening Subcommand', () => {
 		beforeEach(async () => {
+			await cli.setTestProfileAndLogin();
+			await cli.waitUntilOnline();
 			await cli.run(['usb', 'start-listening']);
 			await delay(2000);
 		});
 
 		afterEach(async () => {
 			await cli.resetDevice();
-			await delay(5000);
-			await cli.waitUntilOnline();
+			delay(5000);
+			await cli.run(['device-protection', 'enable']);
 		});
 
 		it('Stops listening', async () => {
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			await cli.run(['usb', 'stop-listening']);
 
 			const args = ['usb', 'cloud-status', DEVICE_ID, '--until', 'connected'];
 			const { stdout, stderr, exitCode } = await cli.run(args);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.equal('connected');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 	});
 
 	describe('USB DFU Subcommand', () => {
-		after(async () => {
-			await cli.resetDevice();
-			await delay(5000);
+		before(async () => {
+			await cli.setTestProfileAndLogin();
 			await cli.waitUntilOnline();
 		});
 
+		beforeEach(async () => {
+			await cli.setTestProfileAndLogin();
+		});
+
+		after(async () => {
+			await cli.resetDevice();
+			delay(5000);
+			await cli.run(['device-protection', 'enable']);
+		});
+
 		it('Enters DFU mode with confirmation', async () => {
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+
 			await cli.run(['usb', 'dfu', DEVICE_ID]);
 
 			const platform = capitalize(DEVICE_PLATFORM_NAME);
 			const { stdout, stderr, exitCode } = await cli.run(['usb', 'list']);
+
 			expect(stdout).to.include(`${DEVICE_NAME} [${DEVICE_ID}] (${platform}, DFU)`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
+
+
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+			// This will fail for device-os < 6.1.2
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
 
 			await cli.resetDevice();
 			await delay(5000);
@@ -292,59 +338,102 @@ describe.only('USB Commands [@device]', function cliUSBCommands(){
 	});
 
 	describe('USB Cloud Status Subcommand', () => {
+		before(async () => {
+			await cli.setTestProfileAndLogin();
+			await cli.waitUntilOnline();
+			await cli.run(['device-protection', 'enable']);
+		});
+
+		beforeEach(async () => {
+			await cli.setTestProfileAndLogin();
+		});
+
+		after(async () => {
+			await cli.run(['device-protection', 'enable']);
+		});
+
 		it('Reports current cloud connection status', async () => {
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout, stderr, exitCode } = await cli.run(['usb', 'cloud-status', DEVICE_NAME]);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.equal('connected');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 
 		it('Reports current cloud connection status for device id', async () => {
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout, stderr, exitCode } = await cli.run(['usb', 'cloud-status', DEVICE_ID]);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.equal('connected');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 
 		it('Polls cloud connection status using the `--until` flag', async () => {
-			await cli.resetDevice();
-			await delay(5000);
-
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const args = ['usb', 'cloud-status', DEVICE_ID, '--until', 'connected'];
 			const { stdout, stderr, exitCode } = await cli.run(args);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.equal('connected');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 
 		it('Fails with timeout error when polling cloud connection status using the `--until` flag', async () => {
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const args = ['usb', 'cloud-status', DEVICE_ID, '--until', 'disconnecting', '--timeout', 2 * 1000];
 			const { stdout, stderr, exitCode } = await cli.run(args);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.equal('timed-out waiting for status...');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(1);
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 	});
 
 	describe('USB network-interfaces Subcommand', () => {
-		after(async () => {
-			await cli.resetDevice();
-			await delay(5000);
+		before(async () => {
 			await cli.waitUntilOnline();
 		});
 
+		after(async () => {
+			await cli.run(['device-protection', 'enable']);
+		});
+
 		it('provides network interfaces', async () => {
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const ifacePattern = /\w+\(\w+\): flags=\d+<[\w,]+> mtu \d+/;
 
 			const { stdout, stderr, exitCode } = await cli.run(['usb', 'network-interfaces']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stdout).to.match(ifacePattern);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 	});
 });


### PR DESCRIPTION
## Description

While running any commands in the CLI, CLI check if a device is a Protected Device and if it is, CLI puts the device in Service Mode, gets the output of the command, then re-enabled Protection back on the device.
This PR adds a spinner that shows this sequence transparently to the user.

- A spinner for `Checking Device Protection...`
- Runs the command and gets the output
- A spinner for `Re-enabling Device Protection...`

## How to Test

<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

