### PR TITLE
Feature/sc 135100/don t delete the file in case doesn t match and

### DIFF
--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -627,6 +627,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 
 	_printOSInfo(build) {
 		const { distribution, variant, distribution_version: distributionVersion, version, region } = build;
+		this.ui.write(os.EOL);
 		this.ui.write(this.ui.chalk.bold('Operating system information:'));
 		this.ui.write(this.ui.chalk.bold(`Tachyon ${distribution} ${distributionVersion} (${variant}, ${region} region)`));
 		this.ui.write(`${this.ui.chalk.bold('Version:')} ${version}`);

--- a/src/lib/download-manager.js
+++ b/src/lib/download-manager.js
@@ -88,12 +88,13 @@ class DownloadManager {
 
 	async _handleInvalidChecksum({ error, filePath, displayName, retryCallback }) {
 		this.ui.write(`${os.EOL}`); // Optional: visual break in terminal
+		this.ui.write(`Invalid checksum for ${displayName}`);
 
 		if (this.ui.isInteractive) {
 			const { removeFile } = await this.ui.prompt({
 				type: 'confirm',
 				name: 'removeFile',
-				message: `Invalid checksum for ${displayName}. Remove and retry?`,
+				message: 'Remove and retry?',
 				default: true
 			});
 
@@ -104,7 +105,7 @@ class DownloadManager {
 			}
 		}
 
-		this.ui.write(`Make sure to manually delete "${displayName}" before trying again`);
+		this.ui.write(`Make sure to manually delete "${filePath}" before trying again`);
 		throw error;
 	}
 

--- a/src/lib/download-manager.js
+++ b/src/lib/download-manager.js
@@ -71,30 +71,41 @@ class DownloadManager {
 				await this._validateChecksum(filePath, expectedChecksum);
 			}
 		} catch (error) {
-			// Remove the invalid file
-			// ask if we should remove it
-			let shouldRetry = false;
-			if (this.ui.isInteractive) {
-				const question = {
-					type: 'confirm',
-					name: 'removeFile',
-					message: `Do you want to remove the invalid downloaded file ${outputFileName}? and retry?`,
-					default: true
-				};
-				const { removeFile } = await this.ui.prompt(question);
-				if (removeFile) {
-					await fs.remove(filePath);
-					this.ui.write(`Removed invalid downloaded file: ${outputFileName}`);
-					shouldRetry = true;
-				}
-			}
-			if (shouldRetry) {
-				return this.download({ url, outputFileName, expectedChecksum, options });
-			}
-			this.ui.write(`Make sure to manually delete "${outputFileName}" before trying again `);
-			throw error;
+			await this._handleInvalidChecksum({
+				error,
+				filePath,
+				displayName: outputFileName,
+				retryCallback: () => this.download({
+					url,
+					outputFileName,
+					expectedChecksum,
+					options
+				})
+			});
 		}
 		return filePath;
+	}
+
+	async _handleInvalidChecksum({ error, filePath, displayName, retryCallback }) {
+		this.ui.write(`${os.EOL}`); // Optional: visual break in terminal
+
+		if (this.ui.isInteractive) {
+			const { removeFile } = await this.ui.prompt({
+				type: 'confirm',
+				name: 'removeFile',
+				message: `Invalid checksum for ${displayName}. Remove and retry?`,
+				default: true
+			});
+
+			if (removeFile) {
+				await fs.remove(filePath);
+				this.ui.write(`Removed invalid downloaded file: ${displayName}`);
+				return retryCallback?.();
+			}
+		}
+
+		this.ui.write(`Make sure to manually delete "${displayName}" before trying again`);
+		throw error;
 	}
 
 
@@ -254,9 +265,11 @@ class DownloadManager {
 					await this._validateChecksum(cachedFilePath, expectedChecksum);
 					return cachedFilePath;
 				} catch (error) {
-					this.ui.write(`Cached file checksum mismatch for ${fileName}`);
-					await fs.remove(cachedFilePath); // Remove the invalid cached file
-					this.ui.write(`Removed invalid cached file: ${fileName}`);
+					await this._handleInvalidChecksum({
+						error: error,
+						filePath: cachedFilePath,
+						displayName: fileName
+					});
 				}
 			}
 		}

--- a/src/lib/download-manager.test.js
+++ b/src/lib/download-manager.test.js
@@ -162,6 +162,7 @@ describe('DownloadManager', () => {
 			const url = 'https://example.com';
 			const outputFileName = 'file.txt';
 			const fileContent = 'This is a test file.';
+			const filePath = path.join(downloadManager.downloadDir, `${outputFileName}`);
 			let error;
 
 			// Mock the HTTP response
@@ -178,7 +179,8 @@ describe('DownloadManager', () => {
 				error = _error;
 			}
 			expect(error.message).to.include('Checksum validation failed for file.txt');
-			expect(ui.write).to.be.calledWith('Make sure to manually delete "file.txt" before trying again');
+			expect(ui.write).to.be.calledWith('Invalid checksum for file.txt');
+			expect(ui.write).to.be.calledWith(`Make sure to manually delete "${filePath}" before trying again`);
 		});
 		it('validates checksum and save the file', async () => {
 			const url = 'https://example.com';

--- a/src/lib/download-manager.test.js
+++ b/src/lib/download-manager.test.js
@@ -177,11 +177,8 @@ describe('DownloadManager', () => {
 			} catch (_error) {
 				error = _error;
 			}
-			const tempPath = path.join(downloadManager.downloadDir, `${outputFileName}.progress`);
-			const finalPath = path.join(downloadManager.downloadDir, `${outputFileName}`);
 			expect(error.message).to.include('Checksum validation failed for file.txt');
-			expect(fs.existsSync(tempPath)).to.be.false;
-			expect(fs.existsSync(finalPath)).to.be.false;
+			expect(ui.write).to.be.calledWith('Make sure to manually delete "file.txt" before trying again');
 		});
 		it('validates checksum and save the file', async () => {
 			const url = 'https://example.com';


### PR DESCRIPTION
## Description
Allow to retry after checksum failure. Confirm with the users if they want to remove the unmatched file or remove it manually.
In case of manual removal it will throw checksum mismatch error.


## How to Test
* Copy an old version of a OS with the name of the stable OS version: `cp tachyon-ubuntu-20.04-NA-desktop-formfactor_dvt-1.0.159.zip tachyon-ubuntu-20.04-NA-desktop-formfactor_dvt-1.0.161.zip`
* Attempt to setup your device with the stable version

**outcome**
* since you are using a different OS, the checksum should fail. 
* It will ask you to remove the wrong file and retry
* In case you hit 'N' it will finish the setup with an error in other case it will remove the file and redownload it again


<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/135100/don-t-delete-the-file-in-case-doesn-t-match-and-ask-the-user-for-retry
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

