### PR TITLE
make dvt default on download, ask for variant and fix rb3 download

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -92,7 +92,7 @@ jobs:
           name: not_signed
           path: build/
       - name: Sign Windows Executable
-        uses: azure/trusted-signing-action@v0.5.0
+        uses: azure/trusted-signing-action@v0
         with:
           azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -615,12 +615,23 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		if (!build) {
 			throw new Error('No build available for the provided parameters');
 		}
+
 		const artifact = build.artifacts[0];
+		this._printOSInfo(build);
 		const url = artifact.artifact_url;
 		const outputFileName = url.replace(/.*\//, '');
 		const expectedChecksum = artifact.sha256_checksum;
 
 		return manager.download({ url, outputFileName, expectedChecksum, options: { alwaysCleanCache } });
+	}
+
+	_printOSInfo(build) {
+		const { distribution, variant, distribution_version: distributionVersion, version, region, board } = build;
+		const boardType = board.includes('dvt') ? 'DVT' : 'EVT';
+		this.ui.write(this.ui.chalk.bold('Operating system information:'));
+		this.ui.write(this.ui.chalk.bold(`Tachyon ${distribution} ${distributionVersion} (${variant}, ${region} region)`));
+		this.ui.write(`${this.ui.chalk.bold('Version:')} ${version}`);
+		this.ui.write(`${this.ui.chalk.bold('Board:')} ${boardType}`);
 	}
 
 	async _getRegistrationCode(productId) {

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -626,12 +626,10 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 	}
 
 	_printOSInfo(build) {
-		const { distribution, variant, distribution_version: distributionVersion, version, region, board } = build;
-		const boardType = board.includes('dvt') ? 'DVT' : 'EVT';
+		const { distribution, variant, distribution_version: distributionVersion, version, region } = build;
 		this.ui.write(this.ui.chalk.bold('Operating system information:'));
 		this.ui.write(this.ui.chalk.bold(`Tachyon ${distribution} ${distributionVersion} (${variant}, ${region} region)`));
 		this.ui.write(`${this.ui.chalk.bold('Version:')} ${version}`);
-		this.ui.write(`${this.ui.chalk.bold('Board:')} ${boardType}`);
 	}
 
 	async _getRegistrationCode(productId) {


### PR DESCRIPTION
## Description
* Add `dvt` as default for download-package command
* Print out OS information on tachyon setup (that would help to debug in case of issues)
* Update sign artifact to use always the latest.

<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
* Try to download a tachyon OS by using `tachyon download-package` command
* Set up your tachyon device


**outcome**
`download-package` command
* By default dvt board will be settled
* You'll be able to pick a variant (desktop/headless) according your board

`tachyon setup` command
* On download step you'll see the OS information that is about to be installed in your device e.g. 👇 

<img width="897" height="235" alt="image" src="https://github.com/user-attachments/assets/c2b4530b-c404-4f34-a808-aafd21429ae7" />


<img width="879" height="190" alt="image" src="https://github.com/user-attachments/assets/25af8f45-e42a-4f63-aff1-1a640990c377" />


## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

