### PR TITLE
Automate Protected Devices to run `particle wifi` commands

### DIFF
--- a/src/cmd/wifi.js
+++ b/src/cmd/wifi.js
@@ -238,13 +238,10 @@ module.exports = class WiFiCommands extends CLICommandBase {
 	}
 
 	async _getNetwork(device) {
-		let network;
 		if (this.file) {
-			network = await this._getNetworkToConnectFromJson();
-		} else {
-			network = await this._getNetworkToConnect(device);
+			return this._getNetworkToConnectFromJson();
 		}
-		return network;
+		return this._getNetworkToConnect(device);
 	}
 
 	async _getNetworkToConnectFromJson() {

--- a/src/cmd/wifi.js
+++ b/src/cmd/wifi.js
@@ -93,8 +93,7 @@ module.exports = class WiFiCommands extends CLICommandBase {
 					}
 				}
 
-				this.ui.stdout.write(`Wi-Fi network '${ssid}' configured successfully.\
-					Attempting to join...${os.EOL}Use ${chalk.yellow('particle wifi current')} to check the current network.${os.EOL}`);
+				this.ui.stdout.write(`Wi-Fi network '${ssid}' configured successfully. Attempting to join...${os.EOL}Use ${chalk.yellow('particle wifi current')} to check the current network.${os.EOL}`);
 			}
 		});
 	}

