### PR TITLE
add board option for tachyon setup and download command

### DIFF
--- a/src/cli/tachyon.js
+++ b/src/cli/tachyon.js
@@ -30,7 +30,11 @@ module.exports = ({ commandProcessor, root }) => {
 			variant: {
 				description: 'Variant of the Tachyon package to download',
 				type: 'string'
-			}
+			},
+			board: {
+				description: 'Board to download package for',
+				type: 'string'
+			},
 		},
 		handler: (args) => {
 			const SetupTachyonCommands = require('../cmd/setup-tachyon');
@@ -54,6 +58,10 @@ module.exports = ({ commandProcessor, root }) => {
 			variant: {
 				description: 'Variant of the Tachyon package to download',
 				type: 'string'
+			},
+			board: {
+				description: 'Board to download package for',
+				type: 'string'
 			}
 		},
 		handler: (args) => {
@@ -74,6 +82,14 @@ module.exports = ({ commandProcessor, root }) => {
 			},
 			version: {
 				description: 'Version to download package for',
+				type: 'string'
+			},
+			variant: {
+				description: 'Variant of the Tachyon package to download',
+				type: 'string'
+			},
+			board: {
+				description: 'Board to download package for',
 				type: 'string'
 			},
 			all: {

--- a/src/cmd/download-tachyon-package.js
+++ b/src/cmd/download-tachyon-package.js
@@ -36,7 +36,7 @@ module.exports = class DownloadTachyonPackageCommand extends CLICommandBase {
 		const answer = await this.ui.prompt(question);
 		return answer.version;
 	}
-	async download ({ region, version, alwaysCleanCache = false, variant = 'headless' }) {
+	async download ({ region, version, alwaysCleanCache = false, variant = 'headless', board = 'formfactor' }) {
 		// prompt for region and version if not provided
 		if (!region) {
 			region = await this._selectRegion();
@@ -46,7 +46,7 @@ module.exports = class DownloadTachyonPackageCommand extends CLICommandBase {
 		}
 		const manager = new DownloadManager(this.ui);
 		const manifest = await manager.fetchManifest({ version });
-		const build = manifest.builds.find((b) => b.region === region && b.variant === variant);
+		const build = manifest.builds.find((b) => b.region === region && b.variant === variant && b.board === board);
 		if (!build) {
 			throw new Error(`No build available for region: ${region}`);
 		}
@@ -58,7 +58,7 @@ module.exports = class DownloadTachyonPackageCommand extends CLICommandBase {
 		return filePath;
 	}
 
-	async cleanUp({ region, version, all }) {
+	async cleanUp({ region, version, variant = 'headless', board ='formfactor', all }) {
 		const manager = new DownloadManager(this.ui);
 		if (all) {
 			await manager.cleanup({ cleanDownload: true, cleanInProgress: true });
@@ -71,7 +71,7 @@ module.exports = class DownloadTachyonPackageCommand extends CLICommandBase {
 				version = await this._selectVersion();
 			}
 			const manifest = await manager.fetchManifest({ version });
-			const build = manifest.builds.find((b) => b.region === region);
+			const build = manifest.builds.find((b) => b.region === region && b.variant === variant && b.board === board);
 			if (!build) {
 				throw new Error(`No build available for region: ${region}`);
 			}

--- a/src/cmd/download-tachyon-package.js
+++ b/src/cmd/download-tachyon-package.js
@@ -48,7 +48,7 @@ module.exports = class DownloadTachyonPackageCommand extends CLICommandBase {
 		const manifest = await manager.fetchManifest({ version });
 		const build = manifest.builds.find((b) => b.region === region && b.variant === variant && b.board === board);
 		if (!build) {
-			throw new Error(`No build available for region: ${region}`);
+			throw new Error('No build available for the provided parameters');
 		}
 		const { artifact_url: url, sha256_checksum: expectedChecksum } = build.artifacts[0];
 		const outputFileName = url.replace(/.*\//, '');
@@ -73,7 +73,7 @@ module.exports = class DownloadTachyonPackageCommand extends CLICommandBase {
 			const manifest = await manager.fetchManifest({ version });
 			const build = manifest.builds.find((b) => b.region === region && b.variant === variant && b.board === board);
 			if (!build) {
-				throw new Error(`No build available for region: ${region}`);
+				throw new Error('No build available for the provided parameters');
 			}
 			const { artifact_url: url } = build.artifacts[0];
 			const outputFileName = url.replace(/.*\//, '');

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -29,7 +29,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		this._formatAndDisplaySteps = this._formatAndDisplaySteps.bind(this);
 	}
 
-	async setup({ skip_flashing_os: skipFlashingOs, region = 'NA', version = 'latest', timezone, load_config: loadConfig, save_config: saveConfig, variant = 'headless' } = {}) {
+	async setup({ skip_flashing_os: skipFlashingOs, region = 'NA', version = 'latest', timezone, load_config: loadConfig, save_config: saveConfig, variant = 'headless', board = 'formfactor' } = {}) {
 		try {
 			const loadedFromFile = !!loadConfig;
 			this._showWelcomeMessage();
@@ -77,7 +77,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
         `if it's interrupted. If you have to kill the CLI, it will pick up where it left. You can also${os.EOL}` +
         "just let it run in the background. We'll wait for you to be ready when its time to flash the device.",
 				4,
-				() => this._download({ region, version, alwaysCleanCache, variant })
+				() => this._download({ region, version, alwaysCleanCache, variant, board })
 			);
 
 			const registrationCode = await this._runStepWithTiming(
@@ -358,7 +358,7 @@ Welcome to the Particle Tachyon setup! This interactive command:
 		return { systemPassword, wifi, sshPublicKey };
 	}
 
-	async _download({ region, version, alwaysCleanCache, variant }) {
+	async _download({ region, version, alwaysCleanCache, variant, board }) {
 		//before downloading a file, we need to check if 'version' is a local file or directory
 		//if it is a local file or directory, we need to return the path to the file
 		if (fs.existsSync(version)) {
@@ -367,9 +367,9 @@ Welcome to the Particle Tachyon setup! This interactive command:
 
 		const manager = new DownloadManager(this.ui);
 		const manifest = await manager.fetchManifest({ version });
-		const build = manifest?.builds.find(build => build.region === region && build.variant === variant);
+		const build = manifest?.builds.find(build => build.region === region && build.variant === variant && build.board === board);
 		if (!build) {
-			throw new Error('No builds available for the selected region or variant');
+			throw new Error('No builds available for the selected region, variant or board');
 		}
 		const artifact = build.artifacts[0];
 		const url = artifact.artifact_url;

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -369,7 +369,7 @@ Welcome to the Particle Tachyon setup! This interactive command:
 		const manifest = await manager.fetchManifest({ version });
 		const build = manifest?.builds.find(build => build.region === region && build.variant === variant && build.board === board);
 		if (!build) {
-			throw new Error('No builds available for the selected region, variant or board');
+			throw new Error('No build available for the provided parameters');
 		}
 		const artifact = build.artifacts[0];
 		const url = artifact.artifact_url;


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
Add `--board` flag in setup command by default `formfactor`

<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
* Attempt to run tachyon setup with variant flag: `npm start -- tachyon setup --board formfactor`
* Attempt to run tachyon setup with a nonexistent variant: `npm start --tachyon setup --board foo`
* Attempt to run tachyon setup without variant flag: `npm start --tachyon setup`

**outcome**
1. With an existent `board`, the download step will download the correct package
2. With a nonexistent `board`, the download step will fail with: `No builds available for the selected region, variant or board`
3. Without  a`board`, the download step will download the package with the headless variant


<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/133923
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

