### PR TITLE
Chore/change tachyon meta url

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -44,7 +44,7 @@ let settings = {
 		'tinker': true
 	},
 
-	tachyonMeta: 'https://tachyon-ci.particle.io/meta',
+	tachyonMeta: 'https://linux-dist.particle.io/meta',
 	tachyonCacheLimitGB: 10
 };
 

--- a/src/cmd/app.js
+++ b/src/cmd/app.js
@@ -15,7 +15,7 @@ const { platformForId } = require('../lib/platform');
 
 const _ = require('lodash');
 
-const DOCKER_CONFIG_URL = 'https://tachyon-ci.particle.io/alpha-assets/2ea71ce0afce170affb38d162a1e3460.json';
+const DOCKER_CONFIG_URL = 'https://linux-dist.particle.io/alpha-assets/2ea71ce0afce170affb38d162a1e3460.json';
 const PARTICLE_ENV_FILE = '.particle_env.yaml';
 
 module.exports = class AppCommands extends CLICommandBase {

--- a/src/lib/download-manager.js
+++ b/src/lib/download-manager.js
@@ -33,7 +33,7 @@ class DownloadManager {
 		}
 	}
 
-	async fetchManifest({ version = 'latest', isRb3Board = false }) {
+	async fetchManifest({ version = 'stable', isRb3Board = false }) {
 		const type = isRb3Board ? 'rb3g2' : 'tachyon';
 		const metadataUrl = `${settings.tachyonMeta}/${type}-${encodeURIComponent(version)}.json`;
 


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
* Update tachyon default version to `stable`
* Change urls in favor of the new domain `https://linux-dist.particle.io/`

<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
* Attempt to download the default version of tachyon OS
* 
<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/134909/update-particle-cli-to-use-the-stable-channel-for-tachyon-software-installs
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