--- a/test/e2e/usb.e2e.js
+++ b/test/e2e/usb.e2e.js
@@ -10,7 +10,7 @@ const {
 const stripAnsi = require('strip-ansi');
 
 
-describe.only('USB Commands [@device]', function cliUSBCommands(){
+describe('USB Commands [@device]', function cliUSBCommands(){
 	this.timeout(5 * 60 * 1000);
 
 	const help = [

--- a/test/e2e/wifi-protected.e2e.js
+++ b/test/e2e/wifi-protected.e2e.js
@@ -1,0 +1,187 @@
+const { expect } = require('../setup');
+const cli = require('../lib/cli');
+const {
+	WIFI_SSID,
+	WIFI_CREDS_FILE
+} = require('../lib/env');
+const stripAnsi = require('strip-ansi');
+
+describe.only('Wi-Fi Commands for Protected Devices [@device,@wifi]', () => {
+	const help = [
+		'Configure Wi-Fi credentials to your device (Supported on Gen 3+ devices).',
+		'Usage: particle wifi <command>',
+		'Help:  particle help wifi <command>',
+		'',
+		'Commands:',
+		'  add      Adds a Wi-Fi network to your device',
+		'  join     Joins a Wi-Fi network',
+		'  clear    Clears the list of Wi-Fi networks on your device',
+		'  list     Lists the Wi-Fi networks on your device',
+		'  remove   Removes a Wi-Fi network from the device',
+		'  current  Gets the current Wi-Fi network',
+		'',
+		'Global Options:',
+		'  -v, --verbose  Increases how much logging to display  [count]',
+		'  -q, --quiet    Decreases how much logging to display  [count]',
+		''
+	];
+
+
+	before(async () => {
+		await cli.setTestProfileAndLogin();
+	});
+
+	after(async () => {
+		await cli.run(['usb', 'setup-done']);
+		await cli.logout();
+		await cli.setDefaultProfile();
+	});
+
+	it('Shows `help` content', async () => {
+		const { stdout, stderr, exitCode } = await cli.run(['help', 'wifi']);
+
+		expect(stripAnsi(stdout)).to.equal('');
+		expect(stderr.split('\n')).to.include.members(help);
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Shows `help` content when run without arguments', async () => {
+		const { stdout, stderr, exitCode } = await cli.run('wifi');
+
+		expect(stripAnsi(stdout)).to.equal('');
+		expect(stderr.split('\n')).to.include.members(help);
+		expect(exitCode).to.equal(0);
+	});
+
+	it('Shows `help` content when run with `--help` flag', async () => {
+		const { stdout, stderr, exitCode } = await cli.run(['wifi', '--help']);
+
+		expect(stripAnsi(stdout)).to.equal('');
+		expect(stderr.split('\n')).to.include.members(help);
+		expect(exitCode).to.equal(0);
+	});
+
+	describe('WiFi Commands', () => {
+        before(async () => {
+            await cli.run(['wifi', 'clear']);
+        });
+
+        beforeEach(async () => {
+            await cli.run(['device-protection', 'enable']);
+        });
+
+		it('Adds a Wi-Fi network', async () => {
+            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'add', '--file', WIFI_CREDS_FILE]);
+            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+
+			expect(stripAnsi(stdout)).to.include(`Wi-Fi network '${WIFI_SSID}' added successfully.`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
+		});
+
+		it('Joins a Wi-Fi network', async () => {
+            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'join', '--file', WIFI_CREDS_FILE]);
+            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+
+			expect(stripAnsi(stdout)).to.include(`Wi-Fi network '${WIFI_SSID}' configured successfully. Attempting to join...\nUse particle wifi current to check the current network.`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
+		});
+
+		it('Joins a known Wi-Fi network', async () => {
+			// expect that the network is present in the list
+            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout: listStdout } = await cli.run(['wifi', 'list']);
+			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'join', '--ssid', WIFI_SSID]);
+            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+
+			expect(listStdout).to.include(WIFI_SSID);
+			expect(stripAnsi(stdout)).to.include(`Wi-Fi network '${WIFI_SSID}' configured successfully. Attemping to join...\nUse particle wifi current to check the current network.`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
+		});
+
+		it('Fetches the current network the device is connected to', async () => {
+			// Let the device join a network and then clear it
+            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'current']);
+            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+
+			expect(stripAnsi(stdout)).to.include(WIFI_SSID);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
+		});
+
+		it('Lists networks on the device', async () => {
+            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'list']);
+            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+
+			expect(stripAnsi(stdout)).to.include('List of Wi-Fi networks on the device:');
+			expect(stripAnsi(stdout)).to.include(WIFI_SSID);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
+		});
+
+		it('removes a Wi-Fi network', async () => {
+            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'remove', '--ssid', WIFI_SSID]);
+            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+
+			const { stdout: listStdout } = await cli.run(['wifi', 'list']);
+
+			expect(stripAnsi(stdout)).to.include(`Wi-Fi network ${WIFI_SSID} removed from device's list successfully.`);
+			expect(listStdout).to.not.include(WIFI_SSID);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
+		});
+
+		it('Clears networks from the device', async () => {
+			// Let the device add a network and then clear it
+            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			await cli.run(['wifi', 'add', '--file', WIFI_CREDS_FILE]);
+			const { stdout: listStdoutBeforeClearing } = await cli.run(['wifi', 'list']);
+			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'clear']);
+			const { stdout : listStdoutAfterClearing }  = await cli.run(['wifi', 'list']);
+            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+
+			expect(stripAnsi(listStdoutBeforeClearing)).to.include(WIFI_SSID);
+			expect(stripAnsi(stdout)).to.include('Wi-Fi networks cleared successfully.');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+			expect(stripAnsi(listStdoutAfterClearing)).to.not.include(WIFI_SSID);
+            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
+			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
+		});
+	});
+
+});
+

