### PR TITLE
add blueprintDir as option on every command and save the config on ev…

### DIFF
--- a/src/cli/app.js
+++ b/src/cli/app.js
@@ -2,10 +2,14 @@ module.exports = ({ commandProcessor, root }) => {
 	const app = commandProcessor.createCategory(root, 'app', 'Manage Edge applications');
 
 	commandProcessor.createCommand(app, 'run', 'Run a Edge application on the local machine', {
-		params: '[blueprintDir]',
+		options: {
+			'blueprintDir': {
+				description: 'The directory containing the Edge application'
+			}
+		},
 		handler: (args) => {
 			const AppCommand = require('../cmd/app');
-			return new AppCommand().run(args.params);
+			return new AppCommand().run({ ...args.params, blueprintDir: args.blueprintDir });
 		},
 		examples: {
 			'$0 $command my_tachyon': 'Build and push the Edge application in the current directory for the device my_tachyon'
@@ -13,18 +17,20 @@ module.exports = ({ commandProcessor, root }) => {
 	});
 
 	commandProcessor.createCommand(app, 'push', 'Build and push an Edge application to a product or device', {
-		params: '[blueprintDir]',
 		options: {
 			'device': {
 				description: 'The device to push to'
 			},
 			'instance': {
 				description: 'The application instance to push'
+			},
+			'blueprintDir': {
+				description: 'The directory containing the Edge application'
 			}
 		},
 		handler: (args) => {
 			const AppCommand = require('../cmd/app');
-			return new AppCommand().push({ ...args.params, deviceId: args.device, instance: args.instance });
+			return new AppCommand().push({ ...args.params, blueprintDir: args.blueprintDir, deviceId: args.device, instance: args.instance });
 		},
 		examples: {
 			'$0 $command my_tachyon': 'Build and push the Edge application in the current directory for the device my_tachyon'
@@ -35,11 +41,14 @@ module.exports = ({ commandProcessor, root }) => {
 		options: {
 			'device': {
 				description: 'The device to list from'
+			},
+			'blueprintDir': {
+				description: 'The directory containing the Edge application'
 			}
 		},
 		handler: (args) => {
 			const AppCommand = require('../cmd/app');
-			return new AppCommand().list({ ...args.params, deviceId: args.device });
+			return new AppCommand().list({ ...args.params, blueprintDir: args.blueprintDir, deviceId: args.device });
 		},
 		examples: {
 			'$0 $command': 'List Edge applications'
@@ -53,11 +62,14 @@ module.exports = ({ commandProcessor, root }) => {
 			},
 			'instance': {
 				description: 'The application instance to remove'
+			},
+			'blueprintDir': {
+				description: 'The directory containing the Edge application'
 			}
 		},
 		handler: (args) => {
 			const AppCommand = require('../cmd/app');
-			return new AppCommand().remove({ deviceId: args.device, appInstance: args.instance });
+			return new AppCommand().remove({ deviceId: args.device, appInstance: args.instance, blueprintDir: args.blueprintDir });
 		},
 		examples: {
 			'$0 $command --instance hello-world_12345': 'Remove this Edge application'

--- a/src/cmd/app.js
+++ b/src/cmd/app.js
@@ -277,11 +277,14 @@ module.exports = class AppCommands extends CLICommandBase {
 		}
 	}
 
-	async list({ deviceId }) {
-		const doc = await this._loadFromEnv('.');
+	async list({ deviceId, blueprintDir = '.' }) {
+		const doc = await this._loadFromEnv(blueprintDir);
 		deviceId ||= doc.get('deviceId');
 		const device = await this._getDevice(deviceId);
 		deviceId = device.id;
+
+		doc.set('deviceId', deviceId);
+		await this._saveToEnv(doc, blueprintDir);
 
 		try {
 			const { data: deviceDoc } = await this.api.getDocument({
@@ -341,16 +344,17 @@ module.exports = class AppCommands extends CLICommandBase {
 		}
 	}
 
-	async remove({ deviceId, appInstance }) {
+	async remove({ deviceId, appInstance, blueprintDir = '.' }) {
 		if (!appInstance) {
 			throw new Error('Application instance is required.');
-
 		}
 
-		const doc = await this._loadFromEnv('.');
+		const doc = await this._loadFromEnv(blueprintDir);
 		deviceId ||= doc.get('deviceId');
 		const device = await this._getDevice(deviceId);
 		deviceId = device.id;
+		doc.set('deviceId', deviceId);
+		await this._saveToEnv(doc, blueprintDir);
 
 		try {
 			const { data: deviceDoc } = await this.api.getDocument({


### PR DESCRIPTION
## Description
Add `buildDir` option to every `app` command
Store deviceId to  `.particle_env.yaml` as we do for push in: `list` and `remove` commands
`run` command doesn't need to be stored since is for local purposes.


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/133959/issues-on-app-commands

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [ ] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [ ] Problem and solution clearly stated
- [ ] Tests have been provided
- [ ] Docs have been updated
- [ ] CI is passing

