### PR TITLE
fix: [sc-140587] Fix secret usages output for logic function objects

### DIFF
--- a/src/cmd/secrets.js
+++ b/src/cmd/secrets.js
@@ -105,8 +105,8 @@ module.exports = class SecretsCommand extends CLICommandBase {
 			if (secret.logicFunctions.length > 0) {
 				this.ui.write('    Logic Functions:');
 				secret.logicFunctions.forEach(logicFunction => {
-					const logicUrl = `${this.consoleBaseUrl}/logic/functions/${logicFunction}/details`;
-					this.ui.write(this.ui.chalk.dim(`     - ${logicUrl}`));
+					const logicUrl = `${this.consoleBaseUrl}/logic/functions/${logicFunction.id}/details`;
+					this.ui.write(`     - ${logicFunction.name}: ${this.ui.chalk.dim(logicUrl)}`);
 				});
 			} else {
 				this.ui.write(`    Logic Functions: ${this.ui.chalk.dim('(none)')}`);
@@ -126,7 +126,7 @@ module.exports = class SecretsCommand extends CLICommandBase {
 					} else {
 						integrationRoute = `${this.consoleBaseUrl}/integrations/${integration.id}`;
 					}
-					this.ui.write(this.ui.chalk.dim(`     - ${integrationRoute}`));
+					this.ui.write(`     - ${integration.name}: ${this.ui.chalk.dim(integrationRoute)}`);
 				});
 			} else {
 				this.ui.write(`    Integrations: ${this.ui.chalk.dim('(none)')}`);

--- a/src/cmd/secrets.test.js
+++ b/src/cmd/secrets.test.js
@@ -338,15 +338,20 @@ describe('SecretsCommand', () => {
 				createdAt: '2024-01-01',
 				updatedAt: '2024-01-02',
 				lastAccessedAt: null,
-				logicFunctions: ['func1', 'func2'],
+				logicFunctions: [
+					{ id: 'func1', name: 'Func One' },
+					{ id: 'func2', name: 'Func Two' }
+				],
 				integrations: []
 			};
 
 			secretsCommand._printSecret(secret);
 
 			expect(secretsCommand.ui.write).to.have.been.calledWith('    Logic Functions:');
-			expect(secretsCommand.ui.chalk.dim).to.have.been.calledWith(sinon.match(/func1/));
-			expect(secretsCommand.ui.chalk.dim).to.have.been.calledWith(sinon.match(/func2/));
+			expect(secretsCommand.ui.write).to.have.been.calledWith(sinon.match(/Func One/));
+			expect(secretsCommand.ui.write).to.have.been.calledWith(sinon.match(/Func Two/));
+			expect(secretsCommand.ui.chalk.dim).to.have.been.calledWith(sinon.match(/logic\/functions\/func1\/details/));
+			expect(secretsCommand.ui.chalk.dim).to.have.been.calledWith(sinon.match(/logic\/functions\/func2\/details/));
 		});
 
 		it('prints secret with no logic functions', () => {
@@ -373,14 +378,16 @@ describe('SecretsCommand', () => {
 				lastAccessedAt: null,
 				logicFunctions: [],
 				integrations: [
-					{ id: 'int1', product_slug: null },
-					{ id: 'int2', product_slug: 'my-product' }
+					{ id: 'int1', name: 'Integration One', product_slug: null },
+					{ id: 'int2', name: 'Integration Two', product_slug: 'my-product' }
 				]
 			};
 
 			secretsCommand._printSecret(secret);
 
 			expect(secretsCommand.ui.write).to.have.been.calledWith('    Integrations:');
+			expect(secretsCommand.ui.write).to.have.been.calledWith(sinon.match(/Integration One/));
+			expect(secretsCommand.ui.write).to.have.been.calledWith(sinon.match(/Integration Two/));
 			expect(secretsCommand.ui.chalk.dim).to.have.been.calledWith(sinon.match(/int1/));
 			expect(secretsCommand.ui.chalk.dim).to.have.been.calledWith(sinon.match(/int2/));
 		});
@@ -433,7 +440,7 @@ describe('SecretsCommand', () => {
 				createdAt: '2024-01-01',
 				updatedAt: '2024-01-02',
 				lastAccessedAt: null,
-				logicFunctions: ['func1'],
+				logicFunctions: [{ id: 'func1', name: 'Func One' }],
 				integrations: []
 			};
 


### PR DESCRIPTION
Story details: https://app.shortcut.com/particle/story/140587

- Fixes `[object Object]` in the logic function console URL in `config secrets get`/`list` output — the API now returns `logic_functions` as `Array<{ id, name }>` instead of `string[]`
- Prints the name alongside the console link for both logic functions and integrations
- Updated unit test fixtures to the new object shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)