### PR TITLE
Change logs folder for tachyon commands

### DIFF
--- a/src/cmd/backup-restore-tachyon.js
+++ b/src/cmd/backup-restore-tachyon.js
@@ -9,6 +9,7 @@ const {
 	addLogFooter,
 	prepareFlashFiles
 } = require('../lib/tachyon-utils');
+const settings = require('../../settings');
 
 const PARTITIONS_TO_BACKUP = ['nvdata1', 'nvdata2', 'fsc', 'fsg', 'modemst1', 'modemst2'];
 
@@ -16,9 +17,11 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 	constructor({ ui } = {}) {
 		super();
 		this.ui = ui || this.ui;
+		this._baseDir = settings.ensureFolder();
+		this._logsDir = path.join(this._baseDir, 'logs');
 	}
 
-	async backup({ 'output-dir': outputDir = process.cwd(), 'log-dir': logDir = process.cwd() } = {}) {
+	async backup({ 'output-dir': outputDir = process.cwd(), 'log-dir': logDir = this._logsDir } = {}) {
 		const { id: deviceId } = await getEDLDevice({ ui: this.ui });
 		const outputDirExist = await fs.exists(outputDir);
 		const logDirExist = await fs.exists(logDir);
@@ -69,7 +72,7 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 
 	async restore({
 		'input-dir': inputDir = process.cwd(),
-		'log-dir': logDir = process.cwd(),
+		'log-dir': logDir = this._logsDir,
 	} = {})	{
 		const { id: deviceId } = await getEDLDevice({ ui: this.ui });
 		if (!await fs.exists(logDir)) {

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -174,8 +174,10 @@ module.exports = class FlashCommand extends CLICommandBase {
 			}
 			return output;
 		}
-
-		const defaultLogFile = path.join(process.cwd(), `tachyon_flash_${Date.now()}.log`);
+		const particleDir = settings.ensureFolder();
+		const logsDir = path.join(particleDir, 'logs');
+		await fs.ensureDir(logsDir);
+		const defaultLogFile = path.join(logsDir, `tachyon_flash_${Date.now()}.log`);
 		await fs.ensureFile(defaultLogFile);
 		return defaultLogFile;
 	}

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -50,6 +50,9 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		this._setupApi();
 		this.ui = ui || this.ui;
 		this.deviceId = null;
+		this._baseDir = settings.ensureFolder();
+		this._logsDir = path.join(this._baseDir, 'logs');
+
 		this.outputLog = null;
 		this.defaultOptions = {
 			region: 'NA',
@@ -65,7 +68,6 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		this.options = {};
 	}
 
-
 	async setup({ skip_flashing_os: skipFlashingOs, timezone, load_config: loadConfig, save_config: saveConfig, region, version, variant, board, skip_cli: skipCli } = {}) {
 		const requiredFields = ['region', 'version', 'systemPassword', 'productId', 'timezone'];
 		const options = { skipFlashingOs, timezone, loadConfig, saveConfig, region, version, variant, board, skipCli };
@@ -78,7 +80,9 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		const { deviceId, usbVersion } = await this._verifyDeviceInEDLMode();
 		this.deviceId = deviceId;
 		this.usbVersion = usbVersion;
-		this.outputLog = path.join(process.cwd(), `tachyon_flash_${this.deviceId}_${Date.now()}.log`);
+		// ensure logs dir
+		await fs.ensureDir(this._logsDir);
+		this.outputLog = path.join(this._logsDir, `tachyon_flash_${this.deviceId}_${Date.now()}.log`);
 		await fs.ensureFile(this.outputLog);
 		this.ui.write(`${os.EOL}Starting Process. See logs at: ${this.outputLog}${os.EOL}`);
 		const deviceInfo = await this._getDeviceInfo();


### PR DESCRIPTION
## Description
Change default logs directory to ~/.particle/logs for:
* `particle tachyon setup`
* `particle flash --tachyon`
* `particle tachyon backup`
* `particle tachyon restore`


<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
Go thru the follow commands:
* tachyon setup: `npm start -- tachyon setup`
* tachyon flash: `npm start -- flash --tachyon`
* tachyon backup: `npm start -- tachyon backup`
* tachyon restore: `npm start -- tachyon restore`


**outcome**
* Default logs should be placed on ~/.particle/logs

<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/134663/update-logs-dir-on-tachyon-commands
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

