### PR TITLE
Add option to filter device with `particle device-protection` commands

### DIFF
--- a/src/cli/device-protection.js
+++ b/src/cli/device-protection.js
@@ -2,9 +2,15 @@ module.exports = ({ commandProcessor, root }) => {
 	const deviceProtection = commandProcessor.createCategory(root, 'device-protection', 'Manage Device Protection');
 
 	commandProcessor.createCommand(deviceProtection, 'status', 'Gets the current Device Protection status', {
-		handler: () => {
+		options: {
+			device: {
+				description: 'Device ID or name',
+				alias: 'd'
+			}
+		},
+		handler: (args) => {
 			const DeviceProtectionCommands = require('../cmd/device-protection');
-			return new DeviceProtectionCommands().getStatus();
+			return new DeviceProtectionCommands().getStatus(args);
 		},
 		examples: {
 			'$0 $command': 'Gets the current Device Protection status'
@@ -12,10 +18,15 @@ module.exports = ({ commandProcessor, root }) => {
 	});
 
 	commandProcessor.createCommand(deviceProtection, 'disable', 'Disables Device Protection', {
-
-		handler: () => {
+		options: {
+			d: {
+				description: 'Device ID or name',
+				alias: 'device'
+			}
+		},
+		handler: (args) => {
 			const DeviceProtectionCommands = require('../cmd/device-protection');
-			return new DeviceProtectionCommands().disableProtection();
+			return new DeviceProtectionCommands().disableProtection(args);
 		},
 		examples: {
 			'$0 $command': 'Puts a Protected Device to Service Mode',
@@ -27,6 +38,10 @@ module.exports = ({ commandProcessor, root }) => {
 		options: {
 			file: {
 				description: 'File to use for Device Protection'
+			},
+			d: {
+				description: 'Device ID or name',
+				alias: 'device'
 			}
 		},
 		handler: (args) => {

--- a/src/cli/device-protection.test.js
+++ b/src/cli/device-protection.test.js
@@ -1,0 +1,153 @@
+const { expect } = require('../../test/setup');
+const commandProcessor = require('../app/command-processor');
+const deviceProtection = require('./device-protection');
+
+describe('Device Protection Command-Line Interface', () => {
+	let root;
+
+	beforeEach(() => {
+		root = commandProcessor.createAppCategory();
+		deviceProtection({ root, commandProcessor });
+	});
+
+	describe('`Device Protection` Namespace', () => {
+		it('Handles `device-protection` command', () => {
+			const argv = commandProcessor.parse(root, ['device-protection']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.equal(undefined);
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['device-protection', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Manage Device Protection',
+					'Usage: particle device-protection <command>',
+					'Help:  particle help device-protection <command>',
+					'',
+					'Commands:',
+					'  status   Gets the current Device Protection status',
+					'  disable  Disables Device Protection',
+					'  enable   Enables Device Protection',
+					''
+				].join('\n'));
+			});
+		});
+
+		describe('`device-protection status` command', () => {
+			it('Handles `status` command', () => {
+				const argv = commandProcessor.parse(root, ['device-protection', 'status']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.params).to.eql({});
+			});
+
+			it('Handles `status` command with a device', () => {
+				const argv = commandProcessor.parse(root, ['device-protection', 'status', '--device', '0123456789abcdef']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.device).to.eql('0123456789abcdef');
+			});
+
+			it('Includes help', () => {
+				const termWidth = null; // don't right-align option type labels so testing is easier
+				commandProcessor.parse(root, ['device-protection', 'status', '--help'], termWidth);
+				commandProcessor.showHelp((helpText) => {
+					expect(helpText).to.equal([
+						'Gets the current Device Protection status',
+						'Usage: particle device-protection status [options]',
+						'',
+						'Options:',
+						'  --device, -d  Device ID or name  [string]',
+						'',
+						'Examples:',
+						'  particle device-protection status  Gets the current Device Protection status',
+						''
+					].join('\n'));
+				});
+			});
+		});
+
+		describe('`device-protection disable` command', () => {
+			it('Handles `disable` command', () => {
+				const argv = commandProcessor.parse(root, ['device-protection', 'disable']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.device).to.eql(undefined);
+			});
+
+			it('Handles `disable` command with a device', () => {
+				const argv = commandProcessor.parse(root, ['device-protection', 'disable', '-d', '0123456789abcdef']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.device).to.eql('0123456789abcdef');
+			});
+
+			it('Includes help', () => {
+				const termWidth = null; // don't right-align option type labels so testing is easier
+				commandProcessor.parse(root, ['device-protection', 'disable', '--help'], termWidth);
+				commandProcessor.showHelp((helpText) => {
+					expect(helpText).to.equal([
+						'Disables Device Protection',
+						'Usage: particle device-protection disable [options]',
+						'',
+						'Options:',
+						'  -d, --device  Device ID or name  [string]',
+						'',
+						'Examples:',
+						'  particle device-protection disable  Puts a Protected Device to Service Mode',
+						'',
+						'A Protected Device in Service Mode allows any command to be performed on it that can be performed on an Open Device like flashing firmware or serial monitor.',
+						''
+					].join('\n'));
+				});
+			});
+		});
+
+		describe('`device-protection enable` command', () => {
+			it('Handles `enable` command', () => {
+				const argv = commandProcessor.parse(root, ['device-protection', 'enable']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.device).to.eql(undefined);
+			});
+
+			it('Handles `enable` command with a device', () => {
+				const argv = commandProcessor.parse(root, ['device-protection', 'enable', '-d', '0123456789abcdef']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.device).to.eql('0123456789abcdef');
+				expect(argv.file).to.eql(undefined);
+			});
+
+			it('Handles `enable` command with a filename', () => {
+				const argv = commandProcessor.parse(root, ['device-protection', 'enable', '--file', 'file.txt']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.device).to.eql(undefined);
+				expect(argv.file).to.eql('file.txt');
+			});
+
+			it('Handles `enable` command with a device and a filename', () => {
+				const argv = commandProcessor.parse(root, ['device-protection', 'enable', '-d', '0123456789abcdef', '--file', 'file.txt']);
+				expect(argv.clierror).to.equal(undefined);
+				expect(argv.device).to.eql('0123456789abcdef');
+				expect(argv.file).to.eql('file.txt');
+			});
+
+			it('Includes help', () => {
+				const termWidth = null; // don't right-align option type labels so testing is easier
+				commandProcessor.parse(root, ['device-protection', 'enable', '--help'], termWidth);
+				commandProcessor.showHelp((helpText) => {
+					expect(helpText).to.equal([
+						'Enables Device Protection',
+						'Usage: particle device-protection enable [options]',
+						'',
+						'Options:',
+						'  --file        File to use for Device Protection  [string]',
+						'  -d, --device  Device ID or name  [string]',
+						'',
+						'Examples:',
+						'  particle device-protection enable  Turns an Open Device into a Protected Device',
+						''
+					].join('\n'));
+				});
+			});
+		});
+	});
+});
+

--- a/src/cmd/device-protection.js
+++ b/src/cmd/device-protection.js
@@ -39,7 +39,8 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	 * @returns {Promise<Object>} The protection state of the device.
 	 * @throws {Error} Throws an error if any of the async operations fail.
 	 */
-	async getStatus() {
+	async getStatus({ device } = {}) {
+		this.deviceId = device;
 		let addToOutput = [];
 		let s;
 		try {
@@ -87,7 +88,8 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	 * @returns {Promise<void>}
 	 * @throws {Error} - Throws an error if any of the async operations fail.
 	 */
-	async disableProtection() {
+	async disableProtection({ device } = {}) {
+		this.deviceId = device;
 		let addToOutput = [];
 		try {
 			await this._withDevice({ spinner: 'Disabling Device Protection' }, async () => {
@@ -132,7 +134,8 @@ module.exports = class DeviceProtectionCommands extends CLICommandBase {
 	 * @returns {Promise<void>}
 	 * @throws {Error} Throws an error if any of the asynchronous operations fail.
 	 */
-	async enableProtection({ file } = {}) {
+	async enableProtection({ file, device } = {}) {
+		this.deviceId = device;
 		let addToOutput = [];
 		try {
 			await this._withDevice({ spinner: 'Enabling Device Protection' }, async () => {


### PR DESCRIPTION
## Description

As title says. The option is `-d` to select device ID or name.

## How to Test

1. Connect multiple devices and verify that they are readable using `particle usb list`
2. Run `particle device-protection status -d device-id-or-name`
3. Run `particle device-protection disable -d device-id-or-name`
4. Run `particle device-protection enable -d device-id-or-name`

## Expected Outcome
```
$ particle.js usb list
armadillo_cheetah [e00fce68623fcff480e85e47] (Boron)
power_robot [0a10aced202194944a04af80] (M-SoM, PROTECTED)

$ particle.js device-protection status -d 0a10aced202194944a04af80
[0a10aced202194944a04af80] (Product 28400): Protected Device
Run particle device-protection disable to put the device in Service Mode.

$
```

## Related Issues / Discussions

https://app.shortcut.com/particle/story/129867/specify-device-by-id-in-device-protection-commands


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

