### PR TITLE
tachyon: make setup recover from unfamiliar GPTs and fix 24.04 onboarding

### DIFF
--- a/src/cli/tachyon.js
+++ b/src/cli/tachyon.js
@@ -32,7 +32,8 @@ module.exports = ({ commandProcessor, root }) => {
 				description: 'Board to download package for'
 			},
 			distro_version: {
-				description: 'Linux distribution version to use'
+				description: 'Linux distribution version to use',
+				type: 'string'
 			},
 			skip_cli: {
 				description: 'Do not log in the Particle CLI',
@@ -67,7 +68,8 @@ module.exports = ({ commandProcessor, root }) => {
 				type: 'string'
 			},
 			distro_version: {
-				description: 'Linux distribution version to use'
+				description: 'Linux distribution version to use',
+				type: 'string'
 			}
 		},
 		handler: (args) => {
@@ -178,4 +180,3 @@ module.exports = ({ commandProcessor, root }) => {
 
 	return tachyon;
 };
-

--- a/src/cli/tachyon.js
+++ b/src/cli/tachyon.js
@@ -116,7 +116,7 @@ module.exports = ({ commandProcessor, root }) => {
 	commandProcessor.createCommand(tachyon, 'backup', 'Backup Tachyon NV data', {
 		options: {
 			'output-dir': {
-				description: 'Directory to save the backup files'
+				description: 'Directory to save the backup files. Defaults to the backups folder in the Particle data directory'
 			},
 			'log-dir': {
 				description: 'Directory to save the log files'
@@ -136,7 +136,7 @@ module.exports = ({ commandProcessor, root }) => {
 	commandProcessor.createCommand(tachyon, 'restore', 'Restore Tachyon NV data', {
 		options: {
 			'input-dir': {
-				description: 'Directory containing the NV data files'
+				description: 'Directory containing the NV data files. Defaults to the backups folder in the Particle data directory'
 			},
 			'log-dir': {
 				description: 'Directory to save the log files'

--- a/src/cmd/backup-restore-tachyon.js
+++ b/src/cmd/backup-restore-tachyon.js
@@ -14,9 +14,19 @@ const {
 } = require('../lib/tachyon-utils');
 const settings = require('../../settings');
 const VError = require('verror');
-const { compressDir, fileExists } = require('../lib/utilities');
+const { compressDir, fileExists, sha256File } = require('../lib/utilities');
+const { createHash } = require('crypto');
 
+// Modem NV. `persist` is deliberately absent: the WLAN and BT MACs live in modem
+// NV (read over AT with +QNVR), not there, and /persist holds only rmtfs symlinks
+// that the device recreates -- and reformats -- on its own if they go missing.
 const PARTITIONS_TO_BACKUP = ['nvdata1', 'nvdata2', 'fsc', 'fsg', 'modemst1', 'modemst2'];
+
+// Sidecar describing what was captured, so a restore can verify the bytes instead
+// of trusting six unlabelled blobs. Archives without it still restore.
+const BACKUP_METADATA_FILE = 'backup.json';
+const BACKUP_SCHEMA_VERSION = 1;
+const SECTOR_SIZE_IN_BYTES = 4096;
 
 module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 	constructor({ ui } = {}) {
@@ -24,10 +34,14 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 		this.ui = ui || this.ui;
 		this._baseDir = settings.ensureFolder();
 		this._logsDir = path.join(this._baseDir, 'logs');
+		// Default to the Particle data directory rather than the working
+		// directory: modem NV is not reproducible, and a backup left in whatever
+		// folder the command happened to run from is one `cd` away from being lost.
+		this._backupDir = path.join(this._baseDir, 'backups');
 		this._setupApi();
 	}
 
-	async backup({ 'output-dir': outputDir = process.cwd(), 'log-dir': logDir = this._logsDir, existingLog } = {}) {
+	async backup({ 'output-dir': outputDir = this._backupDir, 'log-dir': logDir = this._logsDir, existingLog } = {}) {
 		const device = await getEDLDevice({ ui: this.ui });
 		const outputDirExist = await fs.exists(outputDir);
 		const logDirExist = await fs.exists(logDir);
@@ -46,13 +60,18 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 		addLogHeaders({ outputLog, startTime, deviceId: device.id, commandName: 'Tachyon backup' });
 		try {
 			const tmpOutputDir = await temp.mkdir('tachyon_backup');
+			let sourcePartitions = [];
 			const { firehosePath, xmlFile } = await prepareFlashFiles({
 				logFile: outputLog,
 				ui: this.ui,
 				partitionsList: PARTITIONS_TO_BACKUP,
 				dir: tmpOutputDir,
 				device,
-				operation: 'read'
+				operation: 'read',
+				modifyPartitions: (partitions) => {
+					sourcePartitions = partitions;
+					return partitions;
+				}
 			});
 			const files = [
 				firehosePath, // must be first
@@ -68,6 +87,7 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 				serialNumber: device.serialNumber
 			});
 			await qdl.run();
+			await this._writeBackupMetadata({ dir: tmpOutputDir, deviceId: device.id, partitions: sourcePartitions });
 			// zip file
 			const compressedFile = await compressDir({
 				pathToCompress: tmpOutputDir,
@@ -80,6 +100,9 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 			fs.appendFileSync(outputLog, `SHA256: ${compressedFile.sha256}${os.EOL}`);
 			this.ui.stdout.write(`Created File: ${compressedFile.outputFile}${os.EOL}`);
 			this.ui.stdout.write(`Backing up NV data from device ${device.id} complete!${os.EOL}`);
+			this.ui.stdout.write(
+				`Restore it with: particle tachyon restore --filepath ${compressedFile.outputFile}${os.EOL}`
+			);
 		} catch (error) {
 			const { retry } = await handleFlashError({ error, ui: this.ui });
 			if (retry) {
@@ -98,7 +121,7 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 	}
 
 	async restore({
-		'input-dir': inputDir = process.cwd(),
+		'input-dir': inputDir = this._backupDir,
 		'log-dir': logDir = this._logsDir,
 		filepath,
 		existingLog
@@ -114,14 +137,16 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 		this.ui.stdout.write(`Restoring NV data to device ${device.id}...${os.EOL}`);
 		this.ui.stdout.write(`Logs will be saved to ${outputLog}${os.EOL}`);
 		addLogHeaders({ outputLog, startTime, deviceId: device.id, commandName: 'Tachyon restore' });
+		let zipFilePath;
 		try {
-			const zipFilePath = await this._getFilePathToRestore({
+			zipFilePath = await this._getFilePathToRestore({
 				filepath,
 				deviceId: device.id,
 				inputDir
 			});
 			const tempPath = await this.extractZipFile(zipFilePath);
 			// check the file unzip it in a temp and use it to prepare and flash.
+			let targetPartitions = [];
 			const { firehosePath, xmlFile } = await prepareFlashFiles({
 				logFile: outputLog,
 				ui: this.ui,
@@ -129,8 +154,17 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 				dir: tempPath,
 				device,
 				operation: 'program',
-				checkFiles: true
+				checkFiles: true,
+				modifyPartitions: (partitions) => {
+					targetPartitions = partitions;
+					return partitions;
+				}
 			});
+			// Everything that can be checked without touching the device is checked
+			// before the first byte is written: a half-written NV set is worse than
+			// a refused restore.
+			const metadata = await this._readBackupMetadata({ dir: tempPath, deviceId: device.id });
+			await this._verifyBackupFiles({ partitions: targetPartitions, metadata });
 			const files = [
 				firehosePath, // must be first
 				xmlFile,
@@ -145,23 +179,194 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 				serialNumber: device.serialNumber,
 			});
 			await qdl.run();
+			await this._verifyRestoredPartitions({ device, outputLog, partitions: targetPartitions });
 			this.ui.stdout.write(`Restoring NV data to device ${device.id} complete!${os.EOL}`);
 
 		} catch (error) {
 			const { retry } = await handleFlashError({ error, ui: this.ui });
 			if (retry) {
-				return this.backup({
+				return this.restore({
 					'input-dir': inputDir,
 					'log-dir': logDir,
+					filepath,
 					existingLog: outputLog,
 				});
 			}
+			this.ui.stdout.write(
+				`To retry by hand: particle tachyon restore --filepath ${zipFilePath || path.join(inputDir, `manufacturing_backup_${device.id}.zip`)}${os.EOL}`
+			);
 			this.ui.stdout.write(`An error ocurred while trying to restore up your tachyon ${os.EOL}`);
 			this.ui.stdout.write(`Verify your logs ${outputLog} for more information ${os.EOL}`);
 			throw error;
 		} finally {
 			addLogFooter({ outputLog, startTime, endTime: new Date() });
 		}
+	}
+
+	/**
+	 * Record what was captured alongside the blobs: which partition each file came
+	 * from, how big it is and its digest. A restore can then prove it is writing
+	 * the right bytes to the right place instead of trusting six unlabelled files.
+	 */
+	async _writeBackupMetadata({ dir, deviceId, partitions }) {
+		const entries = [];
+		for (const partition of partitions) {
+			const file = path.basename(partition.filename);
+			const exists = await fileExists(partition.filename);
+			if (!exists) {
+				continue;
+			}
+			const { size } = await fs.stat(partition.filename);
+			entries.push({
+				label: partition.label,
+				file,
+				lun: partition.physical_partition_number,
+				startSector: partition.start_sector,
+				numSectors: partition.num_partition_sectors,
+				bytes: size,
+				sha256: await sha256File(partition.filename)
+			});
+		}
+		const metadata = {
+			schemaVersion: BACKUP_SCHEMA_VERSION,
+			deviceId,
+			createdAt: new Date().toISOString(),
+			sectorSize: SECTOR_SIZE_IN_BYTES,
+			partitions: entries
+		};
+		await fs.writeJson(path.join(dir, BACKUP_METADATA_FILE), metadata, { spaces: 2 });
+		return metadata;
+	}
+
+	/**
+	 * Read the sidecar if the archive has one. Backups taken before it existed are
+	 * still restorable -- they just get the size checks and none of the digests.
+	 */
+	async _readBackupMetadata({ dir, deviceId }) {
+		const file = path.join(dir, BACKUP_METADATA_FILE);
+		if (!await fileExists(file)) {
+			this.ui.stdout.write(
+				`This backup predates ${BACKUP_METADATA_FILE}; restoring without content verification.${os.EOL}`
+			);
+			return null;
+		}
+		const metadata = await fs.readJson(file);
+		if (metadata.schemaVersion !== BACKUP_SCHEMA_VERSION) {
+			throw new Error(
+				`Unsupported ${BACKUP_METADATA_FILE} schema version ${metadata.schemaVersion}; this CLI understands ${BACKUP_SCHEMA_VERSION}.`
+			);
+		}
+		if (metadata.deviceId && metadata.deviceId !== deviceId) {
+			this.ui.stdout.write(this.ui.chalk.yellow(
+				`Warning: this backup was taken from device ${metadata.deviceId}, not ${deviceId}.${os.EOL}`
+			));
+		}
+		return metadata;
+	}
+
+	/**
+	 * Refuse the restore unless every file is present, intact and small enough for
+	 * the partition it is bound for. Checked up front so a mismatch never leaves
+	 * the modem with half its NV replaced.
+	 */
+	async _verifyBackupFiles({ partitions, metadata }) {
+		const byLabel = new Map((metadata?.partitions || []).map((p) => [p.label, p]));
+		const problems = [];
+
+		for (const partition of partitions) {
+			const file = partition.filename;
+			if (!await fileExists(file)) {
+				problems.push(`${partition.label}: ${path.basename(file)} is missing from the backup`);
+				continue;
+			}
+			const { size } = await fs.stat(file);
+			const capacity = partition.num_partition_sectors * SECTOR_SIZE_IN_BYTES;
+			if (size > capacity) {
+				problems.push(
+					`${partition.label}: ${size} bytes will not fit the ${capacity}-byte partition on this device`
+				);
+			}
+			const recorded = byLabel.get(partition.label);
+			if (!recorded) {
+				continue;
+			}
+			if (recorded.bytes !== size) {
+				problems.push(`${partition.label}: expected ${recorded.bytes} bytes, found ${size}`);
+				continue;
+			}
+			const digest = await sha256File(file);
+			if (recorded.sha256 && recorded.sha256 !== digest) {
+				problems.push(`${partition.label}: sha256 ${digest} does not match the recorded ${recorded.sha256}`);
+			}
+		}
+
+		if (problems.length) {
+			throw new Error(`The backup cannot be restored to this device:${os.EOL}  - ${problems.join(`${os.EOL}  - `)}`);
+		}
+	}
+
+	/**
+	 * Read the partitions back off the device and compare them with what we just
+	 * wrote. Only the first `bytes` of each read are compared: the read returns the
+	 * whole partition, while the backup may be shorter than it.
+	 */
+	async _verifyRestoredPartitions({ device, outputLog, partitions }) {
+		const verifyDir = await temp.mkdir('tachyon_restore_verify');
+		const { firehosePath, xmlFile } = await prepareFlashFiles({
+			logFile: outputLog,
+			ui: this.ui,
+			partitionsList: partitions.map((p) => p.label),
+			dir: verifyDir,
+			device,
+			operation: 'read'
+		});
+		const qdl = new QdlFlasher({
+			outputLogFile: outputLog,
+			files: [firehosePath, xmlFile],
+			ui: this.ui,
+			currTask: 'Verify restore',
+			skipReset: true,
+			serialNumber: device.serialNumber,
+		});
+		await qdl.run();
+
+		const mismatched = [];
+		for (const partition of partitions) {
+			const readBack = path.join(verifyDir, path.basename(partition.filename));
+			if (!await fileExists(readBack)) {
+				mismatched.push(`${partition.label}: could not be read back from the device`);
+				continue;
+			}
+			const { size } = await fs.stat(partition.filename);
+			const [expected, actual] = await Promise.all([
+				this._sha256Prefix(partition.filename, size),
+				this._sha256Prefix(readBack, size)
+			]);
+			if (expected !== actual) {
+				mismatched.push(`${partition.label}: written bytes do not match the backup`);
+			}
+		}
+		if (mismatched.length) {
+			throw new Error(
+				`Restore verification failed:${os.EOL}  - ${mismatched.join(`${os.EOL}  - `)}${os.EOL}` +
+				'The device may have partially restored NV data; re-run the restore before using it.'
+			);
+		}
+		fs.appendFileSync(outputLog, `Verified ${partitions.length} restored partitions${os.EOL}`);
+	}
+
+	/** sha256 of the first `length` bytes of a file. */
+	_sha256Prefix(filePath, length) {
+		return new Promise((resolve, reject) => {
+			if (length === 0) {
+				return resolve(createHash('sha256').digest('hex'));
+			}
+			const hash = createHash('sha256');
+			const stream = fs.createReadStream(filePath, { start: 0, end: length - 1 });
+			stream.on('data', (chunk) => hash.update(chunk));
+			stream.on('end', () => resolve(hash.digest('hex')));
+			stream.on('error', reject);
+		});
 	}
 
 	async _getFilePathToRestore({ filepath, deviceId, inputDir }) {
@@ -179,6 +384,13 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 		if (defaultFileExists) {
 			this.ui.stdout.write(`Using zip file from ${defaultFileName} ${os.EOL}`);
 			return defaultFileName;
+		}
+		// Backups taken before they were stored under the Particle data directory
+		// landed in whatever directory the command ran from; still accept those.
+		const legacyFileName = path.join(process.cwd(), `manufacturing_backup_${deviceId}.zip`);
+		if (legacyFileName !== defaultFileName && await fileExists(legacyFileName)) {
+			this.ui.stdout.write(`Using zip file from ${legacyFileName} ${os.EOL}`);
+			return legacyFileName;
 		}
 		this.ui.stdout.write(`Downloading file at ${defaultFileName}${os.EOL}`);
 		const resp = await this.api.downloadManufacturingBackup({ deviceId });

--- a/src/cmd/backup-restore-tachyon.js
+++ b/src/cmd/backup-restore-tachyon.js
@@ -96,12 +96,12 @@ module.exports = class BackupRestoreTachyonCommand extends CLICommandBase {
 			});
 			fs.appendFileSync(outputLog, `==================${os.EOL}`);
 			fs.appendFileSync(outputLog, `Backup Done${os.EOL}`);
-			fs.appendFileSync(outputLog, `Created File: ${compressedFile.outputFile}${os.EOL}`);
+			fs.appendFileSync(outputLog, `Created File: ${compressedFile.zipPath}${os.EOL}`);
 			fs.appendFileSync(outputLog, `SHA256: ${compressedFile.sha256}${os.EOL}`);
-			this.ui.stdout.write(`Created File: ${compressedFile.outputFile}${os.EOL}`);
+			this.ui.stdout.write(`Created File: ${compressedFile.zipPath}${os.EOL}`);
 			this.ui.stdout.write(`Backing up NV data from device ${device.id} complete!${os.EOL}`);
 			this.ui.stdout.write(
-				`Restore it with: particle tachyon restore --filepath ${compressedFile.outputFile}${os.EOL}`
+				`Restore it with: particle tachyon restore --filepath ${compressedFile.zipPath}${os.EOL}`
 			);
 		} catch (error) {
 			const { retry } = await handleFlashError({ error, ui: this.ui });

--- a/src/cmd/backup-restore-tachyon.test.js
+++ b/src/cmd/backup-restore-tachyon.test.js
@@ -1,0 +1,233 @@
+'use strict';
+const os = require('os');
+const path = require('path');
+const fs = require('fs-extra');
+const { createHash } = require('crypto');
+const proxyquire = require('proxyquire');
+const { expect, sinon } = require('../../test/setup');
+
+// The command destructures its helpers at require time, so the stubs have to be
+// stable functions that forward to whatever the current test installed.
+let getEDLDevice, prepareFlashFiles, handleFlashError;
+const tachyonUtils = {
+	addLogHeaders: (...args) => addLogHeaders(...args),
+	addLogFooter: () => {},
+	getEDLDevice: (...args) => getEDLDevice(...args),
+	prepareFlashFiles: (...args) => prepareFlashFiles(...args),
+	handleFlashError: (...args) => handleFlashError(...args)
+};
+let addLogHeaders;
+
+let qdlRun;
+class FakeQdlFlasher {
+	run() {
+		return qdlRun();
+	}
+}
+
+let baseDir;
+const settings = { ensureFolder: () => baseDir };
+
+const BackupRestoreTachyonCommand = proxyquire('./backup-restore-tachyon', {
+	'../lib/tachyon-utils': tachyonUtils,
+	'../lib/qdl': FakeQdlFlasher,
+	'../../settings': settings
+});
+
+function fakeUi() {
+	return { stdout: { write: sinon.stub() }, chalk: { yellow: (s) => s } };
+}
+
+function partition(label, numSectors, filename) {
+	return {
+		label,
+		physical_partition_number: 5,
+		start_sector: 1088,
+		num_partition_sectors: numSectors,
+		filename
+	};
+}
+
+describe('BackupRestoreTachyonCommand', () => {
+	let command, ui, dir;
+
+	beforeEach(async () => {
+		baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachyon-particle-'));
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachyon-backup-'));
+		ui = fakeUi();
+		addLogHeaders = sinon.stub();
+		getEDLDevice = sinon.stub().resolves({ id: 'e00fce68', serialNumber: '1' });
+		prepareFlashFiles = sinon.stub().resolves({ firehosePath: 'fh.elf', xmlFile: 'x.xml' });
+		handleFlashError = sinon.stub().resolves({ retry: false });
+		qdlRun = sinon.stub().resolves();
+		command = new BackupRestoreTachyonCommand({ ui });
+	});
+
+	afterEach(async () => {
+		await Promise.all([fs.remove(dir), fs.remove(baseDir)]);
+		sinon.restore();
+	});
+
+	describe('backup metadata', () => {
+		it('records geometry, size and digest for every captured partition', async () => {
+			const file = path.join(dir, 'e00fce68_modemst1.backup');
+			await fs.writeFile(file, Buffer.alloc(4096, 7));
+			const metadata = await command._writeBackupMetadata({
+				dir, deviceId: 'e00fce68', partitions: [partition('modemst1', 1024, file)]
+			});
+
+			expect(metadata.schemaVersion).to.equal(1);
+			expect(metadata.partitions[0]).to.include({
+				label: 'modemst1', lun: 5, startSector: 1088, numSectors: 1024, bytes: 4096
+			});
+			expect(metadata.partitions[0].sha256)
+				.to.equal(createHash('sha256').update(Buffer.alloc(4096, 7)).digest('hex'));
+			expect(await fs.pathExists(path.join(dir, 'backup.json'))).to.equal(true);
+		});
+
+		it('restores an archive that predates the sidecar', async () => {
+			expect(await command._readBackupMetadata({ dir, deviceId: 'e00fce68' })).to.equal(null);
+			expect(ui.stdout.write).to.have.been.calledWithMatch(/predates backup.json/);
+		});
+
+		it('refuses a sidecar written by a newer CLI', async () => {
+			await fs.writeJson(path.join(dir, 'backup.json'), { schemaVersion: 99, partitions: [] });
+			await expect(command._readBackupMetadata({ dir, deviceId: 'e00fce68' }))
+				.to.be.rejectedWith(/schema version 99/);
+		});
+
+		it('warns when the backup came from a different device', async () => {
+			await fs.writeJson(path.join(dir, 'backup.json'), {
+				schemaVersion: 1, deviceId: 'deadbeef', partitions: []
+			});
+			await command._readBackupMetadata({ dir, deviceId: 'e00fce68' });
+			expect(ui.stdout.write).to.have.been.calledWithMatch(/taken from device deadbeef/);
+		});
+	});
+
+	describe('_verifyBackupFiles', () => {
+		let file, partitions;
+
+		beforeEach(async () => {
+			file = path.join(dir, 'e00fce68_modemst1.backup');
+			await fs.writeFile(file, Buffer.alloc(4096, 7));
+			partitions = [partition('modemst1', 1024, file)];
+		});
+
+		it('accepts a legacy archive with no recorded digests', async () => {
+			await command._verifyBackupFiles({ partitions, metadata: null });
+		});
+
+		it('rejects a file that would overrun its target partition', async () => {
+			// a 1.5MiB nvdata backup restored onto a device whose nvdata is 1MiB
+			await fs.writeFile(file, Buffer.alloc(8192, 7));
+			await expect(command._verifyBackupFiles({
+				partitions: [partition('modemst1', 1, file)], metadata: null
+			})).to.be.rejectedWith(/8192 bytes will not fit the 4096-byte partition/);
+		});
+
+		it('rejects a missing file before anything is written', async () => {
+			await fs.remove(file);
+			await expect(command._verifyBackupFiles({ partitions, metadata: null }))
+				.to.be.rejectedWith(/is missing from the backup/);
+		});
+
+		it('rejects a file whose content no longer matches the sidecar', async () => {
+			const metadata = await command._writeBackupMetadata({ dir, deviceId: 'e00fce68', partitions });
+			await fs.writeFile(file, Buffer.alloc(4096, 9));
+			await expect(command._verifyBackupFiles({ partitions, metadata }))
+				.to.be.rejectedWith(/sha256 .* does not match the recorded/);
+		});
+
+		it('reports every problem at once rather than the first', async () => {
+			const other = path.join(dir, 'e00fce68_fsc.backup');
+			await fs.remove(file);
+			await expect(command._verifyBackupFiles({
+				partitions: [...partitions, partition('fsc', 1024, other)], metadata: null
+			})).to.be.rejectedWith(/modemst1[\s\S]*fsc/);
+		});
+	});
+
+	describe('_verifyRestoredPartitions', () => {
+		let source, verifyDir, partitions;
+
+		beforeEach(async () => {
+			source = path.join(dir, 'e00fce68_modemst1.backup');
+			await fs.writeFile(source, Buffer.alloc(4096, 7));
+			partitions = [partition('modemst1', 1024, source)];
+			// prepareFlashFiles is handed the directory the read-back lands in; the
+			// fake qdl "reads" by writing that file itself.
+			prepareFlashFiles = sinon.stub().callsFake(async ({ dir: readDir }) => {
+				verifyDir = readDir;
+				return { firehosePath: 'fh.elf', xmlFile: 'x.xml' };
+			});
+		});
+
+		it('passes when the device reads back what was written', async () => {
+			qdlRun = sinon.stub().callsFake(async () => {
+				// the partition is larger than the backup: the tail is device state
+				await fs.writeFile(
+					path.join(verifyDir, 'e00fce68_modemst1.backup'),
+					Buffer.concat([Buffer.alloc(4096, 7), Buffer.alloc(4096, 0)])
+				);
+			});
+			await command._verifyRestoredPartitions({
+				device: { id: 'e00fce68', serialNumber: '1' },
+				outputLog: path.join(dir, 'log.txt'),
+				partitions
+			});
+		});
+
+		it('fails when the written bytes differ', async () => {
+			qdlRun = sinon.stub().callsFake(async () => {
+				await fs.writeFile(path.join(verifyDir, 'e00fce68_modemst1.backup'), Buffer.alloc(4096, 9));
+			});
+			await expect(command._verifyRestoredPartitions({
+				device: { id: 'e00fce68', serialNumber: '1' },
+				outputLog: path.join(dir, 'log.txt'),
+				partitions
+			})).to.be.rejectedWith(/written bytes do not match the backup/);
+		});
+
+		it('fails when a partition cannot be read back at all', async () => {
+			qdlRun = sinon.stub().resolves();
+			await expect(command._verifyRestoredPartitions({
+				device: { id: 'e00fce68', serialNumber: '1' },
+				outputLog: path.join(dir, 'log.txt'),
+				partitions
+			})).to.be.rejectedWith(/could not be read back/);
+		});
+	});
+
+	describe('restore retry', () => {
+		beforeEach(() => {
+			command._getFilePathToRestore = sinon.stub().resolves(path.join(dir, 'backup.zip'));
+			command.extractZipFile = sinon.stub().resolves(dir);
+			command._verifyBackupFiles = sinon.stub().resolves();
+			command._verifyRestoredPartitions = sinon.stub().resolves();
+			command._readBackupMetadata = sinon.stub().resolves(null);
+		});
+
+		it('retries the restore, not a backup', async () => {
+			// The catch used to call this.backup(), which does not even accept
+			// input-dir: a failed restore quietly overwrote the archive instead.
+			prepareFlashFiles = sinon.stub()
+				.onFirstCall().rejects(new Error('device went away'))
+				.onSecondCall().resolves({ firehosePath: 'fh.elf', xmlFile: 'x.xml' });
+			handleFlashError = sinon.stub()
+				.onFirstCall().resolves({ retry: true })
+				.onSecondCall().resolves({ retry: false });
+
+			await command.restore({ 'input-dir': dir, 'log-dir': dir });
+
+			const commands = addLogHeaders.getCalls().map((c) => c.args[0].commandName);
+			expect(commands).to.eql(['Tachyon restore', 'Tachyon restore']);
+		});
+
+		it('prints the command to run by hand when it gives up', async () => {
+			prepareFlashFiles = sinon.stub().rejects(new Error('device went away'));
+			await expect(command.restore({ 'input-dir': dir, 'log-dir': dir })).to.be.rejected;
+			expect(ui.stdout.write).to.have.been.calledWithMatch(/particle tachyon restore --filepath/);
+		});
+	});
+});

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -10,7 +10,14 @@ const os = require('os');
 
 const DownloadManager = require('../lib/download-manager');
 const path = require('path');
-const { getTachyonInfo, getEDLDevice, handleFlashError, promptOSSelection, isFile, readManifestFromLocalFile
+const {
+	getTachyonInfo,
+	getEDLDevice,
+	handleFlashError,
+	promptOSSelection,
+	isFile,
+	readManifestFromLocalFile,
+	lookupCloudDeviceInfo
 } = require('../lib/tachyon-utils');
 const { TachyonConnectionError } = require('../lib/qdl');
 const { workflows, workflowRun } = require('../lib/tachyon/workflow');
@@ -48,10 +55,9 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		this._logsDir = path.join(this._baseDir, 'logs');
 		this.downloadManager = new DownloadManager(this.ui);
 		this.outputLog = null;
+		this._hardwareOptionSources = {};
 		this.defaultOptions = {
-			region: 'NA',
 			version: settings.tachyonVersion || 'stable',
-			board: 'formfactor_dvt',
 			distroVersion: '20.04',
 			country: settings.profile_json.country || 'USA',
 			variant: null,
@@ -83,19 +89,28 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			this.outputLog = path.join(this._logsDir, `tachyon_flash_${this.device.id}_${Date.now()}.log`);
 			await fs.ensureFile(this.outputLog);
 			this.ui.write(`${os.EOL}Starting Process. See logs at: ${this.outputLog}${os.EOL}`);
+			// EDL supplies the device ID without touching storage, so begin the cloud
+			// lookup immediately while the slower best-effort local read runs.
+			const cloudInfoPromise = lookupCloudDeviceInfo({ deviceId: this.device.id, api: this.api });
 			const deviceInfo = await this._getDeviceInfo();
 			deviceInfo.usbVersion = this.device.usbVersion.major;
-			this._printDeviceInfo(deviceInfo);
 			// check if there is a config file
 			// validate version if local then workflow will be inferred from the manifest
 			const isLocalVersion = version ? await isFile(version) : false;
-			const config = await this._loadConfig({ options, deviceInfo, isLocalVersion });
+			const cloudInfo = await cloudInfoPromise;
+			const config = await this._loadConfig({ options, deviceInfo, cloudInfo, isLocalVersion });
+			const resolvedDeviceInfo = {
+				...deviceInfo,
+				region: config.region,
+				board: config.board
+			};
+			this._printDeviceInfo(resolvedDeviceInfo);
 
 			const context = {
 				...config,
 				ui: this.ui,
 				api: this.api,
-				deviceInfo: deviceInfo,
+				deviceInfo: resolvedDeviceInfo,
 				device: this.device,
 				log: {
 					file: this.outputLog,
@@ -124,13 +139,11 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 				device: this.device
 			}));
 		} catch (error) {
-			// Preserve the retry flow for a transport failure. Layout errors fall
-			// through to the EDL-only identity below.
-			const { retry } = await handleFlashError({ error, ui: this.ui });
-			if (retry) {
-				return this._getDeviceInfo();
-			}
 			if (error instanceof TachyonConnectionError) {
+				const { retry } = await handleFlashError({ error, ui: this.ui });
+				if (retry) {
+					return this._getDeviceInfo();
+				}
 				throw new Error('Unable to communicate with the device. Please restart the device and try again.');
 			}
 
@@ -139,27 +152,34 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			// GPT must not prevent an image containing its own GPT from being flashed.
 			this.ui.write(this.ui.chalk.yellow(
 				`Could not read the existing device layout: ${error.message}${os.EOL}` +
-				`Continuing with the identity reported in EDL mode. Setup will use any ` +
-				`--region and --board options, then its normal defaults.${os.EOL}`
+				`Continuing with the identity reported in EDL mode. Setup will use explicit ` +
+				`options, a loaded configuration, Particle Cloud, or ask you.${os.EOL}`
 			));
 			return {
 				deviceId: this.device.id,
 				region: 'Unknown',
 				manufacturingData: 'Unknown',
 				osVersion: 'Unknown',
-				board: this.defaultOptions.board
+				board: 'Unknown'
 			};
 		}
 	}
 
 	async _printDeviceInfo(deviceInfo) {
+		const sourceSuffix = (name) => {
+			const source = this._hardwareOptionSources[name];
+			return source && source !== 'device' ? ` (from ${source})` : '';
+		};
+		const boardNames = {
+			formfactor: 'EVT',
+			formfactor_dvt: 'DVT or later',
+			rb3g2: 'Qualcomm RB3 Gen 2'
+		};
 		this.ui.write(this.ui.chalk.bold('Device info:'));
 		this.ui.write(os.EOL);
 		this.ui.write(` -  Device ID: ${deviceInfo.deviceId}`);
-		if (deviceInfo.board === 'formfactor') {
-			this.ui.write(' -  Board: EVT');
-		}
-		this.ui.write(` -  Region: ${deviceInfo.region}`);
+		this.ui.write(` -  Board: ${boardNames[deviceInfo.board] || deviceInfo.board}${sourceSuffix('board')}`);
+		this.ui.write(` -  Region: ${deviceInfo.region}${sourceSuffix('region')}`);
 		this.ui.write(` -  OS Version: ${deviceInfo.osVersion}`);
 		let usbWarning = '';
 		if (this.device.usbVersion.major <= 2) {
@@ -192,9 +212,14 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 	 * @return {Promise<void>}
 	 * @private
 	 */
-	async _loadConfig({ options, deviceInfo, isLocalVersion }) {
+	async _loadConfig({ options, deviceInfo, cloudInfo, isLocalVersion }) {
 		const configFromFile = await this._loadConfigFromFile(options.loadConfig);
-		const optionsFromDevice = {};
+		const hardwareOptions = await this._resolveHardwareOptions({
+			options,
+			configFromFile,
+			deviceInfo,
+			cloudInfo
+		});
 
 		const selectedWorkflow = await this._selectWorkflow({
 			isLocalVersion,
@@ -206,17 +231,12 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		const cleanedOptions = Object.fromEntries(
 			Object.entries(options).filter(([_, v]) => v !== undefined)
 		);
-		if (deviceInfo) {
-			optionsFromDevice.region = deviceInfo.region.toLowerCase() !== 'unknown' ? deviceInfo.region : 'NA';
-			optionsFromDevice.board = deviceInfo.board;
-		}
-
 		const config = {
 			...this.defaultOptions,
 			...selectedWorkflow?.overrideDefaults,
-			...optionsFromDevice,
 			...configFromFile,
 			...cleanedOptions,
+			...hardwareOptions,
 			workflow: selectedWorkflow,
 			isLocalVersion: !!isLocalVersion
 		};
@@ -237,6 +257,74 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		}
 
 		return config;
+	}
+
+	/**
+	 * Resolve region and board independently. The first known value wins:
+	 *
+	 *   1. command-line option (the operator's most explicit choice)
+	 *   2. loaded setup configuration
+	 *   3. the physical device's current partitions
+	 *   4. the device's Particle Cloud record
+	 *   5. interactive user input
+	 *
+	 * "Unknown" is not a value and never prevents a later source from answering.
+	 * There is deliberately no implicit NA or DVT fallback: choosing the wrong
+	 * region or board can select an incompatible image.
+	 */
+	async _resolveHardwareOptions({ options, configFromFile, deviceInfo, cloudInfo }) {
+		const resolve = async (name, prompt) => {
+			const candidates = [
+				{ value: options?.[name], source: 'command line' },
+				{ value: configFromFile?.[name], source: 'loaded configuration' },
+				{ value: deviceInfo?.[name], source: 'device' },
+				{ value: cloudInfo?.[name], source: 'Particle Cloud' }
+			];
+			const selected = candidates.find(({ value }) => this._isKnownHardwareOption(value));
+			if (selected) {
+				this._hardwareOptionSources[name] = selected.source;
+				return selected.value;
+			}
+			const value = await prompt();
+			this._hardwareOptionSources[name] = 'user input';
+			return value;
+		};
+
+		return {
+			region: await resolve('region', () => this._selectRegion()),
+			board: await resolve('board', () => this._selectBoard())
+		};
+	}
+
+	_isKnownHardwareOption(value) {
+		return typeof value === 'string' && value.trim() !== '' && value.toLowerCase() !== 'unknown';
+	}
+
+	async _selectRegion() {
+		const { region } = await this.ui.prompt([{
+			type: 'list',
+			name: 'region',
+			message: 'Select the device region:',
+			choices: [
+				{ name: 'NA (North America)', value: 'NA' },
+				{ name: 'RoW (Rest of the World)', value: 'RoW' }
+			]
+		}]);
+		return region;
+	}
+
+	async _selectBoard() {
+		const { board } = await this.ui.prompt([{
+			type: 'list',
+			name: 'board',
+			message: 'Select the device board:',
+			choices: [
+				{ name: 'Tachyon EVT', value: 'formfactor' },
+				{ name: 'Tachyon DVT or later', value: 'formfactor_dvt' },
+				{ name: 'Qualcomm RB3 Gen 2', value: 'rb3g2' }
+			]
+		}]);
+		return board;
 	}
 
 	async _selectWorkflow({ isLocalVersion, version, configFromFile, defaultWorkflow }) {
@@ -262,8 +350,6 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			try {
 				const data = fs.readFileSync(loadConfig, 'utf8');
 				const config = JSON.parse(data);
-				// remove board to prevent overwriting.
-				delete config.board;
 				return { ...config, silent: true, loadedFromFile: true };
 			} catch (error) {
 				throw new VError(error, 'The configuration file is not a valid JSON file');
@@ -284,6 +370,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 	async _saveConfig(config) {
 		const configFields = [
 			'region',
+			'board',
 			'version',
 			'variant',
 			'skipCli',

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -12,6 +12,7 @@ const DownloadManager = require('../lib/download-manager');
 const path = require('path');
 const { getTachyonInfo, getEDLDevice, handleFlashError, promptOSSelection, isFile, readManifestFromLocalFile
 } = require('../lib/tachyon-utils');
+const { TachyonConnectionError } = require('../lib/qdl');
 const { workflows, workflowRun } = require('../lib/tachyon/workflow');
 
 const showWelcomeMessage = (ui) => `
@@ -123,12 +124,31 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 				device: this.device
 			}));
 		} catch (error) {
-			// If this fails, the flash won't work so abort early.
+			// Preserve the retry flow for a transport failure. Layout errors fall
+			// through to the EDL-only identity below.
 			const { retry } = await handleFlashError({ error, ui: this.ui });
 			if (retry) {
 				return this._getDeviceInfo();
 			}
-			throw new Error('Unable to get device info. Please restart the device and try again.');
+			if (error instanceof TachyonConnectionError) {
+				throw new Error('Unable to communicate with the device. Please restart the device and try again.');
+			}
+
+			// Identification is useful for automatically preserving the region and board
+			// type, but it describes the layout being replaced. A blank, corrupt, or new
+			// GPT must not prevent an image containing its own GPT from being flashed.
+			this.ui.write(this.ui.chalk.yellow(
+				`Could not read the existing device layout: ${error.message}${os.EOL}` +
+				`Continuing with the identity reported in EDL mode. Setup will use any ` +
+				`--region and --board options, then its normal defaults.${os.EOL}`
+			));
+			return {
+				deviceId: this.device.id,
+				region: 'Unknown',
+				manufacturingData: 'Unknown',
+				osVersion: 'Unknown',
+				board: this.defaultOptions.board
+			};
 		}
 	}
 

--- a/src/cmd/setup-tachyon.js
+++ b/src/cmd/setup-tachyon.js
@@ -224,6 +224,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		const selectedWorkflow = await this._selectWorkflow({
 			isLocalVersion,
 			version: options.version,
+			distroVersion: options.distroVersion,
 			configFromFile,
 			defaultWorkflow: this.defaultOptions.workflow
 		});
@@ -237,6 +238,7 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			...configFromFile,
 			...cleanedOptions,
 			...hardwareOptions,
+			distroVersion: selectedWorkflow.osInfo.distributionVersion,
 			workflow: selectedWorkflow,
 			isLocalVersion: !!isLocalVersion
 		};
@@ -327,13 +329,36 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 		return board;
 	}
 
-	async _selectWorkflow({ isLocalVersion, version, configFromFile, defaultWorkflow }) {
+	async _selectWorkflow({ isLocalVersion, version, distroVersion, configFromFile, defaultWorkflow }) {
+		const requestedWorkflow = distroVersion ? this._getUbuntuWorkflow(distroVersion) : null;
+
+		// A local image is authoritative because its embedded manifest describes what
+		// will actually be flashed. An explicit distro may confirm it, but may not
+		// contradict it.
 		if (isLocalVersion) {
 			const manifest = await readManifestFromLocalFile(version);
-			return Object.values(workflows).find(wf =>
+			const imageWorkflow = Object.values(workflows).find(wf =>
 				wf.osInfo.distribution === manifest.distribution &&
 				wf.osInfo.distributionVersion === manifest.distribution_version
 			);
+			if (!imageWorkflow) {
+				throw new Error(
+					`The local image uses unsupported distribution '${manifest.distribution} ${manifest.distribution_version}'`
+				);
+			}
+			if (requestedWorkflow && requestedWorkflow !== imageWorkflow) {
+				throw new Error(
+					`The requested distribution version '${distroVersion}' does not match the local image ` +
+					`distribution version '${manifest.distribution_version}'`
+				);
+			}
+			return imageWorkflow;
+		}
+
+		// An explicit command-line distro is the user's selection. It takes priority
+		// over a loaded configuration and avoids asking the OS selection question.
+		if (requestedWorkflow) {
+			return requestedWorkflow;
 		}
 		if (configFromFile?.workflow) {
 			return workflows[configFromFile.workflow];
@@ -343,6 +368,19 @@ module.exports = class SetupTachyonCommands extends CLICommandBase {
 			return this._pickWorkflowToExecute();
 		}
 		return defaultWorkflow;
+	}
+
+	_getUbuntuWorkflow(distroVersion) {
+		const normalizedVersion = String(distroVersion).trim();
+		const ubuntuWorkflows = Object.values(workflows).filter(wf => wf.osInfo.distribution === 'ubuntu');
+		const workflow = ubuntuWorkflows.find(wf => wf.osInfo.distributionVersion === normalizedVersion);
+		if (!workflow) {
+			const supportedVersions = ubuntuWorkflows.map(wf => wf.osInfo.distributionVersion).join(', ');
+			throw new Error(
+				`Unsupported Linux distribution version '${normalizedVersion}'. Supported versions: ${supportedVersions}`
+			);
+		}
+		return workflow;
 	}
 
 	async _loadConfigFromFile(loadConfig) {

--- a/src/cmd/setup-tachyon.test.js
+++ b/src/cmd/setup-tachyon.test.js
@@ -10,6 +10,7 @@ let getEDLDevice;
 let getTachyonInfo;
 let lookupCloudDeviceInfo;
 let handleFlashError;
+let readManifestFromLocalFile;
 let workflowRun;
 let baseDir;
 
@@ -17,7 +18,23 @@ const tachyonUtils = {
 	getEDLDevice: (...args) => getEDLDevice(...args),
 	getTachyonInfo: (...args) => getTachyonInfo(...args),
 	lookupCloudDeviceInfo: (...args) => lookupCloudDeviceInfo(...args),
-	handleFlashError: (...args) => handleFlashError(...args)
+	handleFlashError: (...args) => handleFlashError(...args),
+	readManifestFromLocalFile: (...args) => readManifestFromLocalFile(...args)
+};
+
+const workflowFixtures = {
+	ubuntu20: {
+		value: 'ubuntu20',
+		osInfo: { distribution: 'ubuntu', distributionVersion: '20.04' }
+	},
+	ubuntu24: {
+		value: 'ubuntu24',
+		osInfo: { distribution: 'ubuntu', distributionVersion: '24.04' }
+	},
+	android14: {
+		value: 'android14',
+		osInfo: { distribution: 'android', distributionVersion: '14' }
+	}
 };
 
 const settings = {
@@ -30,7 +47,7 @@ const settings = {
 const SetupTachyonCommand = proxyquire('./setup-tachyon', {
 	'../lib/tachyon-utils': tachyonUtils,
 	'../lib/tachyon/workflow': {
-		workflows: { ubuntu20: { value: 'ubuntu20' } },
+		workflows: workflowFixtures,
 		workflowRun: (...args) => workflowRun(...args)
 	},
 	'../lib/api-call': {
@@ -68,6 +85,7 @@ describe('SetupTachyonCommand', () => {
 		getTachyonInfo = sinon.stub();
 		lookupCloudDeviceInfo = sinon.stub().resolves(null);
 		handleFlashError = sinon.stub().resolves(false);
+		readManifestFromLocalFile = sinon.stub();
 		workflowRun = sinon.stub().resolves({});
 		command = new SetupTachyonCommand({ ui });
 		command.device = device;
@@ -153,6 +171,81 @@ describe('SetupTachyonCommand', () => {
 			board: 'formfactor',
 			silent: true,
 			loadedFromFile: true
+		});
+	});
+
+	describe('workflow selection', () => {
+		for (const [distroVersion, workflowName] of [['20.04', 'ubuntu20'], ['24.04', 'ubuntu24']]) {
+			it(`uses explicit distro version ${distroVersion} and skips the OS selection prompt`, async () => {
+				const selectInteractively = sinon.stub(command, '_pickWorkflowToExecute');
+				sinon.stub(command, '_resolveHardwareOptions').resolves({ region: 'NA', board: 'formfactor_dvt' });
+				sinon.stub(command, '_getManifestBuilds').resolves([]);
+
+				const config = await command._loadConfig({
+					options: { distroVersion },
+					deviceInfo: {},
+					cloudInfo: null,
+					isLocalVersion: false
+				});
+
+				expect(config.workflow).to.equal(workflowFixtures[workflowName]);
+				expect(config.distroVersion).to.equal(distroVersion);
+				expect(selectInteractively).not.to.have.been.called;
+				expect(command._getManifestBuilds).to.have.been.calledWithMatch({
+					osInfo: workflowFixtures[workflowName].osInfo
+				});
+			});
+		}
+
+		it('keeps distro metadata aligned with an interactive OS selection', async () => {
+			sinon.stub(command, '_pickWorkflowToExecute').resolves(workflowFixtures.ubuntu24);
+			sinon.stub(command, '_resolveHardwareOptions').resolves({ region: 'NA', board: 'formfactor_dvt' });
+			sinon.stub(command, '_getManifestBuilds').resolves([]);
+
+			const config = await command._loadConfig({
+				options: {},
+				deviceInfo: {},
+				cloudInfo: null,
+				isLocalVersion: false
+			});
+
+			expect(config.workflow).to.equal(workflowFixtures.ubuntu24);
+			expect(config.distroVersion).to.equal('24.04');
+		});
+
+		it('lets an explicit distro version override a loaded workflow', async () => {
+			const workflow = await command._selectWorkflow({
+				isLocalVersion: false,
+				distroVersion: '24.04',
+				configFromFile: { workflow: 'ubuntu20' },
+				defaultWorkflow: workflowFixtures.ubuntu20
+			});
+
+			expect(workflow).to.equal(workflowFixtures.ubuntu24);
+		});
+
+		it('rejects an unsupported explicit distro version', async () => {
+			await expect(command._selectWorkflow({
+				isLocalVersion: false,
+				distroVersion: '22.04',
+				configFromFile: {},
+				defaultWorkflow: workflowFixtures.ubuntu20
+			})).to.be.rejectedWith("Unsupported Linux distribution version '22.04'");
+		});
+
+		it('rejects a distro version that conflicts with a local image', async () => {
+			readManifestFromLocalFile.resolves({
+				distribution: 'ubuntu',
+				distribution_version: '20.04'
+			});
+
+			await expect(command._selectWorkflow({
+				isLocalVersion: true,
+				version: '/tmp/tachyon-ubuntu-20.04.zip',
+				distroVersion: '24.04',
+				configFromFile: {},
+				defaultWorkflow: workflowFixtures.ubuntu20
+			})).to.be.rejectedWith("does not match the local image distribution version '20.04'");
 		});
 	});
 

--- a/src/cmd/setup-tachyon.test.js
+++ b/src/cmd/setup-tachyon.test.js
@@ -1,0 +1,140 @@
+'use strict';
+const os = require('os');
+const path = require('path');
+const fs = require('fs-extra');
+const proxyquire = require('proxyquire');
+const { expect, sinon } = require('../../test/setup');
+const { TachyonConnectionError } = require('../lib/qdl');
+
+let getEDLDevice;
+let getTachyonInfo;
+let handleFlashError;
+let workflowRun;
+let baseDir;
+
+const tachyonUtils = {
+	getEDLDevice: (...args) => getEDLDevice(...args),
+	getTachyonInfo: (...args) => getTachyonInfo(...args),
+	handleFlashError: (...args) => handleFlashError(...args)
+};
+
+const settings = {
+	ensureFolder: () => baseDir,
+	tachyonVersion: 'stable',
+	profile_json: { country: 'USA' },
+	isStaging: false
+};
+
+const SetupTachyonCommand = proxyquire('./setup-tachyon', {
+	'../lib/tachyon-utils': tachyonUtils,
+	'../lib/tachyon/workflow': {
+		workflows: { ubuntu20: { value: 'ubuntu20' } },
+		workflowRun: (...args) => workflowRun(...args)
+	},
+	'../lib/api-call': {
+		getCurrentUsername: sinon.stub().resolves('test@example.com')
+	},
+	'../../settings': settings
+});
+
+function fakeUi() {
+	const identity = (value) => value;
+	return {
+		write: sinon.stub(),
+		stdout: { write: sinon.stub() },
+		showBusySpinnerUntilResolved: sinon.stub().callsFake((_text, promise) => promise),
+		chalk: {
+			bold: identity,
+			yellow: identity
+		}
+	};
+}
+
+describe('SetupTachyonCommand', () => {
+	let command;
+	let ui;
+	const device = {
+		id: '422a060000000000d0c7965f',
+		serialNumber: 'D0C7965F',
+		usbVersion: { major: 3, minor: 2 }
+	};
+
+	beforeEach(async () => {
+		baseDir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachyon-setup-'));
+		ui = fakeUi();
+		getEDLDevice = sinon.stub().resolves(device);
+		getTachyonInfo = sinon.stub();
+		handleFlashError = sinon.stub().resolves(false);
+		workflowRun = sinon.stub().resolves({});
+		command = new SetupTachyonCommand({ ui });
+		command.device = device;
+	});
+
+	afterEach(async () => {
+		await fs.remove(baseDir);
+		sinon.restore();
+	});
+
+	it('uses information read from a recognised existing layout', async () => {
+		const expected = {
+			deviceId: device.id,
+			region: 'NA',
+			manufacturingData: 'Found',
+			osVersion: 'Ubuntu 20.04',
+			board: 'formfactor_dvt'
+		};
+		getTachyonInfo.resolves(expected);
+
+		expect(await command._getDeviceInfo()).to.equal(expected);
+		expect(ui.write).not.to.have.been.calledWithMatch(/Continuing with the identity/);
+	});
+
+	it('continues from the EDL identity when the outgoing GPT is unsupported', async () => {
+		getTachyonInfo.rejects(new Error('Partition boot_a not found in device partition table'));
+
+		const info = await command._getDeviceInfo();
+
+		expect(info).to.eql({
+			deviceId: device.id,
+			region: 'Unknown',
+			manufacturingData: 'Unknown',
+			osVersion: 'Unknown',
+			board: 'formfactor_dvt'
+		});
+		expect(ui.write).to.have.been.calledWithMatch(/Continuing with the identity reported in EDL mode/);
+	});
+
+	it('lets setup reach the workflow when identification cannot parse the GPT', async () => {
+		getTachyonInfo.rejects(new Error('Failed to parse partition table 0 from device'));
+		sinon.stub(command, '_loadConfig').resolves({ workflow: { value: 'ubuntu20' } });
+
+		await command.setup();
+
+		expect(workflowRun).to.have.been.calledOnce;
+		expect(workflowRun.firstCall.args[1].deviceInfo.deviceId).to.equal(device.id);
+		expect(workflowRun.firstCall.args[1].device).to.equal(device);
+	});
+
+	it('still stops when the device itself is no longer reachable', async () => {
+		getTachyonInfo.rejects(new TachyonConnectionError());
+		handleFlashError.resolves({ retry: false });
+
+		await expect(command._getDeviceInfo()).to.be.rejectedWith('Unable to communicate with the device');
+	});
+
+	it('retries a connection failure when requested', async () => {
+		const expected = {
+			deviceId: device.id,
+			region: 'NA',
+			manufacturingData: 'Found',
+			osVersion: 'Ubuntu 20.04',
+			board: 'formfactor_dvt'
+		};
+		getTachyonInfo.onFirstCall().rejects(new TachyonConnectionError());
+		getTachyonInfo.onSecondCall().resolves(expected);
+		handleFlashError.resolves({ retry: true });
+
+		expect(await command._getDeviceInfo()).to.equal(expected);
+		expect(getTachyonInfo).to.have.been.calledTwice;
+	});
+});

--- a/src/cmd/setup-tachyon.test.js
+++ b/src/cmd/setup-tachyon.test.js
@@ -8,6 +8,7 @@ const { TachyonConnectionError } = require('../lib/qdl');
 
 let getEDLDevice;
 let getTachyonInfo;
+let lookupCloudDeviceInfo;
 let handleFlashError;
 let workflowRun;
 let baseDir;
@@ -15,6 +16,7 @@ let baseDir;
 const tachyonUtils = {
 	getEDLDevice: (...args) => getEDLDevice(...args),
 	getTachyonInfo: (...args) => getTachyonInfo(...args),
+	lookupCloudDeviceInfo: (...args) => lookupCloudDeviceInfo(...args),
 	handleFlashError: (...args) => handleFlashError(...args)
 };
 
@@ -64,6 +66,7 @@ describe('SetupTachyonCommand', () => {
 		ui = fakeUi();
 		getEDLDevice = sinon.stub().resolves(device);
 		getTachyonInfo = sinon.stub();
+		lookupCloudDeviceInfo = sinon.stub().resolves(null);
 		handleFlashError = sinon.stub().resolves(false);
 		workflowRun = sinon.stub().resolves({});
 		command = new SetupTachyonCommand({ ui });
@@ -99,9 +102,10 @@ describe('SetupTachyonCommand', () => {
 			region: 'Unknown',
 			manufacturingData: 'Unknown',
 			osVersion: 'Unknown',
-			board: 'formfactor_dvt'
+			board: 'Unknown'
 		});
 		expect(ui.write).to.have.been.calledWithMatch(/Continuing with the identity reported in EDL mode/);
+		expect(handleFlashError).not.to.have.been.called;
 	});
 
 	it('lets setup reach the workflow when identification cannot parse the GPT', async () => {
@@ -110,6 +114,8 @@ describe('SetupTachyonCommand', () => {
 
 		await command.setup();
 
+		expect(lookupCloudDeviceInfo).to.have.been.calledWith({ deviceId: device.id, api: command.api });
+		expect(lookupCloudDeviceInfo).to.have.been.calledBefore(getTachyonInfo);
 		expect(workflowRun).to.have.been.calledOnce;
 		expect(workflowRun.firstCall.args[1].deviceInfo.deviceId).to.equal(device.id);
 		expect(workflowRun.firstCall.args[1].device).to.equal(device);
@@ -136,5 +142,91 @@ describe('SetupTachyonCommand', () => {
 
 		expect(await command._getDeviceInfo()).to.equal(expected);
 		expect(getTachyonInfo).to.have.been.calledTwice;
+	});
+
+	it('keeps region and board from a loaded configuration', async () => {
+		const filename = path.join(baseDir, 'setup.json');
+		await fs.writeJson(filename, { region: 'RoW', board: 'formfactor' });
+
+		expect(await command._loadConfigFromFile(filename)).to.include({
+			region: 'RoW',
+			board: 'formfactor',
+			silent: true,
+			loadedFromFile: true
+		});
+	});
+
+	describe('hardware option precedence', () => {
+		const local = { region: 'NA', board: 'formfactor_dvt' };
+		const cloud = { region: 'RoW', board: null };
+
+		beforeEach(() => {
+			sinon.stub(command, '_selectRegion').resolves('prompt-region');
+			sinon.stub(command, '_selectBoard').resolves('prompt-board');
+		});
+
+		it('prefers command-line values over every discovered value', async () => {
+			const result = await command._resolveHardwareOptions({
+				options: { region: 'RoW', board: 'rb3g2' },
+				configFromFile: { region: 'NA', board: 'formfactor' },
+				deviceInfo: local,
+				cloudInfo: cloud
+			});
+
+			expect(result).to.eql({ region: 'RoW', board: 'rb3g2' });
+			expect(command._hardwareOptionSources).to.eql({ region: 'command line', board: 'command line' });
+		});
+
+		it('prefers loaded configuration over device and cloud values', async () => {
+			const result = await command._resolveHardwareOptions({
+				options: {},
+				configFromFile: { region: 'RoW', board: 'formfactor' },
+				deviceInfo: local,
+				cloudInfo: cloud
+			});
+
+			expect(result).to.eql({ region: 'RoW', board: 'formfactor' });
+			expect(command._hardwareOptionSources).to.eql({ region: 'loaded configuration', board: 'loaded configuration' });
+		});
+
+		it('prefers readable device values over cloud values', async () => {
+			const result = await command._resolveHardwareOptions({
+				options: {},
+				configFromFile: {},
+				deviceInfo: local,
+				cloudInfo: cloud
+			});
+
+			expect(result).to.eql(local);
+			expect(command._hardwareOptionSources).to.eql({ region: 'device', board: 'device' });
+		});
+
+		it('uses cloud region and prompts for a board the cloud does not report', async () => {
+			const result = await command._resolveHardwareOptions({
+				options: {},
+				configFromFile: {},
+				deviceInfo: { region: 'Unknown', board: 'Unknown' },
+				cloudInfo: cloud
+			});
+
+			expect(result).to.eql({ region: 'RoW', board: 'prompt-board' });
+			expect(command._selectRegion).not.to.have.been.called;
+			expect(command._selectBoard).to.have.been.calledOnce;
+			expect(command._hardwareOptionSources).to.eql({ region: 'Particle Cloud', board: 'user input' });
+		});
+
+		it('prompts instead of silently defaulting when no source knows', async () => {
+			const result = await command._resolveHardwareOptions({
+				options: {},
+				configFromFile: {},
+				deviceInfo: { region: 'Unknown', board: 'Unknown' },
+				cloudInfo: null
+			});
+
+			expect(result).to.eql({ region: 'prompt-region', board: 'prompt-board' });
+			expect(command._selectRegion).to.have.been.calledOnce;
+			expect(command._selectBoard).to.have.been.calledOnce;
+			expect(command._hardwareOptionSources).to.eql({ region: 'user input', board: 'user input' });
+		});
 	});
 });

--- a/src/cmd/tachyon-factory-restore.js
+++ b/src/cmd/tachyon-factory-restore.js
@@ -19,7 +19,9 @@ module.exports = class TachyonFactoryRestore extends CLICommandBase {
 		this.ui = ui || this.ui;
 		spinnerMixin(this);
 		this._baseDir = settings.ensureFolder();
-		this._backupDir = path.join(process.cwd());
+		// Must match BackupRestoreTachyonCommand's default, or hasBackups() looks
+		// in the wrong place and the factory restore silently re-backs-up.
+		this._backupDir = path.join(this._baseDir, 'backups');
 		this._logsDir = path.join(this._baseDir, 'logs');
 		this.outputLog = null;
 		this.device = null;
@@ -46,7 +48,7 @@ module.exports = class TachyonFactoryRestore extends CLICommandBase {
 
 		const hasBackups = await this.hasBackups();
 		if (hasBackups) {
-			this.ui.write('Backup of manufacturing data found in the working directory, skipping backup step.');
+			this.ui.write('Backup of manufacturing data found, skipping backup step.');
 		} else {
 			continueProcess = await this._printMissingFilesWarning();
 			if (!continueProcess) {
@@ -165,9 +167,15 @@ module.exports = class TachyonFactoryRestore extends CLICommandBase {
 	}
 
 	async hasBackups() {
-		const names = await fs.readdir(this._backupDir);
 		const expected = `manufacturing_backup_${this.device.id}.zip`;
-		return names.includes(expected);
+		// Also accept the working directory, where backups landed before they were
+		// stored under the Particle data directory.
+		for (const dir of [this._backupDir, process.cwd()]) {
+			if (await fs.exists(path.join(dir, expected))) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	async backupStep(){

--- a/src/lib/tachyon-utils.js
+++ b/src/lib/tachyon-utils.js
@@ -17,6 +17,8 @@ const BOOT_B_PARTITION = 'boot_b';
 
 const REGION_NA_MARKER = Buffer.from('SG560D-NA');
 const REGION_ROW_MARKER = Buffer.from('SG560D-EM');
+const MODEM_MODEL_PREFIX = 'SG560D';
+const REGION_BY_MODEM_CODE = { NA: 'NA', EM: 'RoW' };
 const EFS_PARTITION_HEADER = Buffer.from('EFS');
 const UBUNTU_20_MARKER = Buffer.from('ANDROID');
 const UBUNTU_24_MARKER = Buffer.from('UEFI');
@@ -353,11 +355,12 @@ async function getIdentification({ deviceId, partitionTable, partitionFilenames 
 	const noBootPartitions = !hasPartition(BOOT_A_PARTITION) && !hasPartition(BOOT_B_PARTITION);
 	const singleSystem = hasPartition('system') && !hasPartition('system_a');
 	let osVersion = 'Unknown';
-	let board = 'formfactor_dvt';
+	let board = 'Unknown';
 	if (nvdataLun === 0) {
 		osVersion = 'Ubuntu 20.04 EVT';
 		board = 'formfactor';
 	} else if (nvdataLun === 5) {
+		board = 'formfactor_dvt';
 		if (hasVendorBoot) {
 			osVersion = 'Android 14';
 		} else if (ubuntu20 && !ubuntu24) {
@@ -609,6 +612,48 @@ async function readManifestFromLocalFile(path, targetFile = 'manifest.json') {
 	}
 }
 
+/**
+ * The cloud reports the modem firmware as e.g. SG560DNAPAR60A03. The two
+ * characters following the model identify the hardware region.
+ */
+function regionFromModemFirmware(firmwareVersion) {
+	if (typeof firmwareVersion !== 'string' || !firmwareVersion.startsWith(MODEM_MODEL_PREFIX)) {
+		return null;
+	}
+	const code = firmwareVersion.slice(MODEM_MODEL_PREFIX.length, MODEM_MODEL_PREFIX.length + 2);
+	return REGION_BY_MODEM_CODE[code] || null;
+}
+
+/**
+ * Best-effort lookup by the device ID exposed in EDL mode. Setup and identify
+ * must continue when the user is offline, the device has never connected, or
+ * the record is unavailable to the current account.
+ */
+async function lookupCloudDeviceInfo({ deviceId, api }) {
+	if (!api || !deviceId) {
+		return null;
+	}
+	try {
+		const device = await api.getDevice({ deviceId });
+		if (!device || !device.id) {
+			return null;
+		}
+		const distro = device.linux_metadata?.distro || {};
+		return {
+			name: device.name || null,
+			region: regionFromModemFirmware(device.modem_firmware_version),
+			serialNumber: device.serial_number || null,
+			modemFirmwareVersion: device.modem_firmware_version || null,
+			imageVersion: distro.version || null,
+			imageVariant: distro.variant || null,
+			productId: device.product_id || null,
+			lastHeard: device.last_heard || null
+		};
+	} catch (_error) {
+		return null;
+	}
+}
+
 const IMAGE_MANIFEST_FILE = 'manifest.json';
 // The first-boot configuration blob lives in `misc`: 1MiB at a 4096-byte sector.
 const CONFIG_PARTITION = 'misc';
@@ -712,6 +757,8 @@ module.exports = {
 	promptOSSelection,
 	isFile,
 	readManifestFromLocalFile,
+	regionFromModemFirmware,
+	lookupCloudDeviceInfo,
 	readPartitionsFromImage,
 	readLunCapacities,
 	parseRawProgramPartitions,

--- a/src/lib/tachyon-utils.js
+++ b/src/lib/tachyon-utils.js
@@ -140,7 +140,53 @@ async function readPartitionsFromDevice({ logFile, ui, tempPath, firehosePath, g
 		// Ignore other errors as the gpt read will fail for LUN 6 for EVT devices.
 		// If there was an actual error reading the partitions, it will trigger an error in parsePartitions.
 	}
+	await logLunCapacities({ gptPath: tempPath, logFile });
 	return parsePartitions({ gptPath: tempPath });
+}
+
+/**
+ * The real size of each LUN, straight off the device.
+ *
+ * The firehose resolves NUM_DISK_SECTORS against the actual LUN when it writes the
+ * GPT, so the header's backup-header LBA is the last sector that LUN has -- the
+ * provisioning XML only ever states what was REQUESTED, which UFS rounds up to a
+ * whole number of allocation units. This is therefore the authoritative answer to
+ * "how big is LUN n on this device", and it costs nothing: the GPTs are already
+ * on disk from the read above.
+ */
+async function readLunCapacities({ gptPath }) {
+	const capacities = [];
+	for (let i = 0; i <= 6; i++) {
+		try {
+			const buffer = await fs.readFile(path.join(gptPath, `gpt_main${i}.bin`));
+			const gpt = new GPT({ blockSize: 4096 });
+			gpt.parse(buffer, gpt.blockSize);
+			// backupLBA is the last addressable sector, so the count is one more.
+			capacities.push({ lun: i, sectors: Number(gpt.backupLBA) + 1 });
+		} catch {
+			// LUN 6 does not exist on EVT devices; a LUN we cannot read simply has
+			// no reportable size.
+		}
+	}
+	return capacities;
+}
+
+async function logLunCapacities({ gptPath, logFile }) {
+	if (!logFile) {
+		return;
+	}
+	try {
+		const capacities = await readLunCapacities({ gptPath });
+		if (!capacities.length) {
+			return;
+		}
+		const lines = capacities.map(({ lun, sectors }) =>
+			`  LUN ${lun}: ${sectors} sectors (${Math.round((sectors * 4096) / 1024 / 1024)} MiB)`
+		);
+		fs.appendFileSync(logFile, `UFS LUN geometry read from the device GPT:${os.EOL}${lines.join(os.EOL)}${os.EOL}`);
+	} catch {
+		// Diagnostics only: never fail a flash because the geometry could not be logged.
+	}
 }
 
 async function parsePartitions({ gptPath }) {
@@ -647,6 +693,7 @@ module.exports = {
 	isFile,
 	readManifestFromLocalFile,
 	readPartitionsFromImage,
+	readLunCapacities,
 	parseRawProgramPartitions,
 	CONFIG_PARTITION,
 	CONFIG_PARTITION_SECTORS,

--- a/src/lib/tachyon-utils.js
+++ b/src/lib/tachyon-utils.js
@@ -76,7 +76,7 @@ async function getEDLDevice({ ui = new UI(), showSetupMessage = false } = {}) {
 	}
 }
 
-async function prepareFlashFiles({ logFile, ui, partitionsList, dir = process.cwd(), device, operation, checkFiles = false, modifyPartitions = (partitions) => partitions } = {}) {
+async function prepareFlashFiles({ logFile, ui, partitionsList, dir = process.cwd(), device, operation, checkFiles = false, optionalPartitions = [], modifyPartitions = (partitions) => partitions } = {}) {
 	const { firehosePath, tempPath, gptXmlPath } = await initFiles();
 
 	const partitionTable = await readPartitionsFromDevice({
@@ -91,7 +91,8 @@ async function prepareFlashFiles({ logFile, ui, partitionsList, dir = process.cw
 		partitionList: partitionsList,
 		partitionTable,
 		deviceId: device.id,
-		dir
+		dir,
+		optionalPartitions
 	}));
 	const partitionFilenames = partitions.reduce((acc, partition) => {
 		acc[partition.label] = partition.filename;
@@ -210,10 +211,16 @@ async function parsePartitions({ gptPath }) {
 	return table;
 }
 
-function partitionDefinitions({ partitionList, partitionTable, deviceId, dir }) {
+function partitionDefinitions({ partitionList, partitionTable, deviceId, dir, optionalPartitions = [] }) {
 	return partitionList.map((name) => {
 		const entry = partitionTable.find(({ partition }) => partition.name === name);
 		if (!entry) {
+			if (optionalPartitions.includes(name)) {
+				// Layouts differ across OS versions: 20.04 has boot_a/boot_b, the 24.04
+				// layout does not. Callers that only sniff these for identification pass
+				// them as optional so a missing one is absence, not a hard failure.
+				return null;
+			}
 			throw new Error(`Partition ${name} not found in device partition table`);
 		}
 		return {
@@ -223,7 +230,7 @@ function partitionDefinitions({ partitionList, partitionTable, deviceId, dir }) 
 			num_partition_sectors: Number(entry.partition.lastLBA) - Number(entry.partition.firstLBA) + 1,
 			filename: path.join(dir, `${deviceId}_${entry.partition.name}.backup`)
 		};
-	});
+	}).filter(Boolean);
 }
 
 async function verifyFilesExist(partitions) {
@@ -276,6 +283,7 @@ async function getTachyonInfo({ outputLog, ui, device }) {
 		ui,
 		logFile: outputLog,
 		partitionsList: [FSG_PARTITION, BOOT_A_PARTITION, BOOT_B_PARTITION],
+		optionalPartitions: [BOOT_A_PARTITION, BOOT_B_PARTITION],
 		dir: partitionDir,
 		device: device,
 		operation: 'read',
@@ -308,8 +316,12 @@ async function getTachyonInfo({ outputLog, ui, device }) {
 
 async function getIdentification({ deviceId, partitionTable, partitionFilenames }) {
 	const fsgBuffer = await fs.readFile(partitionFilenames[FSG_PARTITION]);
-	const bootABuffer = await fs.readFile(partitionFilenames[BOOT_A_PARTITION]);
-	const bootBBuffer = await fs.readFile(partitionFilenames[BOOT_B_PARTITION]);
+	const readIfPresent = async (name) => {
+		const filename = partitionFilenames[name];
+		return filename ? fs.readFile(filename) : Buffer.alloc(0);
+	};
+	const bootABuffer = await readIfPresent(BOOT_A_PARTITION);
+	const bootBBuffer = await readIfPresent(BOOT_B_PARTITION);
 
 	const regionNa = fsgBuffer.includes(REGION_NA_MARKER);
 	const regionRow = fsgBuffer.includes(REGION_ROW_MARKER);
@@ -334,6 +346,12 @@ async function getIdentification({ deviceId, partitionTable, partitionFilenames 
 	const ubuntu20 = bootABuffer.includes(UBUNTU_20_MARKER) || bootBBuffer.includes(UBUNTU_20_MARKER);
 	const ubuntu24 = bootABuffer.includes(UBUNTU_24_MARKER) || bootBBuffer.includes(UBUNTU_24_MARKER);
 	const hasVendorBoot = !!partitionTable.find(({ partition }) => partition.name.startsWith('vendor_boot'));
+	const hasPartition = (name) => !!partitionTable.find(({ partition }) => partition.name === name);
+	// The 24.04 layout dropped boot_a/boot_b and replaced the slotted system_a/system_b
+	// with a single `system`. With no boot partition to sniff a marker from, that shape
+	// is itself the identification.
+	const noBootPartitions = !hasPartition(BOOT_A_PARTITION) && !hasPartition(BOOT_B_PARTITION);
+	const singleSystem = hasPartition('system') && !hasPartition('system_a');
 	let osVersion = 'Unknown';
 	let board = 'formfactor_dvt';
 	if (nvdataLun === 0) {
@@ -345,6 +363,8 @@ async function getIdentification({ deviceId, partitionTable, partitionFilenames 
 		} else if (ubuntu20 && !ubuntu24) {
 			osVersion = 'Ubuntu 20.04';
 		} else if (ubuntu24 && !ubuntu20) {
+			osVersion = 'Ubuntu 24.04';
+		} else if (noBootPartitions && singleSystem) {
 			osVersion = 'Ubuntu 24.04';
 		}
 	}
@@ -695,6 +715,8 @@ module.exports = {
 	readPartitionsFromImage,
 	readLunCapacities,
 	parseRawProgramPartitions,
+	partitionDefinitions,
+	getIdentification,
 	CONFIG_PARTITION,
 	CONFIG_PARTITION_SECTORS,
 	SECTOR_SIZE_IN_BYTES

--- a/src/lib/tachyon-utils.js
+++ b/src/lib/tachyon-utils.js
@@ -543,6 +543,97 @@ async function readManifestFromLocalFile(path, targetFile = 'manifest.json') {
 	}
 }
 
+const IMAGE_MANIFEST_FILE = 'manifest.json';
+// The first-boot configuration blob lives in `misc`: 1MiB at a 4096-byte sector.
+const CONFIG_PARTITION = 'misc';
+const CONFIG_PARTITION_SECTORS = 256;
+const SECTOR_SIZE_IN_BYTES = 4096;
+
+function xmlAttr(attrs, name) {
+	const m = new RegExp(`\\b${name}="([^"]*)"`).exec(attrs);
+	return m ? m[1] : undefined;
+}
+
+/**
+ * Parse the flat, attribute-only Qualcomm rawprogram grammar into partition
+ * extents. Sector values may be ptool expressions ("NUM_DISK_SECTORS-5.") which
+ * only resolve against a real device, so those entries are skipped.
+ * @param {string[]} xmlContents  rawprogramN.xml sources
+ * @returns {Map<string, {lun: number, startSector: number, numSectors: number}>}
+ */
+function parseRawProgramPartitions(xmlContents) {
+	const table = new Map();
+	for (const xml of xmlContents) {
+		const re = /<(?:program|erase)\b([^>]*?)\/?>/g;
+		let match;
+		while ((match = re.exec(xml)) !== null) {
+			const attrs = match[1];
+			const label = xmlAttr(attrs, 'label');
+			const start = Number(xmlAttr(attrs, 'start_sector'));
+			const num = Number(xmlAttr(attrs, 'num_partition_sectors'));
+			const lun = Number(xmlAttr(attrs, 'physical_partition_number'));
+			if (!label || !Number.isFinite(start) || !Number.isFinite(num) || !Number.isFinite(lun)) {
+				continue;
+			}
+			const prev = table.get(label);
+			// An erase entry carries the whole declared extent and each program
+			// chunk its own slice, so the footprint is the union of both.
+			if (!prev) {
+				table.set(label, { lun, startSector: start, numSectors: num });
+			} else {
+				const startSector = Math.min(prev.startSector, start);
+				const end = Math.max(prev.startSector + prev.numSectors, start + num);
+				table.set(label, { lun: prev.lun, startSector, numSectors: end - startSector });
+			}
+		}
+	}
+	return table;
+}
+
+/**
+ * The partition table a system image DECLARES, read from the rawprogram XMLs its
+ * manifest points at.
+ *
+ * This is the layout the device will have AFTER the image is flashed, which is
+ * why a pre-flash check has to be made against it: the live GPT still describes
+ * the OUTGOING layout, and on a 20.04 -> 24.04 setup the two differ.
+ *
+ * @param {Object} args
+ * @param {string} args.imagePath  a system image zip, or an unpacked image directory
+ */
+async function readPartitionsFromImage({ imagePath }) {
+	const stats = await fs.stat(imagePath);
+	let manifest;
+	let xmlContents;
+
+	if (stats.isDirectory()) {
+		manifest = JSON.parse(await fs.readFile(path.join(imagePath, IMAGE_MANIFEST_FILE), 'utf8'));
+		const base = manifest?.targets?.[0]?.qcm6490?.edl?.base || '.';
+		const programXml = manifest?.targets?.[0]?.qcm6490?.edl?.program_xml || [];
+		xmlContents = await Promise.all(
+			programXml.map((f) => fs.readFile(path.join(imagePath, base, f), 'utf8'))
+		);
+	} else {
+		const dir = await unzip.Open.file(imagePath);
+		const manifestEntry = dir.files.find((f) => path.basename(f.path) === IMAGE_MANIFEST_FILE);
+		if (!manifestEntry) {
+			throw new Error(`Unable to find ${IMAGE_MANIFEST_FILE} in ${imagePath}`);
+		}
+		manifest = JSON.parse((await manifestEntry.buffer()).toString());
+		const programXml = manifest?.targets?.[0]?.qcm6490?.edl?.program_xml || [];
+		xmlContents = [];
+		for (const name of programXml) {
+			const entry = dir.files.find((f) => f.path.endsWith(name));
+			if (!entry) {
+				throw new Error(`Unable to find ${name} in ${imagePath}`);
+			}
+			xmlContents.push((await entry.buffer()).toString());
+		}
+	}
+
+	return parseRawProgramPartitions(xmlContents);
+}
+
 module.exports = {
 	addLogHeaders,
 	addManifestInfoLog,
@@ -554,5 +645,10 @@ module.exports = {
 	handleFlashError,
 	promptOSSelection,
 	isFile,
-	readManifestFromLocalFile
+	readManifestFromLocalFile,
+	readPartitionsFromImage,
+	parseRawProgramPartitions,
+	CONFIG_PARTITION,
+	CONFIG_PARTITION_SECTORS,
+	SECTOR_SIZE_IN_BYTES
 };

--- a/src/lib/tachyon-utils.test.js
+++ b/src/lib/tachyon-utils.test.js
@@ -4,7 +4,7 @@ const path = require('path');
 const fs = require('fs-extra');
 const { expect } = require('../../test/setup');
 const GPT = require('gpt');
-const { parseRawProgramPartitions, readPartitionsFromImage, readLunCapacities } = require('./tachyon-utils');
+const { parseRawProgramPartitions, readPartitionsFromImage, readLunCapacities, partitionDefinitions, getIdentification } = require('./tachyon-utils');
 
 const rawprogram0 = `<?xml version="1.0" ?>
 <data>
@@ -68,6 +68,91 @@ describe('tachyon-utils partition tables', () => {
 		it('throws when a referenced rawprogram file is missing', async () => {
 			await fs.remove(path.join(dir, 'rawprogram0.xml'));
 			await expect(readPartitionsFromImage({ imagePath: dir })).to.be.rejected;
+		});
+	});
+
+	describe('partitionDefinitions', () => {
+		const table = [
+			{ lun: 0, partition: { name: 'system', firstLBA: 100n, lastLBA: 199n } },
+			{ lun: 5, partition: { name: 'fsg', firstLBA: 64n, lastLBA: 1087n } }
+		];
+
+		it('throws when a required partition is missing', () => {
+			expect(() => partitionDefinitions({
+				partitionList: ['fsg', 'boot_a'],
+				partitionTable: table,
+				deviceId: 'abc',
+				dir: '/tmp'
+			})).to.throw('Partition boot_a not found in device partition table');
+		});
+
+		it('skips a missing partition that is declared optional', () => {
+			const parts = partitionDefinitions({
+				partitionList: ['fsg', 'boot_a', 'boot_b'],
+				partitionTable: table,
+				deviceId: 'abc',
+				dir: '/tmp',
+				optionalPartitions: ['boot_a', 'boot_b']
+			});
+			expect(parts).to.have.lengthOf(1);
+			expect(parts[0].label).to.equal('fsg');
+		});
+
+		it('still returns an optional partition when it is present', () => {
+			const parts = partitionDefinitions({
+				partitionList: ['system'],
+				partitionTable: table,
+				deviceId: 'abc',
+				dir: '/tmp',
+				optionalPartitions: ['system']
+			});
+			expect(parts).to.have.lengthOf(1);
+			expect(parts[0].num_partition_sectors).to.equal(100);
+		});
+	});
+
+	describe('getIdentification', () => {
+		let dir;
+		const writeFsg = async () => {
+			const fsg = path.join(dir, 'fsg.bin');
+			await fs.writeFile(fsg, Buffer.alloc(64));
+			return fsg;
+		};
+
+		beforeEach(async () => {
+			dir = await fs.mkdtemp(path.join(os.tmpdir(), 'ident-'));
+		});
+		afterEach(async () => {
+			await fs.remove(dir);
+		});
+
+		it('identifies the 24.04 layout when boot_a/boot_b are absent', async () => {
+			const partitionTable = [
+				{ lun: 5, partition: { name: 'nvdata1' } },
+				{ lun: 0, partition: { name: 'system' } },
+				{ lun: 0, partition: { name: 'misc' } }
+			];
+			const info = await getIdentification({
+				deviceId: 'abc',
+				partitionTable,
+				partitionFilenames: { fsg: await writeFsg() }
+			});
+			expect(info.osVersion).to.equal('Ubuntu 24.04');
+			expect(info.deviceId).to.equal('abc');
+		});
+
+		it('does not claim 24.04 for a slotted system layout with no boot partitions', async () => {
+			const partitionTable = [
+				{ lun: 5, partition: { name: 'nvdata1' } },
+				{ lun: 0, partition: { name: 'system_a' } },
+				{ lun: 0, partition: { name: 'system' } }
+			];
+			const info = await getIdentification({
+				deviceId: 'abc',
+				partitionTable,
+				partitionFilenames: { fsg: await writeFsg() }
+			});
+			expect(info.osVersion).to.equal('Unknown');
 		});
 	});
 

--- a/src/lib/tachyon-utils.test.js
+++ b/src/lib/tachyon-utils.test.js
@@ -3,7 +3,8 @@ const os = require('os');
 const path = require('path');
 const fs = require('fs-extra');
 const { expect } = require('../../test/setup');
-const { parseRawProgramPartitions, readPartitionsFromImage } = require('./tachyon-utils');
+const GPT = require('gpt');
+const { parseRawProgramPartitions, readPartitionsFromImage, readLunCapacities } = require('./tachyon-utils');
 
 const rawprogram0 = `<?xml version="1.0" ?>
 <data>
@@ -67,6 +68,46 @@ describe('tachyon-utils partition tables', () => {
 		it('throws when a referenced rawprogram file is missing', async () => {
 			await fs.remove(path.join(dir, 'rawprogram0.xml'));
 			await expect(readPartitionsFromImage({ imagePath: dir })).to.be.rejected;
+		});
+	});
+
+	describe('readLunCapacities', () => {
+		let dir;
+
+		/** A primary GPT whose backup header sits at `lastSector`. */
+		async function writeGpt(lun, lastSector) {
+			const gpt = new GPT({ blockSize: 4096 });
+			gpt.currentLBA = 1n;
+			gpt.backupLBA = BigInt(lastSector);
+			gpt.firstLBA = 6n;
+			gpt.lastLBA = BigInt(lastSector - 5);
+			gpt.tableOffset = 2n;
+			const buffer = Buffer.alloc(gpt.blockSize * 6);
+			gpt.write(buffer, gpt.blockSize);
+			await fs.writeFile(path.join(dir, `gpt_main${lun}.bin`), buffer);
+		}
+
+		beforeEach(async () => {
+			dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachyon-gpt-'));
+		});
+
+		afterEach(async () => {
+			await fs.remove(dir);
+		});
+
+		it('reports each LUN size from the GPT the device is running', async () => {
+			// The firehose resolves NUM_DISK_SECTORS against the real LUN, so this is
+			// the authoritative size -- the provisioning XML only records a request.
+			await writeGpt(1, 2068);
+			await writeGpt(5, 36863);
+			expect(await readLunCapacities({ gptPath: dir })).to.eql([
+				{ lun: 1, sectors: 2069 },
+				{ lun: 5, sectors: 36864 }
+			]);
+		});
+
+		it('skips a LUN that has no GPT, as on an EVT device without LUN 6', async () => {
+			expect(await readLunCapacities({ gptPath: dir })).to.eql([]);
 		});
 	});
 });

--- a/src/lib/tachyon-utils.test.js
+++ b/src/lib/tachyon-utils.test.js
@@ -1,0 +1,72 @@
+'use strict';
+const os = require('os');
+const path = require('path');
+const fs = require('fs-extra');
+const { expect } = require('../../test/setup');
+const { parseRawProgramPartitions, readPartitionsFromImage } = require('./tachyon-utils');
+
+const rawprogram0 = `<?xml version="1.0" ?>
+<data>
+  <erase start_sector="100" physical_partition_number="0" num_partition_sectors="50" SECTOR_SIZE_IN_BYTES="4096" label="system_a"/>
+  <program start_sector="100" physical_partition_number="0" num_partition_sectors="2" filename="system_a.img" SECTOR_SIZE_IN_BYTES="4096" label="system_a"/>
+  <program start_sector="160" physical_partition_number="0" num_partition_sectors="256" filename="" SECTOR_SIZE_IN_BYTES="4096" label="misc"/>
+  <program start_sector="NUM_DISK_SECTORS-5." physical_partition_number="0" num_partition_sectors="5" filename="gpt_backup0.bin" SECTOR_SIZE_IN_BYTES="4096" label="BackupGPT"/>
+</data>
+`;
+
+describe('tachyon-utils partition tables', () => {
+	describe('parseRawProgramPartitions', () => {
+		it('takes the union of the erase extent and the program chunks', () => {
+			const table = parseRawProgramPartitions([rawprogram0]);
+			expect(table.get('system_a')).to.eql({ lun: 0, startSector: 100, numSectors: 50 });
+		});
+
+		it('reads a reserve-only partition that has no payload', () => {
+			const table = parseRawProgramPartitions([rawprogram0]);
+			expect(table.get('misc')).to.eql({ lun: 0, startSector: 160, numSectors: 256 });
+		});
+
+		it('skips entries whose sectors are ptool expressions', () => {
+			// NUM_DISK_SECTORS-5. only resolves against a real device.
+			expect(parseRawProgramPartitions([rawprogram0]).has('BackupGPT')).to.equal(false);
+		});
+
+		it('merges entries spread across several rawprogram files', () => {
+			const other = '<data><program start_sector="8" physical_partition_number="5" num_partition_sectors="16" label="fsc"/></data>';
+			const table = parseRawProgramPartitions([rawprogram0, other]);
+			expect(table.get('fsc')).to.eql({ lun: 5, startSector: 8, numSectors: 16 });
+			expect(table.size).to.equal(3);
+		});
+	});
+
+	describe('readPartitionsFromImage', () => {
+		let dir;
+
+		beforeEach(async () => {
+			dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachyon-image-'));
+			await fs.writeJson(path.join(dir, 'manifest.json'), {
+				targets: [{ qcm6490: { edl: {
+					base: '.',
+					firehose: 'prog_firehose_ddr.elf',
+					program_xml: ['rawprogram0.xml'],
+					patch_xml: ['patch0.xml']
+				} } }]
+			});
+			await fs.writeFile(path.join(dir, 'rawprogram0.xml'), rawprogram0);
+		});
+
+		afterEach(async () => {
+			await fs.remove(dir);
+		});
+
+		it('reads the table an unpacked image declares', async () => {
+			const table = await readPartitionsFromImage({ imagePath: dir });
+			expect(table.get('misc')).to.eql({ lun: 0, startSector: 160, numSectors: 256 });
+		});
+
+		it('throws when a referenced rawprogram file is missing', async () => {
+			await fs.remove(path.join(dir, 'rawprogram0.xml'));
+			await expect(readPartitionsFromImage({ imagePath: dir })).to.be.rejected;
+		});
+	});
+});

--- a/src/lib/tachyon-utils.test.js
+++ b/src/lib/tachyon-utils.test.js
@@ -2,9 +2,17 @@
 const os = require('os');
 const path = require('path');
 const fs = require('fs-extra');
-const { expect } = require('../../test/setup');
+const { expect, sinon } = require('../../test/setup');
 const GPT = require('gpt');
-const { parseRawProgramPartitions, readPartitionsFromImage, readLunCapacities, partitionDefinitions, getIdentification } = require('./tachyon-utils');
+const {
+	parseRawProgramPartitions,
+	readPartitionsFromImage,
+	readLunCapacities,
+	partitionDefinitions,
+	getIdentification,
+	regionFromModemFirmware,
+	lookupCloudDeviceInfo
+} = require('./tachyon-utils');
 
 const rawprogram0 = `<?xml version="1.0" ?>
 <data>
@@ -14,6 +22,46 @@ const rawprogram0 = `<?xml version="1.0" ?>
   <program start_sector="NUM_DISK_SECTORS-5." physical_partition_number="0" num_partition_sectors="5" filename="gpt_backup0.bin" SECTOR_SIZE_IN_BYTES="4096" label="BackupGPT"/>
 </data>
 `;
+
+describe('Tachyon cloud identification', () => {
+	it('derives the region from the modem firmware version', () => {
+		expect(regionFromModemFirmware('SG560DNAPAR60A03')).to.equal('NA');
+		expect(regionFromModemFirmware('SG560DEMPAR60A03')).to.equal('RoW');
+		expect(regionFromModemFirmware('SG560DZZPAR60A03')).to.equal(null);
+		expect(regionFromModemFirmware(null)).to.equal(null);
+	});
+
+	it('returns the setup metadata available from the cloud', async () => {
+		const device = {
+			id: '422a060000000000d0c7965f',
+			name: 'bobs-yellow-hat-d0c7965f',
+			serial_number: 'P06400000000000',
+			modem_firmware_version: 'SG560DNAPAR60A03',
+			product_id: 35245,
+			last_heard: '2026-08-31T02:57:13.857Z',
+			linux_metadata: { distro: { version: '1.2.17', variant: 'headless' } }
+		};
+		const api = { getDevice: sinon.stub().resolves(device) };
+
+		expect(await lookupCloudDeviceInfo({ deviceId: device.id, api })).to.eql({
+			name: device.name,
+			region: 'NA',
+			serialNumber: device.serial_number,
+			modemFirmwareVersion: device.modem_firmware_version,
+			imageVersion: '1.2.17',
+			imageVariant: 'headless',
+			productId: device.product_id,
+			lastHeard: device.last_heard
+		});
+		expect(api.getDevice).to.have.been.calledWith({ deviceId: device.id });
+	});
+
+	it('returns null rather than blocking setup when lookup fails', async () => {
+		const api = { getDevice: sinon.stub().rejects(new Error('offline')) };
+		expect(await lookupCloudDeviceInfo({ deviceId: 'abc', api })).to.equal(null);
+		expect(await lookupCloudDeviceInfo({ deviceId: null, api })).to.equal(null);
+	});
+});
 
 describe('tachyon-utils partition tables', () => {
 	describe('parseRawProgramPartitions', () => {
@@ -153,6 +201,16 @@ describe('tachyon-utils partition tables', () => {
 				partitionFilenames: { fsg: await writeFsg() }
 			});
 			expect(info.osVersion).to.equal('Unknown');
+		});
+
+		it('does not silently classify an unfamiliar layout as DVT', async () => {
+			const info = await getIdentification({
+				deviceId: 'abc',
+				partitionTable: [{ lun: 0, partition: { name: 'system' } }],
+				partitionFilenames: { fsg: await writeFsg() }
+			});
+
+			expect(info.board).to.equal('Unknown');
 		});
 	});
 

--- a/src/lib/tachyon/steps.js
+++ b/src/lib/tachyon/steps.js
@@ -6,7 +6,14 @@ const temp = require('temp').track();
 const path = require('path');
 const settings = require('../../../settings');
 const { sha512crypt } = require('sha512crypt-node');
-const { promptWifiNetworks, prepareFlashFiles } = require('../tachyon-utils');
+const {
+	promptWifiNetworks,
+	prepareFlashFiles,
+	readPartitionsFromImage,
+	CONFIG_PARTITION,
+	CONFIG_PARTITION_SECTORS,
+	SECTOR_SIZE_IN_BYTES
+} = require('../tachyon-utils');
 const { platformForId, PLATFORMS } = require('../platform');
 const { supportedCountries } = require('../supported-countries');
 const DownloadManager = require('../download-manager');
@@ -355,6 +362,12 @@ async function getESIMProfilesStep({ api, ui, deviceInfo, productId, country }, 
 	return { esim };
 }
 
+/**
+ * Build the first-boot configuration blob. It is only written to `misc` after the
+ * OS is flashed (see `flash`), because until then the device's GPT still
+ * describes the OUTGOING layout: resolving the address here and programming it
+ * later would put the blob at whatever moved into those sectors.
+ */
 async function createConfigBlobStep(context, stepIndex) {
 	formatAndDisplaySteps({
 		ui: context.ui,
@@ -362,17 +375,51 @@ async function createConfigBlobStep(context, stepIndex) {
 		step: stepIndex,
 	});
 	const { configBlobPath } = await createBlobFile(context);
-	const { xmlFile: xmlPath } = await prepareFlashFiles({
-		logFile: context.log.file,
-		ui: context.ui,
-		partitionsList: ['misc'],
-		dir: path.dirname(configBlobPath),
-		deviceId: context.deviceInfo.deviceId,
-		operation: 'program',
-		checkFiles: true,
-		device: context.device,
+	return { configBlobPath };
+}
+
+/**
+ * Fail before a multi-GB write if the image we are about to flash cannot hold the
+ * configuration blob. 24.04 shipped without a `misc` partition at all, which made
+ * `particle tachyon setup` fail after the flash on a device already running
+ * 24.04, and silently write the blob to the wrong sectors coming from 20.04.
+ */
+async function verifyConfigPartitionStep({ ui, osFilePath, configBlobPath, skipFlashingOs, workflow }, stepIndex) {
+	if (skipFlashingOs || !configBlobPath) {
+		// Nothing is being flashed, so the live layout is the one that counts and
+		// the post-flash GPT read is the only gate that applies.
+		return {};
+	}
+	formatAndDisplaySteps({
+		ui,
+		text: 'Checking that the operating system image can store your configuration...',
+		step: stepIndex,
 	});
-	return { xmlPath };
+
+	const imageName = path.basename(osFilePath);
+	const partitions = await readPartitionsFromImage({ imagePath: osFilePath });
+	const misc = partitions.get(CONFIG_PARTITION);
+	if (!misc) {
+		throw new VError(
+			`The ${workflow.osInfo.distributionDisplay} image '${imageName}' has no '${CONFIG_PARTITION}' partition, ` +
+			'so your password, Wi-Fi and registration settings cannot be applied. ' +
+			'Use a newer image, or flash without setup and configure the device by hand.'
+		);
+	}
+	if (misc.numSectors < CONFIG_PARTITION_SECTORS) {
+		throw new VError(
+			`The '${CONFIG_PARTITION}' partition in '${imageName}' is ${misc.numSectors} sectors; ` +
+			`at least ${CONFIG_PARTITION_SECTORS} are required.`
+		);
+	}
+	const { size } = await fs.stat(configBlobPath);
+	const capacity = misc.numSectors * SECTOR_SIZE_IN_BYTES;
+	if (size > capacity) {
+		throw new VError(
+			`The configuration is ${size} bytes but the '${CONFIG_PARTITION}' partition in '${imageName}' holds ${capacity}.`
+		);
+	}
+	return {};
 }
 
 async function createBlobFile(context) {
@@ -403,7 +450,7 @@ async function createBlobFile(context) {
 	return { configBlobPath: filePath, configBlob: config };
 }
 
-async function flashOSAndConfigStep({ ui, log, productSlug, device, xmlPath, variant, osFilePath, skipFlashingOs, workflow }, stepIndex) {
+async function flashOSAndConfigStep({ ui, log, productSlug, device, configBlobPath, variant, osFilePath, skipFlashingOs, workflow }, stepIndex) {
 	const message = getFlashMessage({ ui, device, productSlug, workflow });
 	return runStepWithTiming(
 		ui,
@@ -412,30 +459,33 @@ async function flashOSAndConfigStep({ ui, log, productSlug, device, xmlPath, var
 		() => flash({
 			device,
 			log,
+			ui,
 			osPath: osFilePath,
-			xmlPath: xmlPath,
+			configBlobPath,
 			skipFlashingOs: skipFlashingOs,
 			skipReset: variant !== 'headless'
 		})
 	);
 }
 
-async function flash({ device, osPath, xmlPath, skipFlashingOs, skipReset, log }) {
+async function flash({ device, osPath, configBlobPath, skipFlashingOs, skipReset, log, ui }) {
 	const flashCommand = new FlashCommand();
-	const shouldResetOS = skipReset || xmlPath;
+	// Stay in EDL after the OS write while a configuration blob is still to come.
+	const keepInEdl = skipReset || Boolean(configBlobPath);
 	if (!skipFlashingOs) {
 		// flash OS
 		await flashCommand.flashTachyon({
 			device,
 			files: [osPath],
-			skipReset: shouldResetOS,
+			skipReset: keepInEdl,
 			output: log.file,
 			verbose: false
 		});
 	} else {
 		log.info(`Skip flashing OS ${os.EOL}`);
 	}
-	if (xmlPath) {
+	if (configBlobPath) {
+		const xmlPath = await resolveConfigPartition({ device, osPath, configBlobPath, log, ui });
 		// flash xml
 		await flashCommand.flashTachyonXml({
 			device,
@@ -446,6 +496,36 @@ async function flash({ device, osPath, xmlPath, skipFlashingOs, skipReset, log }
 	}
 	return { flashSuccessful: true };
 
+}
+
+/**
+ * Read the GPT the device is running NOW -- after the OS write -- and build the
+ * qdl program XML that puts the configuration blob at that address. Never reuse
+ * an XML built from the pre-flash table: the LBA `misc` had on the outgoing
+ * layout may belong to another partition on the incoming one.
+ */
+async function resolveConfigPartition({ device, osPath, configBlobPath, log, ui }) {
+	try {
+		const { xmlFile } = await prepareFlashFiles({
+			logFile: log.file,
+			ui,
+			partitionsList: [CONFIG_PARTITION],
+			dir: path.dirname(configBlobPath),
+			operation: 'program',
+			checkFiles: true,
+			device,
+		});
+		return xmlFile;
+	} catch (error) {
+		if (error.message && error.message.includes('not found in device partition table')) {
+			throw new VError(
+				`The device has no '${CONFIG_PARTITION}' partition after flashing '${path.basename(osPath)}', ` +
+				'so your password, Wi-Fi and registration settings could not be applied. ' +
+				'The operating system was installed; configure the device by hand, or flash an image that provides it.'
+			);
+		}
+		throw error;
+	}
 }
 
 function getFlashMessage({ ui, device, productSlug, workflow }){
@@ -531,6 +611,7 @@ module.exports = {
 	registerDeviceStep,
 	getESIMProfilesStep,
 	createConfigBlobStep,
+	verifyConfigPartitionStep,
 	flashOSAndConfigStep,
 	setupCompletedStep
 };

--- a/src/lib/tachyon/steps.test.js
+++ b/src/lib/tachyon/steps.test.js
@@ -1,0 +1,141 @@
+'use strict';
+const os = require('os');
+const path = require('path');
+const fs = require('fs-extra');
+const proxyquire = require('proxyquire');
+const { expect, sinon } = require('../../../test/setup');
+
+// steps.js destructures these at require time, so the stub object has to expose
+// stable functions that forward to whatever the current test installed.
+let prepareFlashFiles;
+let readPartitionsFromImage;
+const tachyonUtils = {
+	promptWifiNetworks: () => {},
+	prepareFlashFiles: (...args) => prepareFlashFiles(...args),
+	readPartitionsFromImage: (...args) => readPartitionsFromImage(...args),
+	CONFIG_PARTITION: 'misc',
+	CONFIG_PARTITION_SECTORS: 256,
+	SECTOR_SIZE_IN_BYTES: 4096
+};
+
+let flashTachyon;
+let flashTachyonXml;
+class FakeFlashCommand {
+	flashTachyon(...args) {
+		return flashTachyon(...args);
+	}
+	flashTachyonXml(...args) {
+		return flashTachyonXml(...args);
+	}
+}
+
+const steps = proxyquire('./steps', {
+	'../tachyon-utils': tachyonUtils,
+	'../../cmd/flash': FakeFlashCommand
+});
+
+function fakeUi() {
+	return { write: sinon.stub(), chalk: { yellow: (s) => s, bold: (s) => s } };
+}
+
+function miscTable(numSectors) {
+	return new Map([['misc', { lun: 0, startSector: 160, numSectors }]]);
+}
+
+describe('tachyon setup steps', () => {
+	let ui, dir, configBlobPath, workflow;
+
+	beforeEach(async () => {
+		ui = fakeUi();
+		dir = await fs.mkdtemp(path.join(os.tmpdir(), 'tachyon-steps-'));
+		configBlobPath = path.join(dir, 'e00fce68_misc.backup');
+		await fs.writeFile(configBlobPath, Buffer.alloc(2048));
+		workflow = { osInfo: { distributionDisplay: 'Ubuntu 24.04' } };
+		flashTachyon = sinon.stub().resolves();
+		flashTachyonXml = sinon.stub().resolves();
+		prepareFlashFiles = sinon.stub().resolves({ xmlFile: path.join(dir, 'partitions_program.xml') });
+		readPartitionsFromImage = sinon.stub().resolves(miscTable(256));
+	});
+
+	afterEach(async () => {
+		await fs.remove(dir);
+		sinon.restore();
+	});
+
+	describe('verifyConfigPartitionStep', () => {
+		const run = (over = {}) => steps.verifyConfigPartitionStep(
+			{ ui, osFilePath: '/tmp/tachyon-ubuntu-24.04-NA-headless-1.2.0.zip', configBlobPath, workflow, ...over },
+			2
+		);
+
+		it('accepts an image that declares a 1MiB misc partition', async () => {
+			await run();
+			expect(readPartitionsFromImage).to.have.property('callCount', 1);
+		});
+
+		it('fails when the image has no misc partition at all', async () => {
+			readPartitionsFromImage.resolves(new Map());
+			await expect(run()).to.be.rejectedWith(/has no 'misc' partition/);
+		});
+
+		it('fails when the image declares an undersized misc partition', async () => {
+			readPartitionsFromImage.resolves(miscTable(64));
+			await expect(run()).to.be.rejectedWith(/is 64 sectors; at least 256 are required/);
+		});
+
+		it('fails when the configuration is larger than the partition', async () => {
+			await fs.writeFile(configBlobPath, Buffer.alloc(2 * 1024 * 1024));
+			await expect(run()).to.be.rejectedWith(/holds 1048576/);
+		});
+
+		it('does not inspect the image when the OS is not being flashed', async () => {
+			await run({ skipFlashingOs: true });
+			expect(readPartitionsFromImage).to.have.property('callCount', 0);
+		});
+	});
+
+	describe('flashOSAndConfigStep', () => {
+		const context = () => ({
+			ui,
+			log: { file: path.join(dir, 'flash.log'), info: sinon.stub() },
+			device: { id: 'e00fce68', serialNumber: '1', usbVersion: { major: 3 } },
+			configBlobPath,
+			variant: 'headless',
+			osFilePath: '/tmp/os.zip',
+			workflow
+		});
+
+		it('resolves misc from the GPT only after the OS has been written', async function () {
+			this.timeout(10000);
+			await steps.flashOSAndConfigStep(context(), 3);
+
+			expect(flashTachyon).to.have.property('callCount', 1);
+			expect(prepareFlashFiles).to.have.property('callCount', 1);
+			// The whole point: the partition table is read from the device the image
+			// just installed, not from the one it replaced.
+			expect(flashTachyon.calledBefore(prepareFlashFiles)).to.equal(true);
+			expect(prepareFlashFiles.calledBefore(flashTachyonXml)).to.equal(true);
+			expect(prepareFlashFiles.firstCall.args[0].partitionsList).to.eql(['misc']);
+		});
+
+		it('keeps the device in EDL across the OS write so the blob can follow', async function () {
+			this.timeout(10000);
+			await steps.flashOSAndConfigStep(context(), 3);
+			expect(flashTachyon.firstCall.args[0].skipReset).to.equal(true);
+		});
+
+		it('explains which image is at fault when misc is absent after flashing', async function () {
+			this.timeout(10000);
+			prepareFlashFiles.rejects(new Error('Partition misc not found in device partition table'));
+			await expect(steps.flashOSAndConfigStep(context(), 3))
+				.to.be.rejectedWith(/no 'misc' partition after flashing 'os\.zip'/);
+		});
+
+		it('skips the configuration write entirely when there is no blob', async function () {
+			this.timeout(10000);
+			await steps.flashOSAndConfigStep({ ...context(), configBlobPath: undefined }, 3);
+			expect(prepareFlashFiles).to.have.property('callCount', 0);
+			expect(flashTachyonXml).to.have.property('callCount', 0);
+		});
+	});
+});

--- a/src/lib/tachyon/workflow.js
+++ b/src/lib/tachyon/workflow.js
@@ -23,9 +23,9 @@ const steps = require('./steps');
 /**
  * Setup options used by the workflow runner.
  * @typedef {Object} SetupOptions
- * @property {('NA'|'RoW'|string)} region - Target region. Default: `'NA'`.
+ * @property {('NA'|'RoW'|string)} region - Target region, resolved from explicit input, the device, the cloud, or a prompt.
  * @property {string} version - Tachyon version or channel. Default: `settings.tachyonVersion || 'stable'`.
- * @property {string} board - Hardware/board identifier (e.g., `'formfactor_dvt'`). Default: `'formfactor_dvt'`.
+ * @property {string} board - Hardware/board identifier (e.g., `'formfactor_dvt'`), resolved from explicit input, the device, the cloud, or a prompt.
  * @property {string} distroVersion - Distro version (e.g., `'20.04'`). Default: `'20.04'`.
  * @property {string} country - Country/locale code (e.g., `'USA'`). Default: `'USA'`.
  * @property {string|null} variant - Optional SKU/variant; `null` if not applicable. Default: `null`.

--- a/src/lib/tachyon/workflow.js
+++ b/src/lib/tachyon/workflow.js
@@ -149,13 +149,21 @@ const ubuntu24 = Object.freeze({
 				`For more information about what's currently supported on Ubuntu 24.04, visit https://developer.particle.io/tachyon/software/ubuntu_24_04/overview${os.EOL}${os.EOL}`
 		},
 	],
+	// Same step list as ubuntu20. getCountryStep and getESIMProfilesStep were missing
+	// here, so 24.04 setup never asked for a country and never fetched the eSIM
+	// profiles -- the config blob went out with no `esim` key and the device relied on
+	// whatever was already provisioned on the eUICC. particle-linux has read this since
+	// it shipped (bootstrap.ts stores `esim_bootstrap` from the blob's `esim`), so the
+	// consumer was there the whole time; only the producer was missing.
 	steps: Object.freeze([
 		steps.pickVariant,
 		steps.getUserConfigurationStep,
 		steps.configureProductStep,
+		steps.getCountryStep,
 		steps.downloadOS,
 		steps.printOSInfo,
 		steps.registerDeviceStep,
+		steps.getESIMProfilesStep,
 		steps.createConfigBlobStep,
 		steps.verifyConfigPartitionStep,
 		steps.flashOSAndConfigStep,

--- a/src/lib/tachyon/workflow.js
+++ b/src/lib/tachyon/workflow.js
@@ -134,6 +134,7 @@ const ubuntu24 = Object.freeze({
 				`  - Power off the device by holding the power button for 3 seconds and releasing.${os.EOL}` +
 				`  - Power on the device by pressing the power button.${os.EOL}${os.EOL}` +
 				`When the device boots it will:${os.EOL}` +
+				`  - Activate the built-in 5G modem.${os.EOL}` +
 				`  - Connect to the Particle Cloud.${os.EOL}` +
 				`  - Run all system services, including the desktop if an HDMI monitor is connected.${os.EOL}${os.EOL}` +
 				`For more information about what's currently supported on Ubuntu 24.04, visit https://developer.particle.io/tachyon/software/ubuntu_24_04/overview${os.EOL}${os.EOL}`
@@ -144,6 +145,7 @@ const ubuntu24 = Object.freeze({
 			setupCompletedMessage: 'All done! Your Tachyon device is now booting ' +
 				`into the operating system and will automatically connect to Wi-Fi.${os.EOL}${os.EOL}` +
 				`It will also:${os.EOL}` +
+				`  - Activate the built-in 5G modem${os.EOL}` +
 				`  - Connect to the Particle Cloud${os.EOL}` +
 				`  - Run all system services, including battery charging${os.EOL}${os.EOL}` +
 				`For more information about what's currently supported on Ubuntu 24.04, visit https://developer.particle.io/tachyon/software/ubuntu_24_04/overview${os.EOL}${os.EOL}`

--- a/src/lib/tachyon/workflow.js
+++ b/src/lib/tachyon/workflow.js
@@ -106,6 +106,7 @@ const ubuntu20 = Object.freeze({
 		steps.registerDeviceStep,
 		steps.getESIMProfilesStep,
 		steps.createConfigBlobStep,
+		steps.verifyConfigPartitionStep,
 		steps.flashOSAndConfigStep,
 		steps.setupCompletedStep
 	])
@@ -149,6 +150,7 @@ const ubuntu24 = Object.freeze({
 		steps.printOSInfo,
 		steps.registerDeviceStep,
 		steps.createConfigBlobStep,
+		steps.verifyConfigPartitionStep,
 		steps.flashOSAndConfigStep,
 		steps.setupCompletedStep
 	])

--- a/src/lib/tachyon/workflow.js
+++ b/src/lib/tachyon/workflow.js
@@ -114,11 +114,8 @@ const ubuntu20 = Object.freeze({
 
 /** @type {Workflow} */
 const ubuntu24 = Object.freeze({
-	name: 'Ubuntu 24.04 (beta)',
+	name: 'Ubuntu 24.04',
 	value: 'ubuntu24',
-	selectionWarning: 'Heads-up: Development of Ubuntu 24.04 (beta) is still in progress. Some features may be ' +
-		`unstable or missing.${os.EOL}` +
-		`See https://developer.particle.io/tachyon/software/ubuntu_24_04/overview for more information.${os.EOL}`,
 	osInfo: {
 		distributionDisplay: 'Ubuntu 24.04',
 		distribution: 'ubuntu',
@@ -139,6 +136,16 @@ const ubuntu24 = Object.freeze({
 				`When the device boots it will:${os.EOL}` +
 				`  - Connect to the Particle Cloud.${os.EOL}` +
 				`  - Run all system services, including the desktop if an HDMI monitor is connected.${os.EOL}${os.EOL}` +
+				`For more information about what's currently supported on Ubuntu 24.04, visit https://developer.particle.io/tachyon/software/ubuntu_24_04/overview${os.EOL}${os.EOL}`
+		},
+		{
+			name: 'Headless (command-line only)',
+			value: 'headless',
+			setupCompletedMessage: 'All done! Your Tachyon device is now booting ' +
+				`into the operating system and will automatically connect to Wi-Fi.${os.EOL}${os.EOL}` +
+				`It will also:${os.EOL}` +
+				`  - Connect to the Particle Cloud${os.EOL}` +
+				`  - Run all system services, including battery charging${os.EOL}${os.EOL}` +
 				`For more information about what's currently supported on Ubuntu 24.04, visit https://developer.particle.io/tachyon/software/ubuntu_24_04/overview${os.EOL}${os.EOL}`
 		},
 	],

--- a/src/lib/tachyon/workflow.test.js
+++ b/src/lib/tachyon/workflow.test.js
@@ -38,6 +38,22 @@ describe('tachyon workflows', () => {
 		});
 	}
 
+	it('promises modem activation only where setup actually provisions the eSIM', () => {
+		// The completion message tells the user the device will "activate the built-in
+		// 5G modem". That is only true if setup fetched the eSIM profiles into the
+		// config blob, so tie the claim to the step rather than letting the copy drift
+		// away from what the workflow does -- 24.04 promised the cloud but not the
+		// modem for exactly as long as it was missing getESIMProfilesStep.
+		for (const value of ['ubuntu20', 'ubuntu24']) {
+			const wf = byValue(value);
+			const provisions = stepNames(wf).includes('getESIMProfilesStep');
+			for (const variant of wf.variants) {
+				const claims = /5G modem/.test(variant.setupCompletedMessage);
+				expect(claims, `${value}/${variant.value} modem claim`).to.equal(provisions);
+			}
+		}
+	});
+
 	it('offers a headless variant with a completion message on every ubuntu workflow', () => {
 		for (const value of ['ubuntu20', 'ubuntu24']) {
 			const headless = byValue(value).variants.find((v) => v.value === 'headless');

--- a/src/lib/tachyon/workflow.test.js
+++ b/src/lib/tachyon/workflow.test.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const { expect } = require('../../../test/setup');
+const { workflows } = require('./workflow');
+const steps = require('./steps');
+
+const nameOf = (fn) => Object.keys(steps).find((k) => steps[k] === fn) || fn.name;
+const stepNames = (wf) => wf.steps.map(nameOf);
+
+describe('tachyon workflows', () => {
+	const byValue = (v) => workflows[v];
+
+	it('runs the same steps on ubuntu24 as on ubuntu20', () => {
+		// ubuntu24 shipped without getCountryStep and getESIMProfilesStep, so setup
+		// never fetched the eSIM profiles and the config blob went out with no `esim`
+		// key -- while particle-linux's bootstrap has always read one. Keep the two
+		// lists identical so that cannot silently drift again.
+		expect(stepNames(byValue('ubuntu24'))).to.deep.equal(stepNames(byValue('ubuntu20')));
+	});
+
+	for (const value of ['ubuntu20', 'ubuntu24']) {
+		it(`asks for a country before fetching eSIM profiles on ${value}`, () => {
+			const names = stepNames(byValue(value));
+			expect(names).to.include('getCountryStep');
+			expect(names).to.include('getESIMProfilesStep');
+			// getESIMProfilesStep passes `country` to the API, so the country has to be
+			// resolved first or the profile lookup is made for the wrong region.
+			expect(names.indexOf('getCountryStep'))
+				.to.be.lessThan(names.indexOf('getESIMProfilesStep'));
+		});
+
+		it(`builds the config blob after the eSIM profiles are known on ${value}`, () => {
+			const names = stepNames(byValue(value));
+			// The blob is a snapshot of the context, so anything it must carry has to
+			// have run already.
+			expect(names.indexOf('getESIMProfilesStep'))
+				.to.be.lessThan(names.indexOf('createConfigBlobStep'));
+		});
+	}
+
+	it('offers a headless variant with a completion message on every ubuntu workflow', () => {
+		for (const value of ['ubuntu20', 'ubuntu24']) {
+			const headless = byValue(value).variants.find((v) => v.value === 'headless');
+			expect(headless, `${value} headless variant`).to.exist;
+			expect(headless.setupCompletedMessage, `${value} headless message`).to.be.a('string');
+		}
+	});
+});


### PR DESCRIPTION
## What

Nine commits that make `particle tachyon setup` work on 24.04, and make
`tachyon backup` / `tachyon restore` layout-independent and verified.

| commit | change |
|---|---|
| `3acc9124` | write the config blob to the **post-flash** `misc`; verify NV restores |
| `da0ccaa0` | log the real UFS LUN geometry read back from the device GPT |
| `d8431859` | identify a device whose layout has no `boot_a`/`boot_b` |
| `e19bb122` | offer the headless variant on 24.04, drop the beta label |
| `9dccf641` | fetch eSIM profiles during 24.04 setup, as 20.04 already does |
| `54bd8d90` | tell 24.04 users the modem will activate, as 20.04 does |
| `ba0dea1f` | print the durable backup path, not only its basename |
| `7111fea6` | make the outgoing GPT advisory for setup; EDL identity is sufficient |
| `640ece58` | resolve region/board by explicit input → device → cloud → prompt; remove silent NA/DVT defaults |

No dependency changes. `package.json` is untouched — in particular this does **not**
add `@particle/tachyon-image`, which stays dormant until the A/B work lands.

## Why

### 1. The config blob was written using the wrong GPT

`createConfigBlobStep` resolved the `misc` LBA from the **pre-flash** GPT and
`flashOSAndConfigStep` programmed that XML after the OS was written. On a 20.04 → 24.04
setup that means the blob went to the old `misc` offset — i.e. to whatever the new image
put on those sectors. On a device already running 24.04 it failed outright with
`Partition misc not found in device partition table`, because 24.04 had no `misc` at all
(fixed by tachyon-composer #76).

Reordered to:

1. create the blob (`createBlobFile`, unchanged);
2. **preflight the image** — `verifyConfigPartitionStep` reads the partition table out of
   the image about to be flashed and fails if it has no `misc`, if `misc` is smaller than
   256 sectors, or if the blob would not fit. This runs *before* the multi-GB write, so a
   mismatch costs seconds rather than a full flash;
3. flash the OS/GPT, keeping the device in EDL;
4. read the newly flashed live GPT off the device;
5. resolve `misc` **by label** and generate the QDL program XML.

`flash()` already ran `flashTachyon` then `flashTachyonXml` as two qdl invocations, so
step 4 slots between them. `createConfigBlobStep` now returns only `{ configBlobPath }`.
Step 5 (`resolveConfigPartition`) is the authoritative gate: if `misc` is absent from the
post-flash GPT it fails with a message naming the image and stating that the OS was
installed but the configuration was not applied, rather than silently writing the blob to
whatever now occupies those sectors. `keepInEdl = skipReset || Boolean(configBlobPath)`.

Reset behaviour is unchanged from `master`: `flashTachyonXml({ skipReset })` is called
exactly as before. Only the internal name changed (`shouldResetOS` → `keepInEdl`).

### 2. `restore()`'s retry path called `backup()`

`backup-restore-tachyon.js:151-153` caught a restore failure and retried with
`this.backup({ 'input-dir': … })` — wrong method, and `backup()` does not take
`input-dir`. Now retries `this.restore(...)` with restore's own arguments.

Also: backups stored durably under the Particle data directory with the path always
printed; a `backup.json` sidecar (schema version, device ID, source LUN/LBA geometry,
byte lengths, SHA-256 per file); pre-write validation that each file fits its target
partition; and post-write read-back hash verification. Legacy archives without
`backup.json` are still accepted.

### 3. `identify` threw on any device without `boot_a`

`partitionDefinitions` threw `Partition boot_a not found in device partition table` for
any layout lacking it. 20.04 has `boot_a`/`boot_b`; 24.04 does not — so `tachyon setup`
died at "Unable to get device info." on a 24.04 board. Adds an `optionalPartitions` list
(threaded through `prepareFlashFiles`) so a missing optional partition yields `null` and
is filtered out instead of throwing, and uses the absence of both boot partitions
together with a single non-A/B `system` to report `Ubuntu 24.04`.

### 4. 24.04 offered no headless variant

The `ubuntu24` workflow had a desktop variant only, so step 10 printed
`undefinedLearn more about Tachyon…` — a missing `setupCompletedMessage`. Adds the
`headless` variant with its own completion message, and drops `(beta)` from the 24.04
name plus the now-stale `selectionWarning`.

### 5. 24.04 setup never fetched the eSIM profiles

The `ubuntu24` workflow was missing **`getCountryStep`** and **`getESIMProfilesStep`**.
`ubuntu20` has both. So 24.04 setup never asked for a country, never called
`PUT /v1/products/:productId/devices/:deviceId/target_profile`, and wrote the config blob
with **no `esim` key at all**.

The consumer has been there the whole time — particle-linux's bootstrap declares

```ts
esim?: { profiles: Array<{ iccid, activation_code }>, target_profile: string | null }
```

and calls `storeEsimBootstrap()` whenever the blob carries it. 24.04 devices simply never
got one, so a device worked only if its eUICC happened to already be provisioned.

Both steps are OS-agnostic: `getCountryStep` prompts (or takes `country` from a loaded
config in silent mode), and `getESIMProfilesStep` is non-fatal — it warns and returns
`{ esim: null }` if the lookup fails. `createBlobFile` snapshots the whole context minus a
small exclusion list and drops nulls, so `country` and `esim` reach the blob with no extra
plumbing.

Ordering matters and is now asserted: the country must resolve before the profile lookup
(it is the `countryCode` argument), and both before the blob is built, since the blob is a
snapshot of the context.

### 6. 24.04's completion message did not mention the modem

Both 24.04 variants listed "Connect to the Particle Cloud" but not "Activate the built-in
5G modem"; 20.04 lists both. That was accurate while `ubuntu24` had no
`getESIMProfilesStep`, and stopped being accurate the moment it gained one. Added to the
desktop and headless variants, matching `ubuntu20`'s wording and punctuation.

Tied to behaviour rather than left as prose: a test asserts a workflow claims modem
activation **if and only if** its step list contains `getESIMProfilesStep`, across every
variant — so the copy and the capability cannot drift apart again the way they just did.

> ⚠️ **Not verified end to end on hardware.** head2's eUICC is already provisioned, so
> re-running setup there does not exercise a device that arrives without a profile —
> which is exactly the case this message now promises. Needs an unprovisioned unit before
> release.


### 7. The outgoing GPT is no longer a setup precondition

Commits `7111fea6` and `640ece58` fix the underlying recovery contract rather than
adding another known layout to the allow-list.

#### Why setup read the old GPT in the first place

The original structure appears to have been a convenience: `getTachyonInfo()`
produced one object containing the EDL device ID plus values inferred from storage:

- region from a modem marker in `fsg`;
- EVT/DVT board type from the LUN containing `nvdata1`;
- installed OS from `boot_a`/`boot_b`;
- whether manufacturing data looked present.

Region and board then selected the matching image automatically, while the remaining
fields were printed to the user. That is useful metadata, but setup treated failure to
obtain any of it as proof that flashing could not work. The conclusion does not follow:
the EDL enumeration already supplies the identity used by setup, and the selected image
carries `prog_firehose_ddr.elf`, its rawprogram XMLs, patch XMLs, and Primary/Backup
GPT writes.

#### New behavior

The Particle Cloud lookup starts as soon as USB enumeration supplies the EDL device ID,
in parallel with the slower best-effort storage read. A blank, corrupt, or unfamiliar GPT
now emits a warning and setup continues. Region and board are resolved independently, in
this precedence:

1. an explicit command-line option;
2. a loaded setup configuration;
3. a value read from the physical device;
4. Particle Cloud metadata;
5. an interactive prompt.

The physical device wins over the cloud because the cloud record is only as fresh as its
last connection. Today the cloud supplies region from `modem_firmware_version`; it does
not report EVT/DVT board type, so an unreadable board still prompts unless the operator
provided `--board` or saved it in the setup configuration. The selected source is shown
in the device information. There is no silent NA/DVT fallback.

#### Effect on the onboarding flow

1. Login and EDL enumeration run as before; EDL supplies the device ID without reading storage.
2. The cloud lookup starts immediately from that ID while the existing GPT read runs. Cloud
   failure is non-fatal.
3. Setup resolves region and board separately using the precedence above. A source may answer
   one field without being trusted for the other.
4. The resolved values and any non-device provenance are printed before image selection. If a
   value remains unknown, setup asks the operator instead of guessing.
5. The normal variant, account, product, Wi-Fi, eSIM, image preflight, flash, post-flash GPT
   read, and `misc` configuration steps then continue unchanged.

A real `TachyonConnectionError` is deliberately different: setup still offers a retry
and stops if the user declines, because the device is no longer satisfying the one
hardware precondition -- being reachable in EDL.

#### Downsides and remaining constraints

- The cloud record may be stale, so a readable physical value deliberately wins. If the
  device cannot answer, the output labels cloud-derived values.
- A loaded config is now treated as explicit intent, including `board`, and overrides
  discovery. Reusing a config created for different hardware can therefore select the wrong
  image; explicit `--region` / `--board` remain the final override.
- When no source knows a value, interactive setup pauses for a region or board choice. This
  is intentional: guessing NA/DVT could install an image for the wrong cellular bands or
  hardware revision.
- Keeping identification as best-effort adds one firehose/read attempt before a recovery
  flash. Removing it entirely would be faster, but would regress automatic image
  selection for the normal readable-device case.
- EDL presence is the only required *device state*, not a guarantee that every image is
  compatible. The package must still contain a valid programmer/GPT and fit the target
  UFS geometry.
- The post-flash `misc` read remains intentional. It occurs only after the image has
  installed its own GPT and resolves where the configuration blob belongs. If that new
  image lacks a valid `misc`, the OS is installed but setup reports that configuration
  could not be applied.

The setup tests cover recognized and unsupported layouts, cloud lookup ordering, every
precedence tier, prompt fallback, loaded board configuration, connection failure, and
connection retry. Utility tests cover cloud firmware parsing, non-fatal lookup failure,
and refusing to classify an unfamiliar GPT as DVT.

#### Hardware regression: 24.04 single-slot to 20.04 A/B

Tested on head2, device `422a060000000000d0c7965f`, using the exact command:

```console
pi@head2-pi:~/images $ /opt/particle/bin/particle tachyon setup --version /home/pi/images/tachyon-ubuntu-20.04-NA-headless-formfactor_dvt-1.0.190.zip
```

Before installing the PR build, the old `/opt` binary stopped before any write:

```text
Starting Process. See logs at: .../tachyon_flash_422a060000000000d0c7965f_1788376808082.log
Tachyon setup failed: Unable to get device info. Please restart the device and try again.
```

After installing the PR build at the same path, the command:

- passed identification from the outgoing 24.04 single-slot layout;
- preflighted the supplied image's `misc`;
- wrote the supplied 20.04 A/B GPT and OS;
- re-read that new GPT;
- programmed the configuration into `misc`;
- completed all 12 setup steps.

The booted board reports Ubuntu 20.04.6 LTS, kernel `5.4.219`, root
`/dev/sda11`, Wi-Fi associated, and the Particle, GNSS, and RIL services active.
`misc` resolves to `/dev/sda5`, is exactly 1 MiB, and hashes as an all-zero 1 MiB
buffer after first boot, showing that bootstrap consumed and erased the configuration.

The older 20.04 image reports systemd `degraded`; observed failures across these boots
were `persist.mount`, `sfsconfig.service`, and `thermal-engine.service`. Those boot-time
image issues were recorded but are outside this CLI change.

#### Hardware verification of the final precedence resolver

The `087b8c8d` ARM64 build exercised the final behavior at `/opt/particle/bin/particle`. The final `640ece58` adds only the numbered precedence comment in source; its exact ARM64 artifact was built and installed afterward. The same
20.04 package was run again, with the saved setup configuration streamed after removing
its `region` and `board` keys so discovery—not the config—had to resolve both fields.

The live output was:

```text
 -  Device ID: 422a060000000000d0c7965f
 -  Board: DVT or later
 -  Region: NA (from Particle Cloud)
 -  OS Version: Ubuntu 20.04
```

This exercises the per-field merge rather than an all-or-nothing fallback: the physical
GPT supplied DVT, while the physical `fsg` partition was readable but contained no
`SG560D-NA` / `SG560D-EM` region marker, so the cloud filled only region. `fsg` itself
and its manufacturing-data `EFS` header are present; this is not modem-data damage.

Setup again completed all 12 steps. The board booted Ubuntu 20.04.6, associated to Wi-Fi,
and the Particle, GNSS, and RIL services are active. The post-flash `misc` is 1 MiB and
hashes as an all-zero buffer after bootstrap consumed the configuration.

## Tests

1117 passing, 10 pending, lint clean. New coverage in
`steps.test.js`, `tachyon-utils.test.js` and `backup-restore-tachyon.test.js` for: the
GPT being read *after* the OS flash and the new `misc` LBA being used; an image with no
`misc`, or an undersized one, failing at preflight before any flash; a device with no
`misc` post-flash failing at the second gate; restore retrying `restore`; restore
rejecting a file that would overrun its target; read-back hash verification; legacy
archives with no `backup.json`; and `partitionDefinitions` tolerating absent optional
partitions.

## Hardware

head2, against composer build `1.2.14-dev+build.64a0cda` (tachyon-composer #76). The
board has been on 24.04 since 27 Aug, so **the first two runs are 24.04 → 24.04** — which is the
case defect 1 broke outright. The 20.04 → 24.04 direction is not exercised here.

### Run 1

- setup ran to step 10 with the headless completion message rendered, no `undefined`
- device boots to a login on `Ubuntu 24.04.4 LTS`, kernel `6.8.0-1058-particle`
- `misc -> sda3`, exactly 1048576 bytes, and **entirely zero** after first boot — the blob
  was written to the correct post-flash offset, consumed by the particle-linux bootstrap
  and wiped
- the configured password authenticates (sha512crypt match for `particle` in `/etc/shadow`)
- Wi-Fi associated to the configured SSID and took a DHCP lease
- modem NV byte-identical to the pre-flash capture across all six partitions
  (`modemst1` `bf3b6f09…`, `modemst2` `a00c952e…`, `fsc` `fa43239b…`, `fsg` `abccf416…`,
  `nvdata1`/`nvdata2` `106f0647…`), with `nvdata1/2` still at the 20.04 1.5 MiB sizes

### Run 2 — repeat setup, again on 24.04

Both runs exercise the case that used to fail outright with
`Partition boot_a not found in device partition table` → "Unable to get device info."
That failure is itself the evidence the board was on 24.04: the very first attempt in
this session died there, because 24.04 has no `boot_a`.

- `Device info:` now reports **`OS Version: Ubuntu 24.04`** and setup continues
- **Step 8 — "Checking that the operating system image can store your configuration…"** —
  the new image preflight ran and passed before any flashing
- ran through to step 10, device boots to a login again on `root=PARTLABEL=system` / `sda4`
- `misc` again exactly 1 MiB and again entirely zero after first boot
- Wi-Fi reassociated, same DHCP lease
- modem identity intact — `particle-tachyon-ril-ctl info` reports IMEI-1 `8644300100010 91`,
  IMEI-2 `…92`, ICCID `8935711800001245077`, EID `89044045…`, firmware `SG560DNAPAR60A03`

`fsg`, `fsc`, `nvdata1` and `nvdata2` are byte-identical across **both** flashes.
`modemst1`/`modemst2` differ between the two runs, which is expected and not
flash-related — they are the modem's live working EFS partitions. Verified directly:
with no flashing at all, `modemst2` changed hash within 90 s of idle runtime
(`f05c5fc1…` → `99ff9042…`). After the first flash they matched the pre-flash capture
exactly, which is what shows the flash itself does not touch them.

### On-image suites (run 2 device, `TMPDIR=/tmp`)

| suite | result | baseline |
|---|---|---|
| `particle-linux-test` | 21 passed / 0 failed / 2 skipped | 20 / 0 / 3 |
| `particle-tachyon-gnss-test` | 41 passed / 2 failed / 9 skipped | 43 / 0 / 9 |
| `particle-tachyon-rild-test` | 74 passed / 3 failed | 78 / 0 / 0 |

The failures are pre-existing image issues, not regressions from this PR — see the
composer PR for the reasoning. Note the suites must be run with a valid `TMPDIR`: under
`adb shell`, `TMPDIR` defaults to the Android path `/data/local/tmp`, which does not
exist on this image, and the suites' output redirects fail in a way that looks like a
CLI fault (`'particlectl systemdoc' exited 2`).

## Landing note

Land **after** tachyon-composer #76 and after an image containing `misc` is published —
this PR's post-flash gate fails by design against an image that has no `misc`.







