### PR TITLE
Feature/enable profiles

### DIFF
--- a/src/cmd/esim.js
+++ b/src/cmd/esim.js
@@ -12,13 +12,12 @@ const path = require('path');
 const _ = require('lodash');
 const chalk = require('chalk');
 
-// TODO: Get these from exports
 const PROVISIONING_PROGRESS = 1;
 const PROVISIONING_SUCCESS = 2;
 const PROVISIONING_FAILURE = 3;
 const CTRL_REQUEST_APP_CUSTOM = 10;
 const GET_AT_COMMAND_STATUS = 4;
-
+const LPA_PROFILE_ENABLE_ERROR = 'profile not in disabled state';
 
 const TEST_ICCID = ['89000123456789012341', '89000123456789012358'];
 const TWILIO_ICCID_PREFIX = '8988307';
@@ -91,11 +90,7 @@ module.exports = class ESimCommands extends CLICommandBase {
 
 	async enableCommand(iccid) {
 		await this._checkForTachyonDevice();
-		if (this.isTachyon) {
-			await this.doEnableTachyon(iccid);
-		} else {
-
-		}
+		await this.doEnableTachyon(iccid);
 	}
 
 	async deleteCommand(args, iccid) {
@@ -837,7 +832,7 @@ module.exports = class ESimCommands extends CLICommandBase {
 			res.details.command = enableProfileCmd;
 			return res;
 		} catch (error) {
-			if (error.message.includes('profile not in disabled state')) {
+			if (error.message.includes(LPA_PROFILE_ENABLE_ERROR)) {
 				res.details.rawLogs.push(`Profile already enabled: ${iccid}`);
 				return res;
 			}


### PR DESCRIPTION
## Description

This PR adds support for `esim provision` command to enable profiles that are already downloaded

## How to Test

<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

