### PR TITLE
remove buildTargets list and get since is not being used in the code

### DIFF
--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -145,15 +145,6 @@ module.exports = class ParticleApi {
 		);
 	}
 
-	listBuildTargets(onlyFeatured){
-		return this._wrap(
-			this.api.listBuildTargets({
-				onlyFeatured,
-				auth: this.accessToken
-			})
-		);
-	}
-
 	listDeviceOsVersions(platformId, internalVersion, perPage=100){
 		return this._wrap(
 			this.api.listDeviceOsVersions({

--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -898,31 +898,6 @@ module.exports = class ApiClient {
 		});
 	}
 
-	getBuildTargets(){
-		return new Promise((resolve, reject) => {
-			const options = {
-				uri: '/v1/build_targets',
-				qs: {
-					featured: true
-				},
-				method: 'GET',
-				json: true
-			};
-
-			this.request(options, (error, response, body) => {
-				if (error){
-					return reject(error);
-				}
-
-				if (this.hasBadToken(body)){
-					return reject('Invalid token');
-				}
-
-				resolve(body);
-			});
-		});
-	}
-
 	getClaimCode(){
 		return new Promise((resolve, reject) => {
 			const options = {


### PR DESCRIPTION
## Description
Remove unused `listBuildTargets` in favor of `listDeviceOsVersions`

Both: `getBuildTargets` and `listBuildTargets` are not being used in `particle-cli` so we can remove them
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test

<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/131530/inspect-build-targets-from-api-service-and-create-a-plan-to-remove-old-flags
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [ ] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

