### PR TITLE
Add AI templates

### DIFF
--- a/assets/ai/.github/copilot-instructions.md.template
+++ b/assets/ai/.github/copilot-instructions.md.template
@@ -1,0 +1,3 @@
+# Project instructions
+
+Read `AGENTS.md` at the root of this repository for the full instructions for working on this Particle firmware project.

--- a/assets/ai/AGENTS.md.template
+++ b/assets/ai/AGENTS.md.template
@@ -1,0 +1,91 @@
+# Particle Firmware Project Instructions
+
+Instructions for AI coding assistants working on this Particle IoT firmware project.
+
+## Background
+
+- Particle devices are programmed in C++17 (some older devices use C++11).
+- Devices run an operating system called Device OS that provides a standard API for system and hardware services.
+- Each device runs a single firmware binary that implements all of the desired functionality.
+- Startup code goes in the `setup()` function. Operational code goes in the `loop()` function; keep it non-blocking and return as quickly as possible.
+- Functions to interact with cloud services are in the `Particle` class. Network connectivity is handled by the `Cellular`, `WiFi`, or `Ethernet` classes.
+- In most cases devices are pre-configured with network credentials, so applications do not need code to set them up.
+- The API has many similarities to the Wiring API used on Arduino devices.
+
+## Project layout
+
+- `project.properties`: project metadata and library dependencies.
+- `.vscode/settings.json`: the target platform (`particle.targetPlatform`) and Device OS version (`particle.firmwareVersion`), for example:
+  ```json
+  {
+    "particle.firmwareVersion": "6.5.0",
+    "particle.targetPlatform": "p2"
+  }
+  ```
+  If `particle.targetPlatform` is missing, assume `msom`. If `particle.firmwareVersion` is missing, use the latest version installed in the toolchain directory (see Device OS headers below).
+- `src/`: application source code. The main source file contains `setup()` and `loop()`.
+- `lib/`: local copies of libraries used by the project.
+
+## Firmware conventions
+
+Start the main source file with this standard boilerplate:
+
+```cpp
+#include "Particle.h"
+
+SYSTEM_MODE(AUTOMATIC);
+
+SerialLogHandler logHandler(LOG_LEVEL_INFO);
+```
+
+- Use the logging library (`Log.trace`, `Log.info`, `Log.warn`, `Log.error`) instead of `Serial.print`.
+- Avoid long `delay()` calls in `loop()`. Schedule work with `millis()` comparisons or software timers so the loop stays non-blocking.
+- Check `Particle.connected()` before publishing events to the cloud.
+- See https://docs.particle.io/firmware/best-practices/firmware-introduction/ for more best practices.
+
+## Device OS API documentation
+
+LLM-friendly documentation is published on docs.particle.io:
+
+- Documentation index: https://docs.particle.io/llms.txt
+- Device OS firmware API reference (markdown): https://docs.particle.io/reference/device-os/firmware.md
+
+## Device OS headers
+
+When the Particle local toolchain is installed, the Device OS C++ header files are available at `~/.particle/toolchains/deviceOS/<version>/` on Mac and Linux, or `%USERPROFILE%\.particle\toolchains\deviceOS\<version>\` on Windows, where `<version>` matches `particle.firmwareVersion` in `.vscode/settings.json`. If that setting is missing, use the latest version directory found under the toolchain directory. Use the headers as a reference for the exact API signatures.
+
+## Software libraries
+
+Firmware functionality can be augmented with community libraries. To find and install a library, run these commands from the project root (the directory containing `project.properties`):
+
+```
+particle library search <term>
+particle library copy <name>
+```
+
+`particle library copy` downloads the library into the `lib/` directory, creating it if needed.
+
+An index of the available libraries, most popular first, can be downloaded from https://docs.particle.io/assets/files/libraryIndex.json. For each record in the JSON file, `attributes.name` is the name to pass to `particle library copy`, and `attributes.sentence`, `attributes.paragraph`, and the readme are useful for finding relevant libraries.
+
+## Verifying the firmware compiles
+
+Compile the project in the cloud from the project root:
+
+```
+particle compile <platform> . --saveTo firmware.bin
+```
+
+Replace `<platform>` with `particle.targetPlatform` from `.vscode/settings.json`, such as `msom`, `boron`, `p2`, or `photon2`. If that setting is missing, assume `msom`. Fix any compilation errors and compile again until the build succeeds.
+
+If you are running inside VS Code with the Particle Workbench extension and can execute VS Code build tasks, you can compile locally instead by running the `Particle: Compile application (local)` task.
+
+## Testing on a device
+
+If a device is available, flash the firmware and watch its log output:
+
+```
+particle flash <device-name>
+particle serial monitor --follow
+```
+
+`particle flash <device-name>` compiles the source code in the cloud and flashes the device over the air. Use `particle flash --local` to flash a device connected over USB.

--- a/assets/ai/AGENTS.md.template
+++ b/assets/ai/AGENTS.md.template
@@ -56,16 +56,28 @@ When the Particle local toolchain is installed, the Device OS C++ header files a
 
 ## Software libraries
 
-Firmware functionality can be augmented with community libraries. To find and install a library, run these commands from the project root (the directory containing `project.properties`):
+Firmware functionality can be augmented with community libraries. Install a library from the project root (the directory containing `project.properties`):
 
 ```
