### PR TITLE
Add apiServer, server, and verbose to tachyon bootstrap config flash

### DIFF
--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -81,6 +81,11 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			config.variant = await this._pickVariantStep(config); // step 4
 		}
 
+		const isStaging = settings.apiUrl.includes('staging');
+		config.apiServer = settings.apiUrl;
+		config.server = isStaging ? 'https://host-connect.staging.particle.io': 'https://host-connect.particle.io';
+		config.verbose = isStaging; // Extra logging if connected to staging
+
 		config.packagePath = await this._downloadStep(config); // step 5
 		config.registrationCode = await this._registerDeviceStep(config); // step 6
 		const { xmlPath } = await this._configureConfigAndSaveStep(config); // step 7


### PR DESCRIPTION
* apiServer is based on the configured api URL in your particle config
* server is the websocket server, set based on whether "staging" is in the api URL above
* verbose logging in particle-linux is set to true if we are in staging