### PR TITLE
Setup 20.04 by default, and allow setup of 24.04

### DIFF
--- a/src/cli/tachyon.js
+++ b/src/cli/tachyon.js
@@ -28,6 +28,9 @@ module.exports = ({ commandProcessor, root }) => {
 			board: {
 				description: 'Board to download package for'
 			},
+			distro_version: {
+				description: 'Linux distribution version to use'
+			},
 			skip_cli: {
 				description: 'Do not log in the Particle CLI',
 				boolean: true
@@ -59,6 +62,9 @@ module.exports = ({ commandProcessor, root }) => {
 			board: {
 				description: 'Board to download package for',
 				type: 'string'
+			},
+			distro_version: {
+				description: 'Linux distribution version to use'
 			}
 		},
 		handler: (args) => {

--- a/src/cmd/download-tachyon-package.js
+++ b/src/cmd/download-tachyon-package.js
@@ -58,7 +58,7 @@ module.exports = class DownloadTachyonPackageCommand extends CLICommandBase {
 		return variantMapping[variant];
 	}
 
-	async download ({ region, version, alwaysCleanCache = false, variant, board = 'formfactor_dvt' }) {
+	async download ({ region, version, alwaysCleanCache = false, variant, board = 'formfactor_dvt', distro_version: distroVersion }) {
 		// prompt for region and version if not provided
 		const isRb3Board = board === 'rb3g2'; // RGB board
 		if (!region) {
@@ -71,9 +71,12 @@ module.exports = class DownloadTachyonPackageCommand extends CLICommandBase {
 		if (!variant) {
 			variant = await this._selectVariant(isRb3Board);
 		}
+		if (!distroVersion && !isRb3Board) {
+			distroVersion = '20.04';
+		}
 		const manager = new DownloadManager(this.ui);
 		const manifest = await manager.fetchManifest({ version, isRb3Board });
-		const build = manifest?.builds.find(build => build.region === region && build.variant === variant && build.board === board);
+		const build = manifest?.builds.find(build => build.region === region && build.variant === variant && build.board === board && (!distroVersion || build.distribution_version === distroVersion));
 
 		if (!build) {
 			throw new Error('No build available for the provided parameters');

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -55,6 +55,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			region: 'NA',
 			version: settings.tachyonVersion || 'stable',
 			board: 'formfactor',
+			distroVersion: '20.04',
 			country: 'USA',
 			variant: null,
 			skipFlashingOs: false,
@@ -65,9 +66,9 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		this.options = {};
 	}
 
-	async setup({ skip_flashing_os: skipFlashingOs, timezone, load_config: loadConfig, save_config: saveConfig, region, version, variant, board, skip_cli: skipCli } = {}) {
+	async setup({ skip_flashing_os: skipFlashingOs, timezone, load_config: loadConfig, save_config: saveConfig, region, version, variant, board, distro_version: distroVersion, skip_cli: skipCli } = {}) {
 		const requiredFields = ['region', 'version', 'systemPassword', 'productId', 'timezone'];
-		const options = { skipFlashingOs, timezone, loadConfig, saveConfig, region, version, variant, board, skipCli };
+		const options = { skipFlashingOs, timezone, loadConfig, saveConfig, region, version, variant, board, distroVersion, skipCli };
 		await this.ui.write(showWelcomeMessage(this.ui));
 		// step 1 login
 		this._formatAndDisplaySteps("Okay—first up! Checking if you're logged in...", 1);
@@ -602,7 +603,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		return countryCode;
 	}
 
-	async _download({ region, version, alwaysCleanCache, variant, board, isRb3Board, isLocalVersion }) {
+	async _download({ region, version, alwaysCleanCache, variant, board, distroVersion, isRb3Board, isLocalVersion }) {
 		//before downloading a file, we need to check if 'version' is a local file or directory
 		//if it is a local file or directory, we need to return the path to the file
 		if (isLocalVersion) {
@@ -612,7 +613,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		const manager = new DownloadManager(this.ui);
 		const manifest = await manager.fetchManifest({ version, isRb3Board });
 
-		const build = manifest?.builds.find(build => build.region === region && build.variant === variant && build.board === board);
+		const build = manifest?.builds.find(build => build.region === region && build.variant === variant && build.board === board && (!distroVersion || build.distribution_version === distroVersion));
 		if (!build) {
 			throw new Error('No build available for the provided parameters');
 		}


### PR DESCRIPTION
## Description

Ensure that when setting up Tachyon, we default to using Ubuntu 20.04. Allow setting up 24.04 with `--distro_version 24.04`

## How to Test

Currently there are no released 24.04 images, but we need this PR before we do to ensure we don't start flashing 24.04 accidentally.

So this is expected to fail:
```
particle tachyon setup --distro_version 24.04

Step 7 failed with the following error: No build available for the provided parameters
```

This should still work:
```
particle tachyon setup
```