--- a/test/e2e/wifi-protected.e2e.js
+++ b/test/e2e/wifi-protected.e2e.js
@@ -62,37 +62,37 @@ describe.only('Wi-Fi Commands for Protected Devices [@device,@wifi]', () => {
 	});
 
 	describe('WiFi Commands', () => {
-        before(async () => {
-            await cli.run(['wifi', 'clear']);
-        });
+		before(async () => {
+			await cli.run(['wifi', 'clear']);
+		});
 
-        beforeEach(async () => {
-            await cli.run(['device-protection', 'enable']);
-        });
+		beforeEach(async () => {
+			await cli.run(['device-protection', 'enable']);
+		});
 
 		it('Adds a Wi-Fi network', async () => {
-            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'add', '--file', WIFI_CREDS_FILE]);
-            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.include(`Wi-Fi network '${WIFI_SSID}' added successfully.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
-            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
 			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 
 		it('Joins a Wi-Fi network', async () => {
-            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'join', '--file', WIFI_CREDS_FILE]);
-            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.include(`Wi-Fi network '${WIFI_SSID}' configured successfully. Attempting to join...\nUse particle wifi current to check the current network.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
-            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
 			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
@@ -100,16 +100,16 @@ describe.only('Wi-Fi Commands for Protected Devices [@device,@wifi]', () => {
 
 		it('Joins a known Wi-Fi network', async () => {
 			// expect that the network is present in the list
-            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout: listStdout } = await cli.run(['wifi', 'list']);
 			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'join', '--ssid', WIFI_SSID]);
-            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(listStdout).to.include(WIFI_SSID);
 			expect(stripAnsi(stdout)).to.include(`Wi-Fi network '${WIFI_SSID}' configured successfully. Attemping to join...\nUse particle wifi current to check the current network.`);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
-            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
 			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
@@ -117,38 +117,38 @@ describe.only('Wi-Fi Commands for Protected Devices [@device,@wifi]', () => {
 
 		it('Fetches the current network the device is connected to', async () => {
 			// Let the device join a network and then clear it
-            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'current']);
-            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.include(WIFI_SSID);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
-            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
 			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 
 		it('Lists networks on the device', async () => {
-            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'list']);
-            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(stdout)).to.include('List of Wi-Fi networks on the device:');
 			expect(stripAnsi(stdout)).to.include(WIFI_SSID);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
-            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
 			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
 		});
 
 		it('removes a Wi-Fi network', async () => {
-            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'remove', '--ssid', WIFI_SSID]);
-            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			const { stdout: listStdout } = await cli.run(['wifi', 'list']);
 
@@ -156,7 +156,7 @@ describe.only('Wi-Fi Commands for Protected Devices [@device,@wifi]', () => {
 			expect(listStdout).to.not.include(WIFI_SSID);
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
-            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
 			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');
@@ -164,19 +164,19 @@ describe.only('Wi-Fi Commands for Protected Devices [@device,@wifi]', () => {
 
 		it('Clears networks from the device', async () => {
 			// Let the device add a network and then clear it
-            const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPBefore } = await cli.run(['device-protection', 'status']);
 			await cli.run(['wifi', 'add', '--file', WIFI_CREDS_FILE]);
 			const { stdout: listStdoutBeforeClearing } = await cli.run(['wifi', 'list']);
 			const { stdout, stderr, exitCode } = await cli.run(['wifi', 'clear']);
 			const { stdout : listStdoutAfterClearing }  = await cli.run(['wifi', 'list']);
-            const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
+			const { stdout: stdoutPAfter } = await cli.run(['device-protection', 'status']);
 
 			expect(stripAnsi(listStdoutBeforeClearing)).to.include(WIFI_SSID);
 			expect(stripAnsi(stdout)).to.include('Wi-Fi networks cleared successfully.');
 			expect(stderr).to.equal('');
 			expect(exitCode).to.equal(0);
 			expect(stripAnsi(listStdoutAfterClearing)).to.not.include(WIFI_SSID);
-            expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
+			expect((stdoutPBefore.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPBefore.split('\n'))[0]).to.not.include('Service Mode');
 			expect((stdoutPAfter.split('\n'))[0]).to.include('Protected Device');
 			expect((stdoutPAfter.split('\n'))[0]).to.not.include('Service Mode');


### PR DESCRIPTION
## Description

Support Protected Devices while running `particle wifi xxx` commands

## How to Test

Run `particle wifi xxx` commands on Open Devices and Protected Devices, all platforms, all device-os versions

## Related Issues / Discussions

https://app.shortcut.com/particle/story/129842/automate-protected-devices-to-run-particle-wifi-commands
https://app.shortcut.com/particle/story/129841/automate-protected-devices-to-run-particle-wifi-commands-e2e-tests


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

