### PR TITLE
Simplify the generic helper that takes care of Protected Devices

### DIFF
--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -97,7 +97,7 @@ class UsbPermissionsError extends Error {
 async function executeWithUsbDevice({ args, func, dfuMode = false } = {}) {
 	let device = await getOneUsbDevice(args, { dfuMode });
 	let deviceIsProtected = false;
-	
+
 	const platform = platformForId(device.platformId);
 	if (platform.generation > 2) { // Skipping device protection check for Gen2 platforms
 		try {


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description

See - https://github.com/particle-iot/particle-cli/pull/753
See - https://github.com/particle-iot/particle-cli/pull/754

Simplify the generic wrapper that takes care of Protected Devices.
1. Skips checking Device Protection for gen2 devices (both dfu and normal modes)
2. A Protected Device is put into Service Mode to run a CLI operation and after that CLI command execution finishes (either success/error), we expect the device to be ready to take a control request to turn off Service Mode. It's the responsibility of the module (usb, serial, flash, etc...) to exit the CLI command execution with a device that is able to take control requests in normal mode (or simply be ready in dfu mode)

## How to Test

Unfortunately, this is a stand alone PR. 
Since usb module already uses this helper, run any `particle usb xxx` commands to test this out on your Protected Device.

Your device should be Protected at the start of the test. Run any `particle usb xxx` command. The command should run fine. After the command finishes, check `particle device-protection status` and your device should now be a Protected Device.

## Related Issues / Discussions

A small part of https://app.shortcut.com/particle/story/129067/add-generic-helpers-for-a-device-to-put-into-service-mode-and-back-to-perform-a-cli-operation
See - https://github.com/particle-iot/particle-cli/pull/753
See - https://github.com/particle-iot/particle-cli/pull/754

## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

