### PR TITLE
Add timestamp option to particle serial monitor

### DIFF
--- a/src/cli/serial.js
+++ b/src/cli/serial.js
@@ -23,11 +23,25 @@ module.exports = ({ commandProcessor, root }) => {
 			'follow': {
 				boolean: true,
 				description: 'Reopen the port after it closes, for example when the device resets'
+			},
+			'timestamp': {
+				boolean: true,
+				description: 'Prepend a timestamp to each line of output'
+			},
+			'utc': {
+				boolean: true,
+				description: 'Use UTC instead of local time for the timestamp'
 			}
 		}, portOption),
 		handler: (args) => {
 			const SerialCommands = require('../cmd/serial');
 			return new SerialCommands().monitorPort(args);
+		},
+		examples: {
+			'$0 $command': 'Display messages from a device',
+			'$0 $command --follow': 'Display messages from a device, reopening the port when the device resets',
+			'$0 $command --timestamp': 'Prepend the local time to each line of output',
+			'$0 $command --timestamp --utc': 'Prepend the UTC time to each line of output'
 		}
 	});
 

--- a/src/cli/serial.test.js
+++ b/src/cli/serial.test.js
@@ -1,0 +1,33 @@
+'use strict';
+const { expect } = require('../../test/setup');
+const commandProcessor = require('../app/command-processor');
+const serial = require('./serial');
+
+
+describe('Serial Command-Line Interface', () => {
+	let root;
+
+	beforeEach(() => {
+		root = commandProcessor.createAppCategory();
+		serial({ root, commandProcessor });
+	});
+
+	describe('`serial monitor` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['serial', 'monitor']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.follow).to.equal(false);
+			expect(argv.timestamp).to.equal(false);
+			expect(argv.utc).to.equal(false);
+		});
+
+		it('Parses options', () => {
+			const argv = commandProcessor.parse(root, ['serial', 'monitor', '--follow', '--timestamp', '--utc', '--port', '/dev/ttyACM0']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.follow).to.equal(true);
+			expect(argv.timestamp).to.equal(true);
+			expect(argv.utc).to.equal(true);
+			expect(argv.port).to.equal('/dev/ttyACM0');
+		});
+	});
+});

--- a/src/cmd/serial.js
+++ b/src/cmd/serial.js
@@ -23,6 +23,7 @@ const { platformForId } = require('../lib/platform');
 const { FirmwareModuleDisplayNames } = require('particle-usb');
 const semver = require('semver');
 const { getProtectionStatus, disableDeviceProtection } = require('../lib/device-protection-helper');
+const { createTimestampWriter } = require('../lib/serial-timestamp');
 
 const IDENTIFY_COMMAND_TIMEOUT = 20000;
 
@@ -131,11 +132,19 @@ module.exports = class SerialCommand extends CLICommandBase {
 			});
 	}
 
-	monitorPort({ port, follow }){
+	monitorPort({ port, follow, timestamp, utc }){
+		if (utc && !timestamp){
+			timestamp = true;
+		}
+
 		let cleaningUp = false;
 		let selectedDevice;
 		let serialPort;
 		const { api, auth } = this._particleApi();
+
+		const writeData = timestamp
+			? createTimestampWriter({ write: (text) => process.stdout.write(text), utc })
+			: (text) => process.stdout.write(text);
 
 		const displayError = (err) => {
 			if (err){
@@ -218,7 +227,7 @@ module.exports = class SerialCommand extends CLICommandBase {
 			serialPort = new SerialPort({ path: selectedDevice.port, ...SERIAL_PORT_DEFAULTS });
 			serialPort.on('close', handleClose);
 			serialPort.on('readable', () => {
-				process.stdout.write(serialPort.read().toString());
+				writeData(serialPort.read().toString());
 			});
 			serialPort.on('error', displayError);
 			serialPort.open((err) => {

--- a/src/lib/serial-timestamp.js
+++ b/src/lib/serial-timestamp.js
@@ -1,0 +1,65 @@
+'use strict';
+const moment = require('moment');
+
+/**
+ * Formats a date as an ISO 8601 timestamp with milliseconds.
+ * @param {Date} date Date to format
+ * @param {Boolean} utc When true, format in UTC (2026-08-17T18:04:40.805Z) instead of
+ *   local time (2026-08-17T14:04:40.805-04:00)
+ * @returns {String} formatted timestamp
+ */
+function formatTimestamp(date, utc){
+	if (utc){
+		return date.toISOString();
+	}
+	return moment(date).format('YYYY-MM-DDTHH:mm:ss.SSSZ');
+}
+
+/**
+ * Creates a function that writes text, prepending a timestamp to the start of each line.
+ *
+ * Text is written through as soon as it is received, so a line that hasn't been terminated
+ * yet is not held back. The timestamp reflects the time the text was received, not the time
+ * the line was completed.
+ *
+ * @param {Object} options Options
+ * @param {Function} options.write Called with the text to output
+ * @param {Boolean} options.utc Use UTC timestamps instead of local time
+ * @param {Function} options.now Returns the current date, for testing
+ * @returns {Function} function accepting the text to write
+ */
+function createTimestampWriter({ write, utc = false, now = () => new Date() }){
+	let atLineStart = true;
+
+	return (text) => {
+		if (!text){
+			return;
+		}
+
+		const prefix = `${formatTimestamp(now(), utc)} `;
+		const lines = text.split('\n');
+		let output = '';
+
+		lines.forEach((line, index) => {
+			const isLastLine = index === lines.length - 1;
+			// Don't start a line just because the text ended with a newline, wait for
+			// the next chunk so the timestamp matches when the line was received
+			if (atLineStart && !(isLastLine && line === '')){
+				output += prefix;
+				atLineStart = false;
+			}
+			output += line;
+			if (!isLastLine){
+				output += '\n';
+				atLineStart = true;
+			}
+		});
+
+		write(output);
+	};
+}
+
+module.exports = {
+	formatTimestamp,
+	createTimestampWriter
+};

--- a/src/lib/serial-timestamp.test.js
+++ b/src/lib/serial-timestamp.test.js
@@ -1,0 +1,85 @@
+'use strict';
+const { expect } = require('../../test/setup');
+const { formatTimestamp, createTimestampWriter } = require('./serial-timestamp');
+
+describe('serial-timestamp', () => {
+	describe('formatTimestamp', () => {
+		it('formats a date in UTC', () => {
+			const date = new Date('2026-08-17T18:04:40.805Z');
+			expect(formatTimestamp(date, true)).to.equal('2026-08-17T18:04:40.805Z');
+		});
+
+		it('formats a date in local time with the UTC offset', () => {
+			const date = new Date('2026-08-17T18:04:40.805Z');
+			expect(formatTimestamp(date, false)).to.match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}(Z|[+-]\d{2}:\d{2})$/);
+		});
+	});
+
+	describe('createTimestampWriter', () => {
+		let output;
+		let dates;
+
+		const writer = ({ utc = true } = {}) => createTimestampWriter({
+			write: (text) => output.push(text),
+			utc,
+			now: () => dates.shift()
+		});
+
+		beforeEach(() => {
+			output = [];
+			dates = [
+				new Date('2026-08-17T18:04:40.805Z'),
+				new Date('2026-08-17T18:04:41.900Z'),
+				new Date('2026-08-17T18:04:42.100Z')
+			];
+		});
+
+		it('prepends a timestamp to a single line', () => {
+			writer()('hello\n');
+			expect(output.join('')).to.equal('2026-08-17T18:04:40.805Z hello\n');
+		});
+
+		it('prepends a timestamp to each line of a chunk', () => {
+			writer()('one\ntwo\n');
+			expect(output.join('')).to.equal(
+				'2026-08-17T18:04:40.805Z one\n2026-08-17T18:04:40.805Z two\n'
+			);
+		});
+
+		it('timestamps blank lines', () => {
+			writer()('one\n\n');
+			expect(output.join('')).to.equal(
+				'2026-08-17T18:04:40.805Z one\n2026-08-17T18:04:40.805Z \n'
+			);
+		});
+
+		it('writes an unterminated line right away and does not timestamp its continuation', () => {
+			const write = writer();
+			write('par');
+			write('tial\n');
+			expect(output).to.eql(['2026-08-17T18:04:40.805Z par', 'tial\n']);
+		});
+
+		it('timestamps the next line with the time it was received', () => {
+			const write = writer();
+			write('one\n');
+			write('two\n');
+			expect(output).to.eql([
+				'2026-08-17T18:04:40.805Z one\n',
+				'2026-08-17T18:04:41.900Z two\n'
+			]);
+		});
+
+		it('keeps carriage returns intact', () => {
+			writer()('one\r\ntwo\r\n');
+			expect(output.join('')).to.equal(
+				'2026-08-17T18:04:40.805Z one\r\n2026-08-17T18:04:40.805Z two\r\n'
+			);
+		});
+
+		it('ignores empty text', () => {
+			writer()('');
+			expect(output).to.eql([]);
+		});
+	});
+});


### PR DESCRIPTION
Add `--timestamp` and `--utc` options to `particle serial monitor` to help line up logs between the device and cloud.