### PR TITLE
Feature/tachyon flash retry

### DIFF
--- a/src/cmd/backup-restore-tachyon.js
+++ b/src/cmd/backup-restore-tachyon.js
@@ -7,7 +7,7 @@ const {
 	addLogHeaders,
 	getEDLDevice,
 	addLogFooter,
-	prepareFlashFiles
+	prepareFlashFiles, handleFlashError
 } = require('../lib/tachyon-utils');
 const settings = require('../../settings');
 
@@ -63,6 +63,14 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 			await qdl.run();
 			this.ui.stdout.write(`Backing up NV data from device ${device.id} complete!${os.EOL}`);
 		} catch (error) {
+			const { retry } = await handleFlashError({ error, ui: this.ui });
+			if (retry) {
+				return this.backup({
+					'output-dir': outputDir,
+					'log-dir': logDir,
+					existingLog: outputLog,
+				});
+			}
 			this.ui.stdout.write(`An error ocurred while trying to backing up your tachyon ${os.EOL}`);
 			this.ui.stdout.write(`Error: ${error.message} ${os.EOL}`);
 			this.ui.stdout.write(`Verify your logs ${outputLog} for more information ${os.EOL}`);
@@ -113,6 +121,14 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 			this.ui.stdout.write(`Restoring NV data to device ${device.id} complete!${os.EOL}`);
 
 		} catch (error) {
+			const { retry } = await handleFlashError({ error, ui: this.ui });
+			if (retry) {
+				return this.backup({
+					'input-dir': inputDir,
+					'log-dir': logDir,
+					existingLog: outputLog,
+				});
+			}
 			this.ui.stdout.write(`An error ocurred while trying to restore up your tachyon ${os.EOL}`);
 			this.ui.stdout.write(`Error: ${error.message} ${os.EOL}`);
 			this.ui.stdout.write(`Verify your logs ${outputLog} for more information ${os.EOL}`);

--- a/src/cmd/flash.js
+++ b/src/cmd/flash.js
@@ -76,7 +76,7 @@ module.exports = class FlashCommand extends CLICommandBase {
 	}
 
 	//returns true if successful or false if failed
-	async flashTachyon({ device, files, skipReset, output, verbose=true }) {
+	async flashTachyon({ device, files, skipReset, output, verbose=true }) { // eslint-disable-line max-statements
 		let zipFile;
 		let includeDir = '';
 		let updateFolder = '';
@@ -198,7 +198,19 @@ module.exports = class FlashCommand extends CLICommandBase {
 			// add log footer
 			addLogFooter({ outputLog: output, startTime, endTime: new Date() });
 		} catch (error) {
-			fs.appendFileSync(output, 'Download failed with error: ' + error.message);
+			// check retry here
+			if (error instanceof TachyonConnectionError) {
+				const { retry } = await this._handleConnectionError();
+				if (retry) {
+					return this.flashTachyon({
+						device,
+						files,
+						skipReset,
+						output,
+					});
+				}
+			}
+			fs.appendFileSync(output, error.message);
 			throw new Error('Download failed with error: ' + error.message);
 		}
 	}

--- a/src/cmd/identify-tachyon.js
+++ b/src/cmd/identify-tachyon.js
@@ -4,7 +4,7 @@ const os = require('os');
 
 const {
 	getEDLDevice,
-	getTachyonInfo
+	getTachyonInfo, handleFlashError
 } = require('../lib/tachyon-utils');
 
 
@@ -22,6 +22,10 @@ module.exports = class IdentifyTachyonCommand extends CLICommandBase {
 			const tachyonInfo = await getTachyonInfo({ outputLog, ui: this.ui, device });
 			this.printIdentification(tachyonInfo);
 		} catch (error) {
+			const { retry } = await handleFlashError({ error, ui: this.ui });
+			if (retry) {
+				return this.identify();
+			}
 			this.ui.stdout.write(`An error ocurred while trying to identify your tachyon ${os.EOL}`);
 			this.ui.stdout.write(`Error: ${error.message} ${os.EOL}`);
 			this.ui.stdout.write(`Verify your logs ${outputLog} for more information ${os.EOL}`);

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -15,7 +15,7 @@ const DownloadManager = require('../lib/download-manager');
 const { platformForId, PLATFORMS } = require('../lib/platform');
 const path = require('path');
 const semver = require('semver');
-const { prepareFlashFiles, getTachyonInfo, promptWifiNetworks, getEDLDevice } = require('../lib/tachyon-utils');
+const { prepareFlashFiles, getTachyonInfo, promptWifiNetworks, getEDLDevice, handleFlashError } = require('../lib/tachyon-utils');
 const { supportedCountries } = require('../lib/supported-countries');
 
 const showWelcomeMessage = (ui) => `
@@ -123,6 +123,10 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			}));
 		} catch (error) {
 			// If this fails, the flash won't work so abort early.
+			const { retry } = await handleFlashError({ error, ui: this.ui });
+			if (retry) {
+				return this._getDeviceInfo();
+			}
 			throw new Error('Unable to get device info. Please restart the device and try again.');
 		}
 	}

--- a/src/lib/qdl.js
+++ b/src/lib/qdl.js
@@ -10,6 +10,16 @@ const os = require('os');
 
 const TACHYON_STORAGE_TYPE = 'ufs';
 
+class TachyonConnectionError extends Error {
+	constructor() {
+		super();
+		this.name = TachyonConnectionError.name;
+		this.message = `Error communicating with the device.${os.EOL}` +
+			'Please power off the device completely by disconnecting the battery and USB-C cable, wait 30 seconds, ' +
+			'then reconnect the battery and USB-C.';
+	}
+}
+
 class QdlFlasher {
 	constructor({ files, includeDir, updateFolder, zip, ui, outputLogFile, skipReset=false, currTask=null, serialNumber }) {
 		this.files = files;
@@ -65,7 +75,7 @@ class QdlFlasher {
 				qdlProcess.on('close', (output) => {
 					if (output !== 0) {
 						if (this.connectinoError) {
-							return reject(new Error(this.connectionErrorMessage()));
+							return reject(new TachyonConnectionError());
 						}
 						return reject(new Error('Unable to complete device flashing. See logs for further details.'));
 					} else {
@@ -178,14 +188,8 @@ class QdlFlasher {
 			}
 		}
 	}
-
-	connectionErrorMessage() {
-		return `Error communicating with the device.${os.EOL}` +
-			'Please power off the device completely by disconnecting the battery and USB-C cable, wait 30 seconds, ' +
-			'then reconnect the battery and USB-C.';
-	}
-
 }
 
 
 module.exports = QdlFlasher;
+module.exports.TachyonConnectionError = TachyonConnectionError;

--- a/src/lib/tachyon-utils.js
+++ b/src/lib/tachyon-utils.js
@@ -17,6 +17,7 @@ const VError = require('verror');
 const chalk = require('chalk');
 const inquirer = require('inquirer');
 const wifiScan = require('node-wifiscanner2').scan;
+const { TachyonConnectionError } = require('./qdl');
 
 function addLogHeaders({ outputLog, startTime, deviceId, commandName }) {
 	fs.appendFileSync(outputLog, `Tachyon Logs:${os.EOL}`);
@@ -426,6 +427,27 @@ async function edlModePicker({ ui, devices }) {
 	return devices.find((device) => device.id === selected);
 }
 
+async function handleFlashError({ error, ui }) {
+	if (error instanceof TachyonConnectionError) {
+		ui.write(
+			ui.chalk.yellow(`Device not responding ${os.EOL}`) +
+			`Please turn it off completely: ${os.EOL}` +
+			`    1. Remove the battery and USB-C cable ${os.EOL}` +
+			`    2. Wait 30 seconds ${os.EOL}` +
+			`    3. Reconnect both ${os.EOL}${os.EOL}` +
+			'Press Enter once you\'re ready to retry.'
+		);
+		const question = {
+			type: 'confirm',
+			name: 'retry',
+			message: 'Retry?',
+			default: true
+		};
+		return ui.prompt([question]);
+	}
+	return false;
+}
+
 module.exports = {
 	addLogHeaders,
 	addManifestInfoLog,
@@ -434,4 +456,5 @@ module.exports = {
 	prepareFlashFiles,
 	getTachyonInfo,
 	promptWifiNetworks,
+	handleFlashError
 };


### PR DESCRIPTION
<!--
	Thanks for the contribution 🙏

	As you are working on your changes, be aware of the following:
	- Development Guide: https://github.com/particle-iot/particle-cli#development
	- CI (CircleCI) Reports: https://app.circleci.com/pipelines/github/particle-iot/particle-cli
	- Helpful commands:
		> list available commands: `npm run`
		> run the CI tests locally: `npm run test:ci`
		> lint your code: `npm run lint`
		> run unit tests: `npm run test:unit`
		> run integration tests: `npm run test:integration`
		> run end-to-end tests: `npm run test:e2e` (requires setup - see: https://github.com/particle-iot/particle-cli/blob/master/test/README.md)

	Have any questions? Ask here and a maintainer will be happy to help :)
-->


## Description
Add retry option when tachyon is not in a good state for flashing with `qdl` this affects to `flash`, `setup`, `identify`, `backup`, `restore`, `factory-restore` commands


<!--
	Write a brief description of the changes introduced by this PR: what problem(s) does it address? how does it solve them?
-->


## How to Test
With a tachyon in bad state (you can start flashing one and stop the process at the middle) run the follow commands:
* `tachyon setup`
* `tachyon backup`
* `tachyon restore`
* `tachyon factory-restore`
* `flash --tachyon`

**outcome**
* It prints instructions for retrying the process without start all again.
<img width="1058" height="469" alt="image" src="https://github.com/user-attachments/assets/21a205bd-e467-47a9-bcdd-26e695a5263d" />


<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://docs.google.com/a/particle.io/forms/d/1_2P-vRKGUFg5bmpcKLHO_qNZWGi5HKYnfrrkd-sbZoA/viewform)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

