### PR TITLE
add region flag in case is not passed use NA

### DIFF
--- a/src/cli/tachyon.js
+++ b/src/cli/tachyon.js
@@ -18,6 +18,10 @@ module.exports = ({ commandProcessor, root }) => {
 			save_config: {
 				description: 'Path to dump the config file to after setup',
 				type: 'string'
+			},
+			region: {
+				description: 'Region to download package for',
+				type: 'string',
 			}
 		},
 		handler: (args) => {

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -71,7 +71,6 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 					() => this._selectProduct()
 				);
 				config.productId = product;
-				config.region = region;
 			}
 
 			const packagePath = await this._runStepWithTiming(
@@ -80,7 +79,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
         `if it's interrupted. If you have to kill the CLI, it will pick up where it left. You can also${os.EOL}` +
         "just let it run in the background. We'll wait for you to be ready when its time to flash the device.",
 				4,
-				() => this._download({ region: config.region, version, alwaysCleanCache })
+				() => this._download({ region, version, alwaysCleanCache })
 			);
 
 			const registrationCode = await this._runStepWithTiming(

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -30,11 +30,11 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		this._formatAndDisplaySteps = this._formatAndDisplaySteps.bind(this);
 	}
 
-	async setup({ skip_flashing_os: skipFlashingOs, region, version='latest', load_config: loadConfig, save_config: saveConfig } = {}) {
+	async setup({ skip_flashing_os: skipFlashingOs, region = 'NA', version='latest', load_config: loadConfig, save_config: saveConfig } = {}) {
 		try {
 			const loadedFromFile = !!loadConfig;
 			this._showWelcomeMessage();
-			this._formatAndDisplaySteps("Okay—first up! Checking if you're logged in...", 0);
+			this._formatAndDisplaySteps("Okay—first up! Checking if you're logged in...", 1);
 
 			await this._verifyLogin();
 
@@ -51,13 +51,6 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 					`${os.EOL}${os.EOL}Skipping to Step 4 - Using configuration file: ` + loadConfig + `${os.EOL}`
 				);
 			} else {
-				if (!region) {
-					region = await this._runStepWithTiming(
-						'Next, let\'s select the region to download the Tachyon package from.',
-						1,
-						() => this._selectRegion()
-					);
-				}
 				config = await this._runStepWithTiming(
 					`Now lets capture some information about how you'd like your device to be configured when it first boots.${os.EOL}${os.EOL}` +
 					`First, you'll be asked to set a password for the root account on your Tachyon device.${os.EOL}` +

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -518,8 +518,9 @@ Welcome to the Particle Tachyon setup! This interactive command:
 			'        start_byte_hex="0x2208000"',
 			'        start_sector="8712"',
 			'    />',
-			'</data>'
-		].join(os.EOL);
+			'</data>',
+			''
+		].join('\n'); // Must use UNIX line endings for QDL
 
 		// Create a temporary file for the XML content
 		const tempFile = temp.openSync({ prefix: 'config', suffix: '.xml' });

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -451,7 +451,7 @@ Welcome to the Particle Tachyon setup! This interactive command:
 		return data.registration_code;
 	}
 
-	async _createConfigBlob({ loadedFromFile = false, registrationCode, systemPassword, wifi, sshPublicKey, productId, region }) {
+	async _createConfigBlob({ loadedFromFile = false, registrationCode, systemPassword, wifi, sshPublicKey, productId }) {
 		// Format the config and registration code into a config blob (JSON file, prefixed by the file size)
 		const config = {
 			registrationCode: registrationCode,
@@ -468,10 +468,6 @@ Welcome to the Particle Tachyon setup! This interactive command:
 
 		if (productId) {
 			config.productId = productId;
-		}
-
-		if (region) {
-			config.region = region;
 		}
 
 		// Write config JSON to a temporary file (generate a filename with the temp npm module)

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -30,7 +30,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		this._formatAndDisplaySteps = this._formatAndDisplaySteps.bind(this);
 	}
 
-	async setup({ skip_flashing_os: skipFlashingOs, version, load_config: loadConfig, save_config: saveConfig }) {
+	async setup({ skip_flashing_os: skipFlashingOs, region = 'NA', version, load_config: loadConfig, save_config: saveConfig }) {
 		try {
 			const loadedFromFile = !!loadConfig;
 			this._showWelcomeMessage();
@@ -39,8 +39,6 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			await this._verifyLogin();
 
 			this.ui.write("...All set! You're logged in and ready to go!");
-
-			const region = 'NA'; //await this._selectRegion();
 
 			//if version is not provided, set to latest
 			if (!version) {


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
Add flag region to be used in tachyon setup.
Region can be stored and read it from the config file.
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
1. Pull down the branch: `git pull && git checkout feature/sc-133755/add-region-as-setup-option-by-default-use`
2. Attempt to setup a RoW region `npm start -- tachyon setup --region RoW`
3. Attempt to setup a NA (default)  `npm start -- tachyon setup`
4. Attempt to setup and save the config file `npm start -- tachyon setup --save_config test_region.cfg`


**outcome**
* If you pick `RoW` the binary that will be flashed should be `RoW`
* If you don't pick a region, then it will download `NA` by default
* In the config file you'll see a new element named `region`
* In case you don't pass a region as flag it will ask you to pick one.
<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions

Story details: https://app.shortcut.com/particle/story/133755
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

