### PR TITLE
Skip adding protected devices to non-protection products

### DIFF
--- a/src/cmd/product.js
+++ b/src/cmd/product.js
@@ -42,8 +42,8 @@ module.exports = class ProductCommand extends CLICommandBase {
 			.then(result => this.showDeviceAddResult(result));
 	}
 
-	showDeviceAddResult({ product, identifiers, status: { invalidDeviceIds = [], nonmemberDeviceIds = [] } } = {}){
-		identifiers = filterDeviceIdentifiers(identifiers, invalidDeviceIds, nonmemberDeviceIds);
+	showDeviceAddResult({ product, identifiers, status: { invalidDeviceIds = [], nonmemberDeviceIds = [], protectedDeviceIds = [] } } = {}){
+		identifiers = filterDeviceIdentifiers(identifiers, invalidDeviceIds, nonmemberDeviceIds, protectedDeviceIds);
 		const message = [];
 
 		if (identifiers.length){
@@ -71,6 +71,14 @@ module.exports = class ProductCommand extends CLICommandBase {
 			message.push(
 				'Skipped Invalid IDs:',
 				dedupeAndStringifyIDList(invalidDeviceIds),
+				''
+			);
+		}
+
+		if (protectedDeviceIds.length){
+			message.push(
+				'Skipped Protected IDs:',
+				dedupeAndStringifyIDList(protectedDeviceIds),
 				''
 			);
 		}
@@ -200,9 +208,10 @@ function readDeviceListFile(file){
 		});
 }
 
-function filterDeviceIdentifiers(identifiers, invalid = [], nonmember = []){
+function filterDeviceIdentifiers(identifiers, invalid = [], nonmember = [], protectedDevice = []){
 	return identifiers.reduce((out, x) => {
-		if (!hasDeviceIdentifier(x, invalid) && !hasDeviceIdentifier(x, nonmember)){
+		if (!hasDeviceIdentifier(x, invalid) && !hasDeviceIdentifier(x, nonmember)
+			&& !hasDeviceIdentifier(x, protectedDevice)){
 			out.push(x);
 		}
 		return out;


### PR DESCRIPTION
## Description

As title says.

The `api-service` provides a list of device identifiers called `protectedDeviceIds`. This list includes the IDs of protected devices that are being attempted to be added to non-protected products. These device IDs have already been filtered out by the `api-service` to prevent them from being added to the product. In `particle-cli`, we notify the user that these device IDs are being skipped.

## How to Test

Refer to the testing instructions here - https://github.com/particle-iot-inc/api-service/pull/1564

## Related Issues / Discussions

https://github.com/particle-iot-inc/api-service/pull/1564
https://app.shortcut.com/particle/story/129604/don-t-allow-moving-a-protected-device-to-a-non-protected-product


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

