### PR TITLE
Rely on the LICENSE text at the top of the repo rather than license headers

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -26,7 +26,7 @@
         "moment": "^2.24.0",
         "node-fetch": "^2.7.0",
         "node-wifiscanner2": "^1.2.1",
-        "particle-api-js": "^11.1.0",
+        "particle-api-js": "^11.1.4",
         "particle-commands": "^1.0.2",
         "particle-library-manager": "^1.0.2",
         "particle-usb": "^4.0.0",
@@ -5965,9 +5965,9 @@
       }
     },
     "node_modules/particle-api-js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-11.1.0.tgz",
-      "integrity": "sha512-4L2A/dKLYvZ+USBPeLUxRGtCgR4YhOpmLrZAiv9HYLc6Nd5L/HYMSfI+vQNve4FZ5y8E3mHnQE0Y9oKN0e4tHA==",
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-11.1.4.tgz",
+      "integrity": "sha512-MQS6fAjAHAV57vO9ETC0uJlyXBloMkAC3rc3++Bgz2rdpjMlMVv3dj2nAg008MsZ0ZlW2DkdqJq7LW8bFQdL9Q==",
       "dependencies": {
         "form-data": "^4.0.0",
         "node-fetch": "^2.7.0",
@@ -14198,9 +14198,9 @@
       }
     },
     "particle-api-js": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-11.1.0.tgz",
-      "integrity": "sha512-4L2A/dKLYvZ+USBPeLUxRGtCgR4YhOpmLrZAiv9HYLc6Nd5L/HYMSfI+vQNve4FZ5y8E3mHnQE0Y9oKN0e4tHA==",
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/particle-api-js/-/particle-api-js-11.1.4.tgz",
+      "integrity": "sha512-MQS6fAjAHAV57vO9ETC0uJlyXBloMkAC3rc3++Bgz2rdpjMlMVv3dj2nAg008MsZ0ZlW2DkdqJq7LW8bFQdL9Q==",
       "requires": {
         "form-data": "^4.0.0",
         "node-fetch": "^2.7.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -28,7 +28,7 @@
         "node-wifiscanner2": "^1.2.1",
         "particle-api-js": "^11.1.0",
         "particle-commands": "^1.0.2",
-        "particle-library-manager": "^1.0.1",
+        "particle-library-manager": "^1.0.2",
         "particle-usb": "^4.0.0",
         "request": "^2.79.0",
         "safe-buffer": "^5.2.0",
@@ -6080,9 +6080,9 @@
       }
     },
     "node_modules/particle-library-manager": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/particle-library-manager/-/particle-library-manager-1.0.1.tgz",
-      "integrity": "sha512-amZm+de7OjwW7YP47sBqg8TfA9lyK7HmGuhbX4Bc/y+jE+ZOXIHg7ukHmXydxFhROz5secZuKnno32kdtoxesA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/particle-library-manager/-/particle-library-manager-1.0.2.tgz",
+      "integrity": "sha512-v/h3bQupp78UCvPptitVghsdNJDEqQEVWZy4pPeNBzAA5rZaPDC3e8GZktWU7JejkZKLX8cNb2SnyxVMMB+b7A==",
       "dependencies": {
         "app-root-path": "^2.0.1",
         "async": "^2.0.0-rc.4",
@@ -14295,9 +14295,9 @@
       }
     },
     "particle-library-manager": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/particle-library-manager/-/particle-library-manager-1.0.1.tgz",
