### PR TITLE
change modem data identify property in favor of manufacturing data

### DIFF
--- a/src/cmd/identify-tachyon.js
+++ b/src/cmd/identify-tachyon.js
@@ -28,10 +28,10 @@ module.exports = class IdentifyTachyonCommand extends CLICommandBase {
 		}
 	}
 
-	printIdentification({ deviceId, region, modemData, osVersion }) {
+	printIdentification({ deviceId, region, manufacturingData, osVersion }) {
 		this.ui.stdout.write(`Device ID: ${deviceId}${os.EOL}`);
 		this.ui.stdout.write(`Region: ${region}${os.EOL}`);
-		this.ui.stdout.write(`Modem data: ${modemData}${os.EOL}`);
+		this.ui.stdout.write(`Manufacturing data: ${manufacturingData}${os.EOL}`);
 		this.ui.stdout.write(`OS Version: ${osVersion}${os.EOL}`);
 	}
 };

--- a/src/lib/tachyon-utils.js
+++ b/src/lib/tachyon-utils.js
@@ -248,11 +248,11 @@ async function getIdentification({ deviceId, partitionTable, partitionFilenames 
 	}
 
 	const modemDataValid = fsgBuffer.includes(EFS_PARTITION_HEADER);
-	let modemDataString;
+	let manufacturingDataString;
 	if (modemDataValid) {
-		modemDataString = 'Present';
+		manufacturingDataString = 'Found';
 	} else {
-		modemDataString = 'Erased';
+		manufacturingDataString = 'Missing';
 	}
 
 	const nvdataLun = partitionTable.find(({ partition }) => partition.name === 'nvdata1')?.lun;
@@ -268,7 +268,7 @@ async function getIdentification({ deviceId, partitionTable, partitionFilenames 
 	return {
 		deviceId,
 		region: regionString,
-		modemData: modemDataString,
+		manufacturingData: manufacturingDataString,
 		osVersion
 	};
 }


### PR DESCRIPTION

## Description
Change modem data to Manufacturing data since is more accurate.


## How to Test
* Run tachyon identify command: `npm start -- tachyon identify`

**outcome**
Should return the tachyon info with `Manufacturing data` "Found" or "Missing" depending the case, e.g: 
```
Device ID: 422a060000000000f70d57f7
Region: NA
Manufacturing data: Found
OS Version: Ubuntu 20.04 EVT
```


## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

