### PR TITLE
add esim profiles as used in cache if they have an eid mismatch

### DIFF
--- a/src/cmd/esim.js
+++ b/src/cmd/esim.js
@@ -797,6 +797,13 @@ module.exports = class ESimCommands extends CLICommandBase {
 			} catch (error) {
 				const timeTaken = ((Date.now() - startTime) / 1000).toFixed(2);
 				logAndPush(`\n\tProfile download failed for ${provider} with error: ${error.message}`);
+				if (error.message.includes('The EID is not the same between reservation and request')) {
+					// add the profile to the cache to settled as used
+					const provisionedProfiles = this.cache.get(this.cacheKey) || [];
+					// TODO (hmontero): currently we add all the profiles to the cache if they belong to the same set (change it to add only the failed one)
+					provisionedProfiles.push(profiles);
+					this.cache.set(this.cacheKey, provisionedProfiles);
+				}
 				downloadedProfiles.push({
 					status: 'failed',
 					iccid: iccid,

--- a/src/cmd/esim.js
+++ b/src/cmd/esim.js
@@ -845,6 +845,8 @@ module.exports = class ESimCommands extends CLICommandBase {
 		} catch (error) {
 			if (error.message.includes(LPA_PROFILE_ENABLE_ERROR)) {
 				res.details.rawLogs.push(`Profile already enabled: ${iccid}`);
+				// if the profile is already enabled, we can consider it a success
+				res.status = 'success';
 				return res;
 			}
 			throw error;


### PR DESCRIPTION
## Description
Fix issues when:
The device has already an enabled profile (don't fail)
The EID mismatch with the expected by the esim vendor (the profile is already attached to a device) -> Fail but remove the profile from cache
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->

## How to Test
I was able to test just the enabled profile.
### Before changes
Device led stuck in red
![image](https://github.com/user-attachments/assets/af944665-8748-4909-9a8d-6d8cbd9a1a79)

### After changes
Devices led is green
![image](https://github.com/user-attachments/assets/15504020-2563-4831-a6b8-5422d402e5dd)




<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: 
https://app.shortcut.com/particle/story/134368/fix-enable-profile-logic-when-profile-is-already-active
https://app.shortcut.com/particle/story/134369/handle-eid-mismatch-during-download-profile-step
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