-      "integrity": "sha512-amZm+de7OjwW7YP47sBqg8TfA9lyK7HmGuhbX4Bc/y+jE+ZOXIHg7ukHmXydxFhROz5secZuKnno32kdtoxesA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/particle-library-manager/-/particle-library-manager-1.0.2.tgz",
+      "integrity": "sha512-v/h3bQupp78UCvPptitVghsdNJDEqQEVWZy4pPeNBzAA5rZaPDC3e8GZktWU7JejkZKLX8cNb2SnyxVMMB+b7A==",
       "requires": {
         "app-root-path": "^2.0.1",
         "async": "^2.0.0-rc.4",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "node-wifiscanner2": "^1.2.1",
     "particle-api-js": "^11.1.0",
     "particle-commands": "^1.0.2",
-    "particle-library-manager": "^1.0.1",
+    "particle-library-manager": "^1.0.2",
     "particle-usb": "^4.0.0",
     "request": "^2.79.0",
     "safe-buffer": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "moment": "^2.24.0",
     "node-fetch": "^2.7.0",
     "node-wifiscanner2": "^1.2.1",
-    "particle-api-js": "^11.1.0",
+    "particle-api-js": "^11.1.4",
     "particle-commands": "^1.0.2",
     "particle-library-manager": "^1.0.2",
     "particle-usb": "^4.0.0",

--- a/src/app/command-processor.test.js
+++ b/src/app/command-processor.test.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const { expect, sinon } = require('../../test/setup');
 const commandProcessor = require('./command-processor');
 

--- a/src/cli/library_init.test.js
+++ b/src/cli/library_init.test.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const { expect, sinon } = require('../../test/setup');
 const { LibraryInitGenerator } = require('particle-library-manager');
 const { CLILibraryInitCommandSite } = require('./library_init');

--- a/src/cli/library_install.test.js
+++ b/src/cli/library_install.test.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const { expect } = require('../../test/setup');
 const { LibraryInstallCommand } = require('../cmd');
 const libraryCommands = require('./library');

--- a/src/cli/library_migrate.test.js
+++ b/src/cli/library_migrate.test.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const { expect, sinon } = require('../../test/setup');
 const { CLILibraryTestMigrateCommandSite } = require('./library_migrate');
 

--- a/src/cmd/binary.js
+++ b/src/cmd/binary.js
@@ -1,30 +1,3 @@
-/**
- ******************************************************************************
- * @file    commands/BinaryCommand.js
- * @author  Wojtek Siudzinski (wojtek@particle.io)
- * @company Particle ( https://www.particle.io/ )
- * @source https://github.com/spark/particle-cli
- * @version V1.0.0
- * @date    9-December-2015
- * @brief   Binary command module
- ******************************************************************************
-Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation, either
-version 3 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const fs = require('fs-extra');
 const os = require('os');
 const path = require('path');

--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -1,33 +1,4 @@
 /**
- ******************************************************************************
- * @file    lib/api-client.js
- * @author  David Middlecamp (david@particle.io)
- * @company Particle ( https://www.particle.io/ )
- * @source https://github.com/spark/particle-cli
- * @version V1.0.0
- * @date    14-February-2014
- * @brief   Basic API wrapper module
- ******************************************************************************
-Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation, either
-version 3 of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
-
-
-/**
  *
  * Example Usage:
  *

--- a/src/lib/utilities.js
+++ b/src/lib/utilities.js
@@ -1,31 +1,3 @@
-/**
- ******************************************************************************
- * @file    lib/utilities.js
- * @author  David Middlecamp (david@particle.io)
- * @company Particle ( https://www.particle.io/ )
- * @source https://github.com/spark/particle-cli
- * @version V1.0.0
- * @date    14-February-2014
- * @brief   General Utilities Module
- ******************************************************************************
-Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation, either
-version 3 of the License, or (at your option) any later version.
-
-This program is distributed in the hope utilities it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
-
 const fs = require('fs');
 const _ = require('lodash');
 const propertiesParser = require('properties-parser');

--- a/test/integration/command-processor.integration.js
+++ b/test/integration/command-processor.integration.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const { expect } = require('../setup');
 const CLI = require('../../src/app/cli');
 const commandProcessor = require('../../src/app/command-processor');

--- a/test/integration/library.integration.js
+++ b/test/integration/library.integration.js
@@ -1,23 +1,3 @@
-
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const path = require('path');
 const settings = require('../../settings');
 const { expect, sinon } = require('../setup');

--- a/test/integration/library_init.integration.js
+++ b/test/integration/library_init.integration.js
@@ -1,22 +1,3 @@
-
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
 const { expect } = require('../setup');
 const fs = require('fs-extra');
 const path = require('path');

--- a/test/integration/library_install.integration.js
+++ b/test/integration/library_install.integration.js
@@ -1,22 +1,3 @@
-/*
- ******************************************************************************
- Copyright (c) 2016 Particle Industries, Inc.  All rights reserved.
-
- This program is free software; you can redistribute it and/or
- modify it under the terms of the GNU Lesser General Public
- License as published by the Free Software Foundation, either
- version 3 of the License, or (at your option) any later version.
-
- This program is distributed in the hope that it will be useful,
- but WITHOUT ANY WARRANTY; without even the implied warranty of
- MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- Lesser General Public License for more details.
-
- You should have received a copy of the GNU Lesser General Public
- License along with this program; if not, see <http://www.gnu.org/licenses/>.
- ******************************************************************************
- */
-
 const mockfs = require('mock-fs');
 const settings = require('../../settings');
 const { expect } = require('../setup');


### PR DESCRIPTION
#245 Changed the license to Apache 2.0 but left some comment headers with the previous LGPL language.

This PR completes the intent of #245 that the LICENSE file at the top of the repo should define the text of the license for all the files in the repo rather than some files having separate license headers.