### PR TITLE
add skip-reset flag to prevent the device boot after flashing

### DIFF
--- a/src/cli/flash.js
+++ b/src/cli/flash.js
@@ -42,6 +42,10 @@ module.exports = ({ commandProcessor, root }) => {
 				boolean: true,
 				description: 'Flash Tachyon'
 			},
+			'skip-reset': {
+				boolean: true,
+				description: 'Skip resetting the device after flashing. Only available for Tachyon'
+			},
 			'output': {
 				describe: 'Folder to output the log file. Only available for Tachyon'
 			},

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -47,6 +47,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 		yes,
 		tachyon,
 		output,
+		'skip-reset': skipReset,
 		'application-only': applicationOnly
 	}) {
 		if (!tachyon && !device && !binary && !local) {
@@ -65,7 +66,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 			await this.flashLocal({ files: allFiles, applicationOnly, target });
 		} else if (tachyon) {
 			let allFiles = binary ? [binary, ...files] : files;
-			await this.flashTachyon({ files: allFiles, output });
+			await this.flashTachyon({ files: allFiles, skipReset, output });
 		} else {
 			await this.flashCloud({ device, files, target });
 		}


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
Add a new flag to prevent the device boot after flash is completed
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->




## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/134175/prevent-device-boot-after-flashing-in-flash-firmware-station
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

