### PR TITLE
close the device if still open, for protected devices

### DIFF
--- a/src/cmd/usb-util.js
+++ b/src/cmd/usb-util.js
@@ -141,6 +141,9 @@ async function executeWithUsbDevice({ args, func, enterDfuMode = false, allowPro
 	} finally {
 		if (deviceIsProtected) {
 			try {
+				if (device && device.isOpen) {
+					await device.close();
+				}
 				device = await waitForDeviceToRespond(deviceId);
 				await deviceProtectionHelper.turnOffServiceMode(device);
 			} catch (_err) {
@@ -201,6 +204,10 @@ async function _putDeviceInSafeMode(dev) {
 		await dev.enterSafeMode();
 	} catch (_err) {
 		// ignore errors
+	} finally {
+		if (dev.isOpen) {
+			await dev.close();
+		}
 	}
 	return reopenInNormalMode({ id: deviceId });
 }


### PR DESCRIPTION
## Description
Close the device connection when wrapped device-protected devices completes the workflow.


## How to Test

### Steps to reproduce the issue
**With a protected device**

1. Put your device in dfu?: `npm start -- usb dfu`
2. Reset your device: `npm start -- usb reset`

**outcome**
* Reset command just stalls and doesn't finish after the `done` message

**expected outcome**
* Reset command should exit after the device is reset.

 
<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions

<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://part.cl/icla)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

