### PR TITLE
tachyon: resolve 24.04 from the stable channel (like 20.04)

### DIFF
--- a/src/lib/tachyon/workflow.js
+++ b/src/lib/tachyon/workflow.js
@@ -124,9 +124,6 @@ const ubuntu24 = Object.freeze({
 		distributionVersion: '24.04',
 		distributionVariant: 'ubuntu'
 	},
-	overrideDefaults:{
-		version: 'latest',
-	},
 	variants: [
 		{
 			name: 'Desktop (GUI)',


### PR DESCRIPTION
## Why
`particle tachyon setup` was serving in-development **1.2.x** for Ubuntu 24.04 by default. The 24.04 workflow hard-set `overrideDefaults.version = 'latest'`, so it fetched `tachyon-latest.json` and picked whatever the newest 24.04 release happened to be. Ubuntu 20.04 has **no** such override — it uses the default `stable` channel (`settings.tachyonVersion || 'stable'`).

## Change
Remove the `version: 'latest'` override from the `ubuntu24` workflow so 24.04 resolves exactly like 20.04 — from the **stable** channel (`tachyon-stable.json`). Android 14 is unchanged (still `latest`).

```diff
 	},
-	overrideDefaults:{
-		version: 'latest',
-	},
 	variants: [
```

## Pairs with
tachyon-composer #60, which seeds `meta/tachyon-stable.json` with a curated 24.04 entry (currently pinned to 1.1.43 desktop). With both landed, `particle tachyon setup` → 24.04 serves the stable build instead of the newest release.

Lint passes; no test asserted the old `latest` behaviour.