### PR TITLE
Improve change type when adding or removing an override

### DIFF
--- a/src/lib/env.js
+++ b/src/lib/env.js
@@ -156,12 +156,14 @@ const EM_DASH = '\u2014';
 function buildPendingChangesTable(data, ui) {
 	const snapshotOwn = data.last_snapshot?.own || {};
 	const latestOwn = data.latest?.own || {};
+	const inherited = data.latest?.inherited || {};
 	const allKeys = [...new Set([...Object.keys(snapshotOwn), ...Object.keys(latestOwn)])];
 
 	const rows = [];
 	for (const key of allKeys) {
 		const inSnapshot = key in snapshotOwn;
 		const inLatest = key in latestOwn;
+		const inInherited = key in inherited;
 
 		if (inSnapshot && inLatest && snapshotOwn[key].value === latestOwn[key].value) {
 			continue;
@@ -176,11 +178,29 @@ function buildPendingChangesTable(data, ui) {
 			change = 'Updated';
 		}
 
+		let oldValue;
+		if (inSnapshot) {
+			oldValue = snapshotOwn[key].value;
+		} else if (inInherited) {
+			oldValue = inherited[key].value;
+		} else {
+			oldValue = EM_DASH;
+		}
+		let newValue;
+		if (inLatest) {
+			newValue = latestOwn[key].value;
+		} else if (inInherited) {
+			newValue = inherited[key].value;
+		} else {
+			newValue = EM_DASH;
+		}
+
+
 		rows.push({
 			change,
 			name: key,
-			oldValue: inSnapshot ? snapshotOwn[key].value : EM_DASH,
-			newValue: inLatest ? latestOwn[key].value : EM_DASH
+			oldValue,
+			newValue
 		});
 	}
 

--- a/src/lib/env.test.js
+++ b/src/lib/env.test.js
@@ -491,6 +491,109 @@ describe('lib/env', () => {
 			expect(output).to.include('\u2014');
 		});
 
+		it('classifies as Added when variable is added to own but exists in inherited', () => {
+			const data = {
+				last_snapshot: { own: {} },
+				latest: {
+					own: { MY_VAR: { value: 'own-value' } },
+					inherited: { MY_VAR: { value: 'inherited-value', from: 'Organization' } }
+				}
+			};
+
+			const output = buildPendingChangesTable(data, ui).toString();
+			expect(output).to.include('Added');
+			expect(output).to.not.include('Updated');
+			expect(output).to.include('MY_VAR');
+			expect(output).to.include('inherited-value');
+			expect(output).to.include('own-value');
+		});
+
+		it('classifies as Removed when variable is removed from own but exists in inherited', () => {
+			const data = {
+				last_snapshot: { own: { MY_VAR: { value: 'own-value' } } },
+				latest: {
+					own: {},
+					inherited: { MY_VAR: { value: 'inherited-value', from: 'Organization' } }
+				}
+			};
+
+			const output = buildPendingChangesTable(data, ui).toString();
+			expect(output).to.include('Removed');
+			expect(output).to.not.include('Updated');
+			expect(output).to.include('MY_VAR');
+			expect(output).to.include('own-value');
+			expect(output).to.include('inherited-value');
+		});
+
+		it('shows inherited value as old value when variable is added and inherited exists', () => {
+			const data = {
+				last_snapshot: { own: {} },
+				latest: {
+					own: { MY_VAR: { value: 'new-own' } },
+					inherited: { MY_VAR: { value: 'from-parent', from: 'Organization' } }
+				}
+			};
+
+			const output = buildPendingChangesTable(data, ui).toString();
+			expect(output).to.include('from-parent');
+			expect(output).to.include('new-own');
+			expect(output).to.not.include(EM_DASH);
+		});
+
+		it('shows inherited value as new value when variable is removed and inherited exists', () => {
+			const data = {
+				last_snapshot: { own: { MY_VAR: { value: 'old-own' } } },
+				latest: {
+					own: {},
+					inherited: { MY_VAR: { value: 'from-parent', from: 'Organization' } }
+				}
+			};
+
+			const output = buildPendingChangesTable(data, ui).toString();
+			expect(output).to.include('old-own');
+			expect(output).to.include('from-parent');
+			expect(output).to.not.include(EM_DASH);
+		});
+
+		it('classifies as Added when variable is new and not in inherited', () => {
+			const data = {
+				last_snapshot: { own: {} },
+				latest: {
+					own: { NEW_VAR: { value: 'hello' } },
+					inherited: { OTHER_VAR: { value: 'other', from: 'Organization' } }
+				}
+			};
+
+			const output = buildPendingChangesTable(data, ui).toString();
+			expect(output).to.include('Added');
+			expect(output).to.include('NEW_VAR');
+		});
+
+		it('classifies as Removed when variable is deleted and not in inherited', () => {
+			const data = {
+				last_snapshot: { own: { OLD_VAR: { value: 'bye' } } },
+				latest: {
+					own: {},
+					inherited: { OTHER_VAR: { value: 'other', from: 'Organization' } }
+				}
+			};
+
+			const output = buildPendingChangesTable(data, ui).toString();
+			expect(output).to.include('Removed');
+			expect(output).to.include('OLD_VAR');
+		});
+
+		it('handles missing inherited data gracefully', () => {
+			const data = {
+				last_snapshot: { own: {} },
+				latest: { own: { NEW_VAR: { value: 'hello' } } }
+			};
+
+			const output = buildPendingChangesTable(data, ui).toString();
+			expect(output).to.include('Added');
+			expect(output).to.include('NEW_VAR');
+		});
+
 		it('sorts rows by change type then name alphabetically', () => {
 			const data = {
 				last_snapshot: { own: { Z_UPDATE: { value: 'old' }, A_REMOVE: { value: 'x' }, B_REMOVE: { value: 'y' } } },


### PR DESCRIPTION
List the previous and new value correctly when adding or removing an override.

Steps to test:
- Define a product env var, save and apply
- Define a device override.
- See the Added line in the CLI showing the previous value as the inherited value and the new value as the override.
- Open the Console to save and apply
- Delete the device override
- See the Removed line in the CLI showing the previous value as the override and the new value as the inherited value.