### PR TITLE
[A] fix installer to validate correctly the checksum

### DIFF
--- a/installer/unix/install-cli
+++ b/installer/unix/install-cli
@@ -90,13 +90,19 @@ mkdir -p "$DEST_PATH"
 TMP_FILE=$(mktemp)
 
 echo ":::: Downloading CLI version $VERSION"
-curl "$BINARY_URL" | gunzip > "$TMP_FILE"
+TMP_GZ="$TMP_FILE.gz"
+curl "$BINARY_URL" -o "$TMP_GZ"
 
-echo "$BINARY_SHA256  $TMP_FILE" | shasum a 256 -c > /dev/null 2>&1
-if [ $? -eq 1 ]; then
+# The manifest sha256 is computed over the gzipped binary, so verify before unzipping
+echo "$BINARY_SHA256  $TMP_GZ" | shasum -a 256 -c > /dev/null 2>&1
+if [ $? -ne 0 ]; then
    echo ':::: Checksum check failed! Aborting installation'
+   rm -f "$TMP_GZ" "$TMP_FILE"
    exit 1
 fi
+
+gunzip -c "$TMP_GZ" > "$TMP_FILE"
+rm -f "$TMP_GZ"
 
 mv -f "$TMP_FILE" "$DEST"
 chmod +x "$DEST"


### PR DESCRIPTION

## Description
Fix unix installer for particle-cli sha-256 check.
*  Eyeballing the installer script at installer/unix/install-cli shows that you're using 'shasum a 256... ' instead of 'shasum -a 256... ' on line:
* Also the sha was checking the uncompressed file instead of the compressed one/

## How to Test
* Try to use the sh file to install the cli.


**outcome**
* Sha verification should happen
* it will validate the compressed file instead of the uncompressed one.


<!--
	Please try to add automated tests which appropriately verify your changes! At the least, provide simple steps an end-user can manually perform in order to vet the update(s).
-->


## Related Issues / Discussions
Issue: https://github.com/particle-iot/particle-cli/issues/909
<!--
	Link to the issue that is fixed by this PR (if there is one)
	e.g. Fixes #1234

	Link to an issue that is partially addressed by this PR (if there are any)
	e.g. Addresses #1234

	Link to related issues (if there are any)
	e.g. Related to #1234

	Link to any relevant community discussions
	e.g. As discussed here: https://community.particle.io/
-->


## Completeness

- [x] User is totes amazing for contributing!
- [x] Contributor has signed [CLA](https://part.cl/icla)
- [x] Problem and solution clearly stated
- [x] Tests have been provided
- [x] Docs have been updated
- [x] CI is passing

