### PR TITLE
add deviceId to registration code

### DIFF
--- a/src/cmd/api.js
+++ b/src/cmd/api.js
@@ -241,11 +241,12 @@ module.exports = class ParticleApi {
 		);
 	}
 
-	getRegistrationCode(productId) {
+	getRegistrationCode({ productId, deviceId }) {
 		return this._wrap(
 			this.api.post({
 				uri: `/v1/products/${productId}/registration_code`,
-				auth: this.accessToken
+				auth: this.accessToken,
+				data: { device_id: deviceId }
 			})
 		);
 	}

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -639,10 +639,9 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		return manager.download({ url, outputFileName, expectedChecksum, options: { alwaysCleanCache } });
 	}
 
-	async _getRegistrationCode(product) {
-		// add device id to the product
-		await this._assignDeviceToProduct({ productId:product, deviceId: this.deviceId });
-		const data = await this.api.getRegistrationCode(product);
+	async _getRegistrationCode(productId) {
+		await this._assignDeviceToProduct({ productId: productId, deviceId: this.deviceId });
+		const data = await this.api.getRegistrationCode({ productId, deviceId: this.deviceId });
 		return data.registration_code;
 	}
 


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
Send deviceId when registering a new linux device. That will be required to get data to connect with the cloud
<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
* Attempt to setup a tachyon device
<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
https://app.shortcut.com/particle/story/134502/change-cli-tachyon-setup-for-esim-implementation
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

