### PR TITLE
normalize the wrapped error in case of this exist

### DIFF
--- a/src/cmd/cloud.js
+++ b/src/cmd/cloud.js
@@ -366,7 +366,7 @@ module.exports = class CloudCommand extends CLICommandBase {
 		try {
 			resp = await createAPI().compileCode(fileMapping, platformId, targetVersion);
 		} catch (error) {
-			throw normalizedApiError(error);
+			throw normalizedApiError(error?.error || error); // get first the wrapped error from the API client, if it exists, otherwise use the original error
 		}
 
 		if (resp && resp.binary_url && resp.binary_id) {


### PR DESCRIPTION
## Description
Show the actual error when a compilation error occurs.


## How to Test
1. Pull down the branch: `git pull && git checkout bug/sc-139521/compilation-errors-are-not-being-displayed`
2. Attempt to flash a device with an specific project with compilation errors: `npm start -- flash --local {project_path}`


**outcome**
* It should shows the compilation error output.
<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Story details: https://app.shortcut.com/particle/story/139521/compilation-errors-are-not-being-displayed-when-running-particle-compile-local-command
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://part.cl/icla)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

