### PR TITLE
Avoid background update when running update-cli

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,9 @@ module.exports = {
 	},
 	rules: {
 		'no-console': 'off',
-		'valid-jsdoc': 'off'
+		'valid-jsdoc': 'off',
+		'max-depth': ['warn', 5],
+		'max-statements': ['warn', 40]
 	}
 };
 

--- a/src/app/cli.js
+++ b/src/app/cli.js
@@ -167,12 +167,14 @@ module.exports = class CLI {
 	async run(args){
 		settings.whichProfile();
 		settings.loadOverrides();
-		settings.disableUpdateCheck = this.hasArg('--no-update-check', args);
+		if (this.hasArg('--no-update-check', args)) {
+			settings.disableUpdateCheck = true;
+		}
 		const force = this.hasArg('--force-update-check', args);
 
 		try {
-			await updateCheck(settings.disableUpdateCheck, force);
 			const cmdargs = args.slice(2); // remove executable and script
+			await updateCheck(settings.disableUpdateCheck, force, cmdargs[0]);
 			return await this.runCommand(cmdargs);
 		} catch (error){
 			const onError = commandProcessor.createErrorHandler();

--- a/src/app/update-check.js
+++ b/src/app/update-check.js
@@ -2,17 +2,14 @@ const settings = require('../../settings');
 const childProcess = require('node:child_process');
 
 
-module.exports = async (skip, force) => {
-	if (skip) {
-		return;
-	}
+module.exports = async (skip, force, command) => {
 	if (!process.pkg) { // running from source
 		return;
 	}
 
 	const now = Date.now();
 	const lastCheck = settings.profile_json.last_version_check || 0;
-	const skipUpdates = !!(settings.profile_json.enableUpdates === false || settings.disableUpdateCheck);
+	const skipUpdates = !!(settings.profile_json.enableUpdates === false || skip || command === 'update-cli');
 
 	if ((now - lastCheck >= settings.updateCheckInterval) || force){
 		settings.profile_json.last_version_check = now;

--- a/src/app/update-check.test.js
+++ b/src/app/update-check.test.js
@@ -69,12 +69,28 @@ describe('Update Check', () => {
 		expect(childProcess.spawn).to.have.property('callCount', 0);
 	});
 
-	it('Does nothing when `skip` flag is set', async () => {
+	it('just saves the last update time when `skip` flag is set', async () => {
 		const skip = true;
+		const lastCheck = settings.profile_json.last_version_check;
+
 		const result = await updateCheck(skip);
 
 		expect(result).to.equal(undefined);
-		expect(settings.saveProfileData).to.have.property('callCount', 0);
+		expect(settings.saveProfileData).to.have.property('callCount', 1);
+		expect(settings.profile_json.last_version_check).to.be.at.least(lastCheck);
+		expect(settings.profile_json).to.not.have.property('newer_version');
+		expect(childProcess.spawn).to.have.property('callCount', 0);
+	});
+
+	it('just saves the last update time when the command is `update-cli`', async () => {
+		const lastCheck = settings.profile_json.last_version_check;
+
+		const result = await updateCheck(false, false, 'update-cli');
+
+		expect(result).to.equal(undefined);
+		expect(settings.saveProfileData).to.have.property('callCount', 1);
+		expect(settings.profile_json.last_version_check).to.be.at.least(lastCheck);
+		expect(settings.profile_json).to.not.have.property('newer_version');
 		expect(childProcess.spawn).to.have.property('callCount', 0);
 	});
 

--- a/src/cmd/esim.js
+++ b/src/cmd/esim.js
@@ -126,6 +126,7 @@ module.exports = class ESimCommands extends CLICommandBase {
 		}
 	}
 
+	/* eslint-disable max-statements, max-depth */
 	async doProvision(device) {
 		let provisionOutputLogs = [];
 		let eid = null;
@@ -298,6 +299,7 @@ module.exports = class ESimCommands extends CLICommandBase {
 			this._exitQlril();
 		}
 	}
+	/* eslint-enable max-statements, max-depth */
 
 	async doEnableTachyon(iccid) {
 		try {

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -54,7 +54,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			variant: null,
 			skipFlashingOs: false,
 			skipCli: false,
-			timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+			timezone: Intl.DateTimeFormat().resolvedOptions().timeZone, // eslint-disable-line new-cap
 			alwaysCleanCache: false
 		};
 		this.options = {};

--- a/src/cmd/update-cli.js
+++ b/src/cmd/update-cli.js
@@ -12,10 +12,8 @@ const Spinner = require('cli-spinner').Spinner;
 const crypto = require('crypto');
 
 /*
- * The update-cli command tells the CLI installer to reinstall the latest version of the CLI
- * See https://github.com/particle-iot/particle-cli-wrapper/blob/master/shell.go#L12
- *
- * If the CLI was installed using npm, tell the user to update using npm
+ * The update-cli command updates the latest single executable version of the CLI.
+ * If the CLI is not running the single executable version, recommend using the installer.
  */
 class UpdateCliCommand {
 	update({ 'enable-updates': enableUpdates, 'disable-updates': disableUpdates, version }) {


### PR DESCRIPTION
Running `particle update-cli` can trigger a background run of `particle update-cli` which leads to a race condition between the 2 update processes.

Rework the background update check to skip an update when running `particle update-cli`.