### PR TITLE
Fix download race condition

### DIFF
--- a/src/lib/device-os-version-util.js
+++ b/src/lib/device-os-version-util.js
@@ -119,15 +119,17 @@ async function downloadBinary({ platformName, module, baseUrl, version }) {
  * @returns {Promise<unknown>} - a promise that resolves when the file is downloaded
  */
 async function downloadFile({ url, directory, filename }) {
-	let file;
+	filename = filename || url.match(/.*\/(.*)/)[1];
+	await fs.ensureDir(directory);
+	const filePath = path.join(directory, filename);
+	const file = fs.createWriteStream(filePath);
 	try {
-		filename = filename || url.match(/.*\/(.*)/)[1];
-		await fs.ensureDir(directory);
-		file = fs.createWriteStream(directory + '/' + filename);
 		await new Promise((resolve, reject) => {
 			file.on('error', (error) => {
 				reject(error);
 			});
+			// only resolve once the data has been flushed to disk. Resolving when the
+			// response ends leaves the file truncated for whoever reads it next
 			file.on('finish', () => {
 				resolve();
 			});
@@ -136,13 +138,13 @@ async function downloadFile({ url, directory, filename }) {
 				if (response.statusCode !== 200) {
 					req.abort();
 					reject(new Error('Failed to download file: ' + response.statusCode));
+					return;
 				}
 
-				response.pipe(file);
-				response.on('end', () => {
-					file.end();
-					resolve(filename);
+				response.on('error', (error) => {
+					reject(error);
 				});
+				response.pipe(file);
 			});
 
 			req.on('error', (err) => {
@@ -150,10 +152,10 @@ async function downloadFile({ url, directory, filename }) {
 			});
 		});
 		return filename;
-	} finally {
-		if (file) {
-			file.end();
-		}
+	} catch (error) {
+		file.destroy();
+		await fs.remove(filePath);
+		throw error;
 	}
 
 }

--- a/src/lib/device-os-version-util.js
+++ b/src/lib/device-os-version-util.js
@@ -154,6 +154,7 @@ async function downloadFile({ url, directory, filename }) {
 		return filename;
 	} catch (error) {
 		file.destroy();
+		await new Promise((resolve) => file.once('close', resolve));
 		await fs.remove(filePath);
 		throw error;
 	}

--- a/src/lib/device-os-version-util.test.js
+++ b/src/lib/device-os-version-util.test.js
@@ -87,6 +87,26 @@ describe('downloadDeviceOsVersionBinaries', () => {
 
 	});
 
+	it('should not resolve until the downloaded files are fully written to disk', async() => {
+		const largeBinary = Buffer.concat(new Array(200).fill(binary));
+		const api = {
+			getDeviceOsVersions: sinon.stub().resolves({
+				version: '2.3.1',
+				base_url: 'https://api.particle.io/v1/firmware/device-os/v2.3.1',
+				modules: [
+					{ filename: 'photon-system-part1@2.3.1.bin', prefixInfo: { moduleFunction: 'system-part' } }
+				]
+			})
+		};
+		nock('https://api.particle.io/v1/firmware/device-os/v2.3.1')
+			.intercept('/photon-system-part1@2.3.1.bin', 'GET')
+			.reply(200, largeBinary);
+
+		const data = await downloadDeviceOsVersionBinaries({ api, platformId: 6, version: '2.3.1', ui });
+
+		expect(fs.statSync(data[0]).size).to.equal(largeBinary.length);
+	});
+
 	it('should fail if the platform is not supported by the requested version', async() => {
 		let error;
 		const api = {


### PR DESCRIPTION
Fix issue when downloading device os and flashing it right away.
```
particle update --target 6.5.0
Updating msom ... to Device OS version 6.5.0
Downloaded Device OS 6.5.0
Unknown module type: 131
```

This was due to a race condition between the HTTP request completing and the file being written. It was possible for the file to not be done writing when the promise for the download resolved.

Unit test reproduces the issue and the code change fixes it.