### PR TITLE
feat: [sc-131051] Remove access_token query param from CLI

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -7,6 +7,7 @@ let settings = {
 	apiUrl: 'https://api.particle.io',
 	clientId: 'CLI2',
 	access_token: null,
+	username: null,
 	minimumApiDelay: 500,
 	useSudoForDfu: false,
 	flashWarningShownOn: null,

--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -469,7 +469,7 @@ module.exports = class CloudCommand extends CLICommandBase {
 			.then(credentials => {
 				const { token, username, password, sso } = credentials;
 				const msg = 'Sending login details...';
-				const api = new ApiClient();
+				const api = new ApiClient(null, token);
 
 				this._usernameProvided = username;
 
@@ -485,7 +485,7 @@ module.exports = class CloudCommand extends CLICommandBase {
 				}
 
 				if (token){
-					return this.ui.showBusySpinnerUntilResolved(msg, api.getUser(token))
+					return this.ui.showBusySpinnerUntilResolved(msg, api.getUser())
 						.then(response => ({ token, username: response.username }));
 				}
 				const login = api.login(settings.clientId, username, password);

--- a/src/cmd/cloud.test.js
+++ b/src/cmd/cloud.test.js
@@ -64,7 +64,6 @@ describe('Cloud Commands', () => {
 					expect(t).to.equal(fakeToken);
 					expect(api.login).to.have.property('callCount', 0);
 					expect(api.getUser).to.have.property('callCount', 1);
-					expect(api.getUser.firstCall.args).to.eql([fakeToken]);
 					expect(settings.override).to.have.property('callCount', 2);
 					expect(settings.override.firstCall.args).to.eql([null, 'access_token', fakeToken]);
 					expect(settings.override.secondCall.args).to.eql([null, 'username', username]);

--- a/src/cmd/whoami.js
+++ b/src/cmd/whoami.js
@@ -17,9 +17,7 @@ module.exports = class WhoAmICommand {
 
 		return Promise.resolve()
 			.then(() => {
-				if (!api.hasToken()){
-					throw new VError('You are not signed in! Please run: `particle login`');
-				}
+				api.ensureToken();
 
 				this.newSpin('Checking...').start();
 

--- a/src/cmd/whoami.test.js
+++ b/src/cmd/whoami.test.js
@@ -1,61 +1,48 @@
-const proxyquire = require('proxyquire');
 const { expect, sinon } = require('../../test/setup');
 const { withConsoleStubs } = require('../../test/lib/mocha-utils');
-
-const stubs = {
-	api: {
-		hasToken: () => {},
-		getUser: () => {}
-	},
-	settings: {
-		clientId: 'CLITESTS',
-		username: '',
-		override: () => {}
-	},
-	ApiClient: function ApiClient(){
-		return stubs.api;
-	}
-};
-
-const WhoAmICommands = proxyquire('./whoami', {
-	'../../settings': stubs.settings,
-	'../lib/api-client': stubs.ApiClient
-});
+const settings = require('../../settings');
+const ApiClient = require('../lib/api-client');
+const WhoAmICommands = require('./whoami');
 
 
 describe('Whoami Commands', () => {
 	const sandbox = sinon.createSandbox();
-	let fakeUser, fakeUserPromise;
+
+	// We cannot mock the prototype since the spinner is from a mixin :cat-scream:
+	function whoAmICommands() {
+		const whoAmI = new WhoAmICommands();
+		sandbox.stub(whoAmI, 'newSpin').returns({ start: sandbox.stub() });
+		sandbox.stub(whoAmI, 'stopSpin');
+
+		return whoAmI;
+	}
 
 	beforeEach(() => {
-		fakeUser = { username: 'from-api@example.com' };
-		fakeUserPromise = Promise.resolve(fakeUser);
+		sandbox.stub(settings, 'access_token').value('valid-access-token');
 	});
 
 	afterEach(() => {
 		sandbox.restore();
-		stubs.settings.username = '';
 	});
 
 	it('fails when user is signed-out', () => {
-		const { whoami, api } = stubForWhoAmI(new WhoAmICommands(), stubs);
-		api.hasToken.returns(false);
+		sandbox.stub(ApiClient.prototype, '_access_token').get(() => null);
+		const whoAmI = whoAmICommands();
 
-		return whoami.getUsername()
+		return whoAmI.getUsername()
 			.then(() => {
 				throw new Error('expected promise to be rejected');
 			})
 			.catch(error => {
-				expect(error).to.have.property('message', 'You are not signed in! Please run: `particle login`');
+				expect(error).to.have.property('message', 'You\'re not logged in. Please login using [1m[36mparticle cloud login[39m[22m before using this command');
 			});
 	});
 
 	it('fails when token is invalid', () => {
-		const { whoami, api } = stubForWhoAmI(new WhoAmICommands(), stubs);
-		api.hasToken.returns(true);
-		api.getUser.throws();
+		sandbox.stub(ApiClient.prototype, 'getUser').throws();
+		const whoAmI = whoAmICommands();
 
-		return whoami.getUsername()
+		return whoAmI.getUsername()
 			.then(() => {
 				throw new Error('expected promise to be rejected');
 			})
@@ -65,65 +52,56 @@ describe('Whoami Commands', () => {
 	});
 
 	it('returns username from the local settings when user is signed-in', withConsoleStubs(sandbox, () => {
-		const { whoami, api } = stubForWhoAmI(new WhoAmICommands(), stubs);
-		stubs.settings.username = 'from-settings@example.com';
-		api.getUser.returns(fakeUserPromise);
-		api.hasToken.returns(true);
+		sandbox.stub(settings, 'username').value('from-settings@example.com');
+		sandbox.spy(ApiClient.prototype, 'ensureToken');
+		sandbox.stub(ApiClient.prototype, 'getUser').resolves({ username: 'from-api@example.com' });
+		const whoAmI = whoAmICommands();
 
-		return whoami.getUsername()
-			.then(username => {
-				expect(username).to.equal(stubs.settings.username);
-				expect(api.hasToken).to.have.property('callCount', 1);
-				expect(api.getUser).to.have.property('callCount', 1);
-				expectSuccessMessage(stubs.settings.username);
+		return whoAmI.getUsername()
+			.then((username) => {
+				expect(username).to.equal(settings.username);
+				expect(ApiClient.prototype.ensureToken).to.have.property('callCount', 1);
+				expect(ApiClient.prototype.getUser).to.have.property('callCount', 1);
+				validateStdoutContainsUsername(settings.username);
 			});
 	}));
 
 	it('returns username from the API when user is signed-in and username isn\'t saved locally', withConsoleStubs(sandbox, () => {
-		const { whoami, api } = stubForWhoAmI(new WhoAmICommands(), stubs);
-		api.getUser.returns(fakeUserPromise);
-		api.hasToken.returns(true);
+		const apiUsername = 'from-api@example.com';
+		sandbox.stub(settings, 'username').value(null);
+		sandbox.spy(ApiClient.prototype, 'ensureToken');
+		sandbox.stub(ApiClient.prototype, 'getUser').resolves({ username: apiUsername });
+		const whoAmI = whoAmICommands();
 
-		return whoami.getUsername()
+		return whoAmI.getUsername()
 			.then(username => {
-				expect(username).to.equal(fakeUser.username);
-				expect(api.hasToken).to.have.property('callCount', 1);
-				expect(api.getUser).to.have.property('callCount', 1);
-				expectSuccessMessage(fakeUser.username);
+				expect(username).to.equal(apiUsername);
+				expect(ApiClient.prototype.ensureToken).to.have.property('callCount', 1);
+				expect(ApiClient.prototype.getUser).to.have.property('callCount', 1);
+				validateStdoutContainsUsername(apiUsername);
 			});
 	}));
 
 	it('returns fallback when user is signed-in but username is not saved locally or available in the API', withConsoleStubs(sandbox, () => {
-		const { whoami, api } = stubForWhoAmI(new WhoAmICommands(), stubs);
-		fakeUser.username = '';
-		stubs.settings.username = '';
-		api.getUser.returns(fakeUserPromise);
-		api.hasToken.returns(true);
+		sandbox.stub(settings, 'username').value(null);
+		sandbox.spy(ApiClient.prototype, 'ensureToken');
+		sandbox.stub(ApiClient.prototype, 'getUser').resolves({ username: '' });
+		const whoAmI = whoAmICommands();
 
-		return whoami.getUsername()
+		return whoAmI.getUsername()
 			.then(username => {
 				const fallback = 'unknown username';
 				expect(username).to.equal(fallback);
-				expect(api.hasToken).to.have.property('callCount', 1);
-				expect(api.getUser).to.have.property('callCount', 1);
-				expectSuccessMessage(fallback);
+				expect(ApiClient.prototype.ensureToken).to.have.property('callCount', 1);
+				expect(ApiClient.prototype.getUser).to.have.property('callCount', 1);
+				validateStdoutContainsUsername(fallback);
 			});
 	}));
 
-	function expectSuccessMessage(username){
+	function validateStdoutContainsUsername(username){
 		expect(process.stdout.write).to.have.property('callCount', 1);
 		expect(process.stdout.write.firstCall.args[0])
 			.to.match(new RegExp(`${username}\\n$`));
-	}
-
-	function stubForWhoAmI(whoami, stubs){
-		const { api } = stubs;
-		sandbox.stub(whoami, 'newSpin');
-		sandbox.stub(whoami, 'stopSpin');
-		whoami.newSpin.returns({ start: sandbox.stub() });
-		sandbox.stub(api, 'hasToken');
-		sandbox.stub(api, 'getUser');
-		return { whoami, api };
 	}
 });
 

--- a/test/lib/mocha-utils.js
+++ b/test/lib/mocha-utils.js
@@ -27,13 +27,13 @@ module.exports.withConsoleStubs = (sandbox, fn) => {
 	return () => {
 		let result;
 
-		sandbox.stub(process.stdout, 'write');
+		sandbox.spy(process.stdout, 'write');
 
 		if (process.stdout.isTTY){
 			sandbox.stub(process.stdout, 'isTTY').get(() => false);
 		}
 
-		sandbox.stub(process.stderr, 'write');
+		sandbox.spy(process.stderr, 'write');
 
 		if (process.stderr.isTTY){
 			sandbox.stub(process.stderr, 'isTTY').get(() => false);


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/131051

# Story
* Remove query param access_token usage from ApiClient class

## Other
* Cleanup ApiClient so it has consistent handling of auth header/access token
  * Refactor getUser so it doesn't take a token directly anymore. No idea why it ever did
* Refactor WhoAmICommands tests to replace proxyquire with sinon stubs
* Update WhoAmICommands to use api.ensureToken
* Add default null username in settings so we can properly "stub" it in tests
* Change stdout/stderr stubs into spys so they still log for debugging purposes
