### PR TITLE
Handle multi-step flashing on Protected Devices

### DIFF
--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -105,11 +105,11 @@ module.exports = class FlashCommand extends CLICommandBase {
 		const resetAfterFlash = !factory && modulesToFlash[0].prefixInfo.moduleFunction === ModuleInfo.FunctionType.USER_PART;
 		await flashFiles({ device, flashSteps, resetAfterFlash, ui: this.ui });
 
-		// The device obtained here is may be closed so reopen the device and ensure its ready to talk to
+		// The device obtained here could be closed, so reopen the device and ensure it is ready to talk to
 		// FIXME: Gen2 devices may not be able to respond to control requests immediately after flashing
 		const platform = platformForId(device.platformId);
 		if (platform.generation > 2) {
-			device = await usbUtils.waitForDeviceToRespond(deviceId, { timeout: 5000 });
+			device = await usbUtils.waitForDeviceToRespond(deviceId);
 			return device;
 		}
 	}
@@ -185,11 +185,11 @@ module.exports = class FlashCommand extends CLICommandBase {
 
 		await flashFiles({ device, flashSteps, ui: this.ui, verbose });
 
-		// The device obtained here is may be closed so reopen the device and ensure its ready to talk to
+		// The device obtained here may have been closed, so reopen it and ensure it is ready to send control requests to.
 		// FIXME: Gen2 devices may not be able to respond to control requests immediately after flashing
 		const platform = platformForId(device.platformId);
 		if (platform.generation > 2) {
-			device = await usbUtils.waitForDeviceToRespond(deviceId, { timeout: 5000 });
+			device = await usbUtils.waitForDeviceToRespond(deviceId);
 			return device;
 		}
 	}

--- a/src/cmd/update.js
+++ b/src/cmd/update.js
@@ -54,11 +54,11 @@ module.exports = class UpdateCommand extends CLICommandBase {
 
 		this.ui.write('Update success!');
 
-		// The device obtained here is may be closed so reopen the device and ensure its ready to talk to
+		// The device obtained here may have been closed, so reopen it and ensure it is ready to send control requests to.
 		// FIXME: Gen2 devices may not be able to respond to control requests immediately after flashing
 		const platform = platformForId(device.platformId);
 		if (platform.generation > 2) {
-			device = await usbUtils.waitForDeviceToRespond(deviceId, { timeout: 5000 });
+			device = await usbUtils.waitForDeviceToRespond(deviceId);
 			return device;
 		}
 	}

--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -167,7 +167,6 @@ async function waitForDeviceToRespond(deviceId, { timeout = 10000 } = {}) {
 	const REBOOT_INTERVAL_MSEC = 500;
 	const start = Date.now();
 	let device;
-
 	while (Date.now() - start < REBOOT_TIME_MSEC) {
 		try {
 			if (device && device.isOpen) {
@@ -183,6 +182,10 @@ async function waitForDeviceToRespond(deviceId, { timeout = 10000 } = {}) {
 			return device;
 		} catch (error) {
 			// ignore errors
+			// device could be open after the last iteration
+			if (device && device.isOpen) {
+				await device.close();
+			}
 		}
 	}
 	return null;

--- a/src/lib/flash-helper.test.js
+++ b/src/lib/flash-helper.test.js
@@ -675,6 +675,11 @@ describe('flash-helper', () => {
 		beforeEach(async () => {
 			device = {
 				getProtectionState: sinon.stub(),
+				isInDfuMode: false,
+				getFirmwareModuleInfo: sinon.stub().resolves([
+					{ type: 'BOOTLOADER', index: 0, version: 3000 },
+					{ type: 'SYSTEM_PART', index: 1, version: 6000 },
+				])
 			};
 
 			const oldBootloaderBuffer = await firmwareTestHelper.createFirmwareBinary({


### PR DESCRIPTION
## Description

This is only applicable for device-os 6.1.1 and lower.

The flashing operation is a multi-step process where each step obtains the device handle, sets the device to the appropriate mode (normal or DFU) based on the binary type, and then flashes the binary onto the device.

Currently, a generic wrapper is used to manage Protected Devices, placing the device in Service Mode only once at the beginning of the flashing process. However, this approach has a limitation: the devices on 6.1.0 and 6.0.0 exit Service Mode and return to a Protected state after flashing the bootloader. You could think of starting in DFU mode, but these device-os versions don't work well on Protected Devices in DFU mode.

The PR throws a downgrade error on Protected Devices if downgrading device-os from 6.1.1 to either 6.1.0 or 6.0.0.

One alternative to downgrade is to convert the Protected Device to Open Device via cloud, and then downgrade via CLI.

## How to Test

1. Flash 6.1.1 on your device. Enable Device Protection on it.
2. Upgrade to develop-6.x or 6.1.1 again -> It will work
3. Downgrade to 6.1.0 again -> It won't work

## Related Issues / Discussions



## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