-particle library search <term>
 particle library copy <name>
 ```
 
-`particle library copy` downloads the library into the `lib/` directory, creating it if needed.
+This downloads the library into the `lib/` directory, creating it if needed.
 
-An index of the available libraries, most popular first, can be downloaded from https://docs.particle.io/assets/files/libraryIndex.json. For each record in the JSON file, `attributes.name` is the name to pass to `particle library copy`, and `attributes.sentence`, `attributes.paragraph`, and the readme are useful for finding relevant libraries.
+To find the right library name:
+
+- If you know the library name or one distinctive keyword (a chip or product name like `DS2482` or `neopixel`), run `particle library search <term>`. It matches a single literal substring of the library name and one-line description only, so multi-word capability queries like `1-wire to i2c bridge` return nothing.
+- When searching by capability, or when a search returns zero or ambiguous results, do not keep retrying search terms. Instead, download the full library index once and query it locally:
+
+  ```
+  curl -s https://docs.particle.io/assets/files/libraryIndex.json -o /tmp/libraryIndex.json
+  ```
+
+  The index holds every public library, most popular first, including each library's full readme, so it supports the full-text capability searches that `particle library search` cannot do. It is about 3 MB: query it with `jq` or a script instead of reading it into context. In each record of `.libraries[]`, `attributes.name` is the name to pass to `particle library copy`, `attributes.sentence` is the one-line description, and `readme` is the full readme text. Prefer earlier (more popular) matches. Example capability search:
+
+  ```
+  jq -r '.libraries[] | select(((.attributes.sentence // "") + (.readme // "")) | test("1-wire.*i2c|i2c.*1-wire"; "i")) | .attributes.name + " - " + (.attributes.sentence // "")' /tmp/libraryIndex.json
+  ```
 
 ## Verifying the firmware compiles
 

--- a/assets/ai/CLAUDE.md.template
+++ b/assets/ai/CLAUDE.md.template
@@ -1,3 +1,1 @@
-# Project instructions
-
-Read `AGENTS.md` in this directory for the full instructions for working on this Particle firmware project.
+@AGENTS.md

--- a/assets/ai/CLAUDE.md.template
+++ b/assets/ai/CLAUDE.md.template
@@ -1,0 +1,3 @@
+# Project instructions
+
+Read `AGENTS.md` in this directory for the full instructions for working on this Particle firmware project.

--- a/src/cli/project.js
+++ b/src/cli/project.js
@@ -6,10 +6,26 @@ module.exports = ({ commandProcessor, root }) => {
 		options: {
 			'name' : {
 				description: 'provide a name for the project'
+			},
+			'ai': {
+				description: 'also add AI assistant instruction files to the project',
+				boolean: true
 			}
 		},
 		params: '[dir]',
 		handler: (...args) => require('./project_init').command(...args)
+	});
+
+	commandProcessor.createCommand(project, 'ai', 'Add AI assistant instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md) to a project', {
+		params: '[dir]',
+		handler: (args) => {
+			const ProjectAICommand = require('../cmd/project-ai');
+			return new ProjectAICommand().addAIFiles({ dir: args.params.dir });
+		},
+		examples: {
+			'$0 $command': 'Add AI assistant instruction files to the project in the current directory',
+			'$0 $command my_project': 'Add AI assistant instruction files to the project in the my_project directory'
+		}
 	});
 
 	return project;

--- a/src/cli/project.test.js
+++ b/src/cli/project.test.js
@@ -1,0 +1,108 @@
+'use strict';
+const { expect } = require('../../test/setup');
+const commandProcessor = require('../app/command-processor');
+const project = require('./project');
+
+
+describe('Project Command-Line Interface', () => {
+	let root;
+
+	beforeEach(() => {
+		root = commandProcessor.createAppCategory();
+		project({ root, commandProcessor });
+	});
+
+	describe('Top-Level `project` Namespace', () => {
+		it('Handles `project` command', () => {
+			const argv = commandProcessor.parse(root, ['project']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.equal(undefined);
+		});
+
+		it('Includes help', () => {
+			commandProcessor.parse(root, ['project', '--help']);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Manage application projects',
+					'Usage: particle project <command>',
+					'Help:  particle help project <command>',
+					'',
+					'Commands:',
+					'  create  Create a new project in the current or specified directory',
+					'  ai      Add AI assistant instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md) to a project',
+					''
+				].join('\n'));
+			});
+		});
+	});
+
+	describe('Handles `project create` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['project', 'create', 'my-dir']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ dir: 'my-dir' });
+			expect(argv.ai).to.equal(false);
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['project', 'create']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ dir: undefined });
+			expect(argv.ai).to.equal(false);
+		});
+
+		it('Parses options', () => {
+			const argv = commandProcessor.parse(root, ['project', 'create', 'my-dir', '--name', 'my-project', '--ai']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ dir: 'my-dir' });
+			expect(argv.name).to.equal('my-project');
+			expect(argv.ai).to.equal(true);
+		});
+
+		it('Includes help', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['project', 'create', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Create a new project in the current or specified directory',
+					'Usage: particle project create [options] [dir]',
+					'',
+					'Options:',
+					'  --name  provide a name for the project  [string]',
+					'  --ai    also add AI assistant instruction files to the project  [boolean]',
+					''
+				].join('\n'));
+			});
+		});
+	});
+
+	describe('Handles `project ai` Command', () => {
+		it('Parses arguments', () => {
+			const argv = commandProcessor.parse(root, ['project', 'ai', 'my-dir']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ dir: 'my-dir' });
+		});
+
+		it('Parses optional arguments', () => {
+			const argv = commandProcessor.parse(root, ['project', 'ai']);
+			expect(argv.clierror).to.equal(undefined);
+			expect(argv.params).to.eql({ dir: undefined });
+		});
+
+		it('Includes help with examples', () => {
+			const termWidth = null; // don't right-align option type labels so testing is easier
+			commandProcessor.parse(root, ['project', 'ai', '--help'], termWidth);
+			commandProcessor.showHelp((helpText) => {
+				expect(helpText).to.equal([
+					'Add AI assistant instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md) to a project',
+					'Usage: particle project ai [options] [dir]',
+					'',
+					'Examples:',
+					'  particle project ai             Add AI assistant instruction files to the project in the current directory',
+					'  particle project ai my_project  Add AI assistant instruction files to the project in the my_project directory',
+					''
+				].join('\n'));
+			});
+		});
+	});
+});

--- a/src/cli/project_init.js
+++ b/src/cli/project_init.js
@@ -158,7 +158,13 @@ module.exports.command = (argv) => {
 	return site.dialog()
 		.then((ready) => {
 			if (ready){
-				return site.run(cmd);
+				return Promise.resolve(site.run(cmd))
+					.then(() => {
+						if (argv.ai){
+							const ProjectAICommand = require('../cmd/project-ai');
+							return new ProjectAICommand().addAIFiles({ dir: site.directory() });
+						}
+					});
 			}
 		});
 };

--- a/src/cmd/project-ai.js
+++ b/src/cmd/project-ai.js
@@ -3,7 +3,7 @@ const os = require('os');
 const path = require('path');
 const fs = require('fs-extra');
 const { loadTemplateFiles } = require('../lib/template-processor');
-const aiTemplatePath = path.join(__dirname, '/../../assets/ai');
+const aiTemplatePath = path.join(__dirname, '../../assets/ai');
 const CLICommandBase = require('./base');
 
 /**

--- a/src/cmd/project-ai.js
+++ b/src/cmd/project-ai.js
@@ -1,0 +1,37 @@
+'use strict';
+const os = require('os');
+const path = require('path');
+const fs = require('fs-extra');
+const { loadTemplateFiles } = require('../lib/template-processor');
+const aiTemplatePath = path.join(__dirname, '/../../assets/ai');
+const CLICommandBase = require('./base');
+
+/**
+ * Commands for adding AI assistant instruction files to a project.
+ * @constructor
+ */
+module.exports = class ProjectAICommand extends CLICommandBase {
+	async addAIFiles({ dir = process.cwd() } = {}) {
+		const projectPropertiesPath = path.join(dir, 'project.properties');
+		if (!await fs.pathExists(projectPropertiesPath)) {
+			throw new Error(`${dir} is not a Particle project directory (no project.properties found)`);
+		}
+
+		const files = await loadTemplateFiles({
+			templatePath: aiTemplatePath,
+			contentReplacements: {},
+			fileNameReplacements: []
+		});
+
+		for (const file of files) {
+			const relativePath = path.relative(aiTemplatePath, file.fileName);
+			const destinationPath = path.join(dir, relativePath);
+			if (await fs.pathExists(destinationPath)) {
+				this.ui.stdout.write(`Skipped ${relativePath} (already exists)${os.EOL}`);
+			} else {
+				await fs.outputFile(destinationPath, file.content);
+				this.ui.stdout.write(`Created ${relativePath}${os.EOL}`);
+			}
+		}
+	}
+};

--- a/src/cmd/project-ai.test.js
+++ b/src/cmd/project-ai.test.js
@@ -38,7 +38,7 @@ describe('ProjectAICommand', () => {
 			const claude = await fs.readFile(path.join(projectDir, 'CLAUDE.md'), 'utf8');
 			const copilot = await fs.readFile(path.join(projectDir, '.github', 'copilot-instructions.md'), 'utf8');
 			expect(agents).to.include('# Particle Firmware Project Instructions');
-			expect(claude).to.include('Read `AGENTS.md`');
+			expect(claude).to.include('@AGENTS.md');
 			expect(copilot).to.include('Read `AGENTS.md`');
 			const output = projectAICommand.ui.stdout.write.getCalls().map((call) => call.args[0]).join('');
 			expect(output).to.include('Created AGENTS.md');

--- a/src/cmd/project-ai.test.js
+++ b/src/cmd/project-ai.test.js
@@ -1,0 +1,78 @@
+'use strict';
+const fs = require('fs-extra');
+const path = require('path');
+const { expect, sinon } = require('../../test/setup');
+const ProjectAICommand = require('./project-ai');
+const { PATH_TMP_DIR } = require('../../test/lib/env');
+
+describe('ProjectAICommand', () => {
+	let projectAICommand;
+	let projectDir;
+
+	beforeEach(async () => {
+		projectAICommand = new ProjectAICommand();
+		projectAICommand.ui = {
+			stdout: {
+				write: sinon.stub()
+			},
+			stderr: {
+				write: sinon.stub()
+			}
+		};
+		projectDir = path.join(PATH_TMP_DIR, 'project-ai-test');
+		await fs.ensureDir(projectDir);
+	});
+
+	afterEach(async () => {
+		sinon.restore();
+		fs.emptyDirSync(PATH_TMP_DIR);
+	});
+
+	describe('addAIFiles', () => {
+		it('creates the AI instruction files in a fresh project', async () => {
+			await fs.writeFile(path.join(projectDir, 'project.properties'), 'name=my-project');
+
+			await projectAICommand.addAIFiles({ dir: projectDir });
+
+			const agents = await fs.readFile(path.join(projectDir, 'AGENTS.md'), 'utf8');
+			const claude = await fs.readFile(path.join(projectDir, 'CLAUDE.md'), 'utf8');
+			const copilot = await fs.readFile(path.join(projectDir, '.github', 'copilot-instructions.md'), 'utf8');
+			expect(agents).to.include('# Particle Firmware Project Instructions');
+			expect(claude).to.include('Read `AGENTS.md`');
+			expect(copilot).to.include('Read `AGENTS.md`');
+			const output = projectAICommand.ui.stdout.write.getCalls().map((call) => call.args[0]).join('');
+			expect(output).to.include('Created AGENTS.md');
+			expect(output).to.include('Created CLAUDE.md');
+			expect(output).to.include(`Created ${path.join('.github', 'copilot-instructions.md')}`);
+		});
+
+		it('skips files that already exist without overwriting them', async () => {
+			await fs.writeFile(path.join(projectDir, 'project.properties'), 'name=my-project');
+			const existingContent = '# My custom agent instructions';
+			await fs.writeFile(path.join(projectDir, 'AGENTS.md'), existingContent);
+
+			await projectAICommand.addAIFiles({ dir: projectDir });
+
+			const agents = await fs.readFile(path.join(projectDir, 'AGENTS.md'), 'utf8');
+			expect(agents).to.eql(existingContent);
+			expect(await fs.pathExists(path.join(projectDir, 'CLAUDE.md'))).to.be.true;
+			expect(await fs.pathExists(path.join(projectDir, '.github', 'copilot-instructions.md'))).to.be.true;
+			const output = projectAICommand.ui.stdout.write.getCalls().map((call) => call.args[0]).join('');
+			expect(output).to.include('Skipped AGENTS.md (already exists)');
+			expect(output).to.include('Created CLAUDE.md');
+		});
+
+		it('rejects when the directory is not a Particle project', async () => {
+			let error;
+			try {
+				await projectAICommand.addAIFiles({ dir: projectDir });
+			} catch (e) {
+				error = e;
+			}
+
+			expect(error).to.be.an.instanceof(Error);
+			expect(error.message).to.eql(`${projectDir} is not a Particle project directory (no project.properties found)`);
+			expect(await fs.pathExists(path.join(projectDir, 'AGENTS.md'))).to.be.false;
+		});
+	});
+});

--- a/test/e2e/help.e2e.js
+++ b/test/e2e/help.e2e.js
@@ -75,7 +75,7 @@ describe('Help & Unknown Command / Argument Handling', () => {
 		'logic-function enable', 'logic-function delete', 'logic-function logs', 'logic-function',
 		'login', 'logout', 'monitor', 'nyan', 'preprocess',
 		'product device list', 'product device add', 'product device remove',
-		'product device', 'product', 'profile', 'project create', 'project', 'publish',
+		'product device', 'product', 'profile', 'project create', 'project ai', 'project', 'publish',
 		'serial list', 'serial monitor', 'serial identify', 'serial wifi',
 		'serial mac', 'serial inspect', 'serial flash', 'serial', 'subscribe',
 		'tachyon setup', 'tachyon download-package', 'tachyon clean-cache',

--- a/test/e2e/project.e2e.js
+++ b/test/e2e/project.e2e.js
@@ -21,6 +21,7 @@ describe('Project Commands', () => {
 		'',
 		'Commands:',
 		'  create  Create a new project in the current or specified directory',
+		'  ai      Add AI assistant instruction files (AGENTS.md, CLAUDE.md, copilot-instructions.md) to a project',
 		'',
 		'Global Options:',
 		'  -v, --verbose  Increases how much logging to display  [count]',
@@ -144,6 +145,76 @@ describe('Project Commands', () => {
 				'src',
 				'src/test-proj.cpp'
 			]);
+		});
+
+		it('Creates a project with AI assistant instruction files using the `--ai` flag', async () => {
+			const args = ['project', 'create', '--name', projName, '--ai', PATH_TMP_DIR];
+			const { stdout, stderr, exitCode } = await cli.run(args);
+
+			expect(await fs.exists(localProjPath)).to.equal(true);
+			expect(stdout).to.include(`Initializing project in directory ${localProjPath}...`);
+			expect(stdout).to.include(`A new project has been initialized in directory ${localProjPath}`);
+			expect(stdout).to.include('Created .github/copilot-instructions.md');
+			expect(stdout).to.include('Created AGENTS.md');
+			expect(stdout).to.include('Created CLAUDE.md');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+
+			const contents = await fs.getDirectoryContents(localProjPath, { maxDepth: 2 });
+			const stripRoot = (x) => x.replace(localProjPath + path.sep, '');
+
+			expect(contents.map(stripRoot)).to.eql([
+				'.github',
+				'.github/copilot-instructions.md',
+				'.github/workflows',
+				'.github/workflows/main.yaml',
+				'.gitignore',
+				'AGENTS.md',
+				'CLAUDE.md',
+				'README.md',
+				'project.properties',
+				'src',
+				'src/test-proj.cpp'
+			]);
+		});
+	});
+
+	describe('Project AI Subcommand', () => {
+		beforeEach(async () => {
+			await cli.run(['project', 'create', '--name', projName, PATH_TMP_DIR], { reject: true });
+		});
+
+		it('Adds AI assistant instruction files to a project', async () => {
+			const { stdout, stderr, exitCode } = await cli.run(['project', 'ai', localProjPath]);
+
+			expect(stdout).to.include('Created .github/copilot-instructions.md');
+			expect(stdout).to.include('Created AGENTS.md');
+			expect(stdout).to.include('Created CLAUDE.md');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+			expect(await fs.exists(path.join(localProjPath, 'AGENTS.md'))).to.equal(true);
+			expect(await fs.exists(path.join(localProjPath, 'CLAUDE.md'))).to.equal(true);
+			expect(await fs.exists(path.join(localProjPath, '.github', 'copilot-instructions.md'))).to.equal(true);
+		});
+
+		it('Skips existing AI assistant instruction files when run again', async () => {
+			await cli.run(['project', 'ai', localProjPath], { reject: true });
+
+			const { stdout, stderr, exitCode } = await cli.run(['project', 'ai', localProjPath]);
+
+			expect(stdout).to.include('Skipped .github/copilot-instructions.md (already exists)');
+			expect(stdout).to.include('Skipped AGENTS.md (already exists)');
+			expect(stdout).to.include('Skipped CLAUDE.md (already exists)');
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(0);
+		});
+
+		it('Fails when run in a directory that is not a Particle project', async () => {
+			const { stdout, stderr, exitCode } = await cli.run(['project', 'ai', PATH_TMP_DIR]);
+
+			expect(stdout).to.include(`${PATH_TMP_DIR} is not a Particle project directory (no project.properties found)`);
+			expect(stderr).to.equal('');
+			expect(exitCode).to.equal(1);
 		});
 	});
 });


### PR DESCRIPTION
Adds the commands `particle project ai` and `particle project create --ai` to add AI agents files to make writing, compiling and testing Particle firmware easier.