### PR TITLE
tachyon: identify from the EDL device ID and the cloud, not partition sniffing

### DIFF
--- a/src/cmd/identify-tachyon.js
+++ b/src/cmd/identify-tachyon.js
@@ -5,38 +5,107 @@ const os = require('os');
 
 const {
 	getEDLDevice,
-	getTachyonInfo, handleFlashError
+	getTachyonInfo, handleFlashError,
+	lookupCloudDeviceInfo
 } = require('../lib/tachyon-utils');
 
 
 module.exports = class IdentifyTachyonCommand extends CLICommandBase {
-	constructor({ ui } = {}) {
+	constructor({ ui, api } = {}) {
 		super();
 		this.ui = ui || this.ui;
+		this.api = api || this._particleApi().api;
 	}
 
+	/**
+	 * A device in EDL mode reports its device ID over USB enumeration, before any
+	 * firehose upload or partition read. Everything else worth knowing hangs off
+	 * that ID in the cloud, so ask for it there first.
+	 *
+	 * The on-device read still runs, because it is the only source of the
+	 * manufacturing-data check and the only source at all when the machine is
+	 * offline or the CLI is not logged in. It is no longer allowed to sink the
+	 * command: a partition layout this version of the CLI cannot parse used to make
+	 * `identify` fail outright, even though the device ID had already been read.
+	 */
 	async identify() {
 		const device = await getEDLDevice({ ui: this.ui });
 		const outputLog = path.join(os.tmpdir(), `tachyon_${device.id}_identify_${Date.now()}.log`);
 
+		const cloudInfo = await lookupCloudDeviceInfo({ deviceId: device.id, api: this.api });
+		const localInfo = await this._readFromDevice({ device, outputLog });
+
+		if (!cloudInfo && !localInfo) {
+			this.ui.stdout.write(`Device ID: ${device.id}${os.EOL}`);
+			this.ui.stdout.write(`Could not read this device, and it is not in your Particle account.${os.EOL}`);
+			this.ui.stdout.write(`Verify your logs ${outputLog} for more information${os.EOL}`);
+			return;
+		}
+
+		this.printIdentification(this._merge({ deviceId: device.id, cloudInfo, localInfo }));
+	}
+
+	/**
+	 * Read what only the device itself can tell us. Returns null instead of throwing
+	 * so a failed read degrades to whatever the cloud knows.
+	 */
+	async _readFromDevice({ device, outputLog }) {
 		try {
-			const tachyonInfo = await getTachyonInfo({ outputLog, ui: this.ui, device });
-			this.printIdentification(tachyonInfo);
+			return await getTachyonInfo({ outputLog, ui: this.ui, device });
 		} catch (error) {
 			const { retry } = await handleFlashError({ error, ui: this.ui });
 			if (retry) {
-				return this.identify();
+				return this._readFromDevice({ device, outputLog });
 			}
-			this.ui.stdout.write(`An error ocurred while trying to identify your tachyon ${os.EOL}`);
-			this.ui.stdout.write(`Error: ${error.message} ${os.EOL}`);
-			this.ui.stdout.write(`Verify your logs ${outputLog} for more information ${os.EOL}`);
+			this.ui.stdout.write(`Could not read the device directly: ${error.message}${os.EOL}`);
+			this.ui.stdout.write(`Verify your logs ${outputLog} for more information${os.EOL}${os.EOL}`);
+			return null;
 		}
 	}
 
-	printIdentification({ deviceId, region, manufacturingData, osVersion }) {
-		this.ui.stdout.write(`Device ID: ${deviceId}${os.EOL}`);
-		this.ui.stdout.write(`Region: ${region}${os.EOL}`);
-		this.ui.stdout.write(`Manufacturing data: ${manufacturingData}${os.EOL}`);
-		this.ui.stdout.write(`OS Version: ${osVersion}${os.EOL}`);
+	/**
+	 * The device wins on anything it could actually answer -- that comes from the
+	 * hardware in front of you, whereas a cloud record is only as fresh as the
+	 * device's last handshake. The cloud fills the gaps and adds what it alone knows.
+	 */
+	_merge({ deviceId, cloudInfo, localInfo }) {
+		const local = localInfo || {};
+		const cloud = cloudInfo || {};
+		const localRegion = local.region && local.region !== 'Unknown' ? local.region : null;
+		const region = localRegion || cloud.region || 'Unknown';
+
+		return {
+			deviceId,
+			name: cloud.name,
+			region,
+			regionSource: !localRegion && cloud.region ? 'Particle Cloud' : null,
+			serialNumber: cloud.serialNumber,
+			modemFirmwareVersion: cloud.modemFirmwareVersion,
+			manufacturingData: local.manufacturingData || null,
+			osVersion: local.osVersion && local.osVersion !== 'Unknown' ? local.osVersion : null,
+			imageVersion: cloud.imageVersion,
+			imageVariant: cloud.imageVariant,
+			productId: cloud.productId
+		};
+	}
+
+	printIdentification(info) {
+		const write = (label, value, suffix = '') => {
+			if (value !== null && value !== undefined) {
+				this.ui.stdout.write(`${label}: ${value}${suffix}${os.EOL}`);
+			}
+		};
+
+		write('Device ID', info.deviceId);
+		write('Name', info.name);
+		write('Region', info.region, info.regionSource ? ` (from ${info.regionSource})` : '');
+		write('Serial number', info.serialNumber);
+		write('Modem firmware', info.modemFirmwareVersion);
+		write('Manufacturing data', info.manufacturingData);
+		write('OS Version', info.osVersion);
+		if (info.imageVersion) {
+			write('Image', `${info.imageVersion}${info.imageVariant ? ` (${info.imageVariant})` : ''}`);
+		}
+		write('Product', info.productId);
 	}
 };

--- a/src/cmd/identify-tachyon.test.js
+++ b/src/cmd/identify-tachyon.test.js
@@ -1,0 +1,191 @@
+'use strict';
+const { expect } = require('../../test/setup');
+const sinon = require('sinon');
+const IdentifyTachyonCommand = require('./identify-tachyon');
+const { regionFromModemFirmware, lookupCloudDeviceInfo } = require('../lib/tachyon-utils');
+
+describe('regionFromModemFirmware', () => {
+	it('reads NA out of a North America firmware string', () => {
+		expect(regionFromModemFirmware('SG560DNAPAR60A03')).to.equal('NA');
+	});
+
+	it('reads RoW out of an EM firmware string', () => {
+		expect(regionFromModemFirmware('SG560DEMPAR60A03')).to.equal('RoW');
+	});
+
+	it('returns null for an unrecognised region code', () => {
+		expect(regionFromModemFirmware('SG560DZZPAR60A03')).to.equal(null);
+	});
+
+	it('returns null for a string that is not a SG560D firmware version', () => {
+		expect(regionFromModemFirmware('EG25GGBR07A08M2G')).to.equal(null);
+	});
+
+	it('returns null for absent or non-string input', () => {
+		expect(regionFromModemFirmware(undefined)).to.equal(null);
+		expect(regionFromModemFirmware(null)).to.equal(null);
+		expect(regionFromModemFirmware(42)).to.equal(null);
+	});
+});
+
+describe('lookupCloudDeviceInfo', () => {
+	const cloudDevice = {
+		id: '422a060000000000d0c7965f',
+		name: 'bobs-yellow-hat-d0c7965f',
+		serial_number: 'P06400000000000',
+		modem_firmware_version: 'SG560DNAPAR60A03',
+		product_id: 35245,
+		last_heard: '2026-08-31T02:57:13.857Z',
+		linux_metadata: { distro: { version: '1.2.17', variant: 'headless' } }
+	};
+
+	it('derives the region and identity from the cloud record', async () => {
+		const api = { getDevice: sinon.stub().resolves(cloudDevice) };
+
+		const info = await lookupCloudDeviceInfo({ deviceId: cloudDevice.id, api });
+
+		expect(info).to.eql({
+			name: 'bobs-yellow-hat-d0c7965f',
+			region: 'NA',
+			serialNumber: 'P06400000000000',
+			modemFirmwareVersion: 'SG560DNAPAR60A03',
+			imageVersion: '1.2.17',
+			imageVariant: 'headless',
+			productId: 35245,
+			lastHeard: '2026-08-31T02:57:13.857Z'
+		});
+		expect(api.getDevice).to.have.been.calledWith({ deviceId: cloudDevice.id });
+	});
+
+	it('copes with a record that has no linux_metadata', async () => {
+		const api = { getDevice: sinon.stub().resolves({ id: 'abc', serial_number: 'P064' }) };
+
+		const info = await lookupCloudDeviceInfo({ deviceId: 'abc', api });
+
+		expect(info.imageVersion).to.equal(null);
+		expect(info.region).to.equal(null);
+		expect(info.serialNumber).to.equal('P064');
+	});
+
+	it('returns null when the device is not in the cloud', async () => {
+		const api = { getDevice: sinon.stub().resolves({}) };
+		expect(await lookupCloudDeviceInfo({ deviceId: 'abc', api })).to.equal(null);
+	});
+
+	it('returns null rather than throwing when the lookup fails', async () => {
+		const api = { getDevice: sinon.stub().rejects(new Error('HTTP error 403')) };
+		expect(await lookupCloudDeviceInfo({ deviceId: 'abc', api })).to.equal(null);
+	});
+
+	it('returns null when there is no api or no device id', async () => {
+		expect(await lookupCloudDeviceInfo({ deviceId: 'abc', api: null })).to.equal(null);
+		expect(await lookupCloudDeviceInfo({ deviceId: null, api: {} })).to.equal(null);
+	});
+});
+
+describe('IdentifyTachyonCommand', () => {
+	let ui;
+	let output;
+	const deviceId = '422a060000000000d0c7965f';
+
+	const localRead = (overrides = {}) => ({
+		deviceId,
+		region: 'Unknown',
+		manufacturingData: 'Found',
+		osVersion: 'Ubuntu 24.04',
+		...overrides
+	});
+
+	const cloudRead = (overrides = {}) => ({
+		name: 'bobs-yellow-hat-d0c7965f',
+		region: 'NA',
+		serialNumber: 'P06400000000000',
+		modemFirmwareVersion: 'SG560DNAPAR60A03',
+		imageVersion: '1.2.17',
+		imageVariant: 'headless',
+		productId: 35245,
+		lastHeard: null,
+		...overrides
+	});
+
+	beforeEach(() => {
+		output = [];
+		ui = { stdout: { write: (msg) => output.push(msg) } };
+	});
+
+	const command = () => new IdentifyTachyonCommand({ ui, api: {} });
+	const text = () => output.join('');
+
+	describe('_merge', () => {
+		it('prefers a region the device could answer and does not credit the cloud', () => {
+			const merged = command()._merge({
+				deviceId,
+				cloudInfo: cloudRead({ region: 'RoW' }),
+				localInfo: localRead({ region: 'NA' })
+			});
+
+			expect(merged.region).to.equal('NA');
+			expect(merged.regionSource).to.equal(null);
+		});
+
+		it('falls back to the cloud region when the device read is Unknown', () => {
+			const merged = command()._merge({ deviceId, cloudInfo: cloudRead(), localInfo: localRead() });
+
+			expect(merged.region).to.equal('NA');
+			expect(merged.regionSource).to.equal('Particle Cloud');
+		});
+
+		it('stays Unknown when neither source knows', () => {
+			const merged = command()._merge({
+				deviceId,
+				cloudInfo: cloudRead({ region: null }),
+				localInfo: localRead()
+			});
+
+			expect(merged.region).to.equal('Unknown');
+			expect(merged.regionSource).to.equal(null);
+		});
+
+		it('reports cloud identity when the on-device read failed entirely', () => {
+			const merged = command()._merge({ deviceId, cloudInfo: cloudRead(), localInfo: null });
+
+			expect(merged.deviceId).to.equal(deviceId);
+			expect(merged.region).to.equal('NA');
+			expect(merged.serialNumber).to.equal('P06400000000000');
+			expect(merged.manufacturingData).to.equal(null);
+			expect(merged.osVersion).to.equal(null);
+		});
+
+		it('reports the on-device read when the cloud knows nothing', () => {
+			const merged = command()._merge({
+				deviceId,
+				cloudInfo: null,
+				localInfo: localRead({ region: 'NA' })
+			});
+
+			expect(merged.region).to.equal('NA');
+			expect(merged.manufacturingData).to.equal('Found');
+			expect(merged.serialNumber).to.equal(undefined);
+		});
+	});
+
+	describe('printIdentification', () => {
+		it('omits every field nothing could supply', () => {
+			command().printIdentification(command()._merge({ deviceId, cloudInfo: null, localInfo: localRead({ region: 'NA' }) }));
+
+			expect(text()).to.include('Device ID: 422a060000000000d0c7965f');
+			expect(text()).to.include('Region: NA');
+			expect(text()).to.not.include('Serial number');
+			expect(text()).to.not.include('Image');
+		});
+
+		it('says where a cloud-sourced region came from', () => {
+			command().printIdentification(command()._merge({ deviceId, cloudInfo: cloudRead(), localInfo: localRead() }));
+
+			expect(text()).to.include('Region: NA (from Particle Cloud)');
+			expect(text()).to.include('Serial number: P06400000000000');
+			expect(text()).to.include('Modem firmware: SG560DNAPAR60A03');
+			expect(text()).to.include('Image: 1.2.17 (headless)');
+		});
+	});
+});

--- a/src/lib/tachyon-utils.js
+++ b/src/lib/tachyon-utils.js
@@ -17,6 +17,13 @@ const BOOT_B_PARTITION = 'boot_b';
 
 const REGION_NA_MARKER = Buffer.from('SG560D-NA');
 const REGION_ROW_MARKER = Buffer.from('SG560D-EM');
+
+// The modem firmware string carries the region in the two characters that follow
+// the `SG560D` model prefix: `SG560DNA...` is North America, `SG560DEM...` is the
+// rest of the world. This is the same rule the manufacturing test applies -- see
+// tachyon-overlays: overlays/manufacturing/files/read-region.sh.
+const MODEM_MODEL_PREFIX = 'SG560D';
+const REGION_BY_MODEM_CODE = { NA: 'NA', EM: 'RoW' };
 const EFS_PARTITION_HEADER = Buffer.from('EFS');
 const UBUNTU_20_MARKER = Buffer.from('ANDROID');
 const UBUNTU_24_MARKER = Buffer.from('UEFI');
@@ -543,6 +550,60 @@ async function readManifestFromLocalFile(path, targetFile = 'manifest.json') {
 	}
 }
 
+/**
+ * Derive the region from a modem firmware version string.
+ *
+ * @param {string} firmwareVersion e.g. `SG560DNAPAR60A03`
+ * @returns {('NA'|'RoW'|null)} null when the string is absent or unrecognised
+ */
+function regionFromModemFirmware(firmwareVersion) {
+	if (typeof firmwareVersion !== 'string' || !firmwareVersion.startsWith(MODEM_MODEL_PREFIX)) {
+		return null;
+	}
+	const code = firmwareVersion.slice(MODEM_MODEL_PREFIX.length, MODEM_MODEL_PREFIX.length + 2);
+	return REGION_BY_MODEM_CODE[code] || null;
+}
+
+/**
+ * Look a device up in the Particle Cloud by its device ID.
+ *
+ * A device in EDL mode reports its device ID over plain USB enumeration, before
+ * any firehose upload or partition read. That ID is enough to ask the cloud what
+ * the device is, which is both faster and more complete than sniffing partitions:
+ * the cloud knows the region (via `modem_firmware_version`, the same
+ * `SG560D` + `NA`/`EM` string the manufacturing test reads), the serial number,
+ * and which image was last reported.
+ *
+ * This never throws. A CLI that is not logged in, a device that has never
+ * connected, and a machine with no network are all ordinary outcomes here.
+ *
+ * @returns {Promise<Object|null>} null when the device cannot be looked up
+ */
+async function lookupCloudDeviceInfo({ deviceId, api }) {
+	if (!api || !deviceId) {
+		return null;
+	}
+	try {
+		const device = await api.getDevice({ deviceId });
+		if (!device || !device.id) {
+			return null;
+		}
+		const distro = (device.linux_metadata && device.linux_metadata.distro) || {};
+		return {
+			name: device.name || null,
+			region: regionFromModemFirmware(device.modem_firmware_version),
+			serialNumber: device.serial_number || null,
+			modemFirmwareVersion: device.modem_firmware_version || null,
+			imageVersion: distro.version || null,
+			imageVariant: distro.variant || null,
+			productId: device.product_id || null,
+			lastHeard: device.last_heard || null
+		};
+	} catch (_error) {
+		return null;
+	}
+}
+
 module.exports = {
 	addLogHeaders,
 	addManifestInfoLog,
@@ -554,5 +615,7 @@ module.exports = {
 	handleFlashError,
 	promptOSSelection,
 	isFile,
-	readManifestFromLocalFile
+	readManifestFromLocalFile,
+	regionFromModemFirmware,
+	lookupCloudDeviceInfo
 };


### PR DESCRIPTION
## The problem

`particle tachyon identify` derived everything it printed from a partition read — region by scanning `fsg` for `SG560D-NA` / `SG560D-EM`, OS version by sniffing markers in `boot_a` / `boot_b`. It had no other source, so when the sniff came up empty the information was simply lost.

Two concrete failures on a 24.04 build (`422a060000000000d0c7965f`):

- **`fsg` holds no `SG560D` string at all.** Not a hyphen mismatch — `strings fsg.backup | grep SG560D` returns nothing on this unit. So `identify` printed `Region: Unknown` while the device's own `/opt/particle/syscon.json` said `"region": "NA"`.
- **The 24.04 layout has no `boot_a`**, so `identify` failed outright with `Partition boot_a not found in device partition table` — *after* it had already read the device ID successfully.

## The approach

A device in EDL mode reports its full device ID over plain USB enumeration, before any firehose upload or partition read:

```
> getEdlDevices()
{ serialNumber: 'D0C7965F', id: '422a060000000000d0c7965f' }
```

That ID is enough to ask the cloud what the device is, so ask there first. The cloud records the region in `modem_firmware_version` — the same `SG560D` + `NA`/`EM` string the manufacturing test parses ([`read-region.sh`](https://github.com/particle-iot/tachyon-overlays/blob/main/overlays/manufacturing/files/read-region.sh)) — along with the serial number, device name, product, and last-reported image.

The on-device read still runs. It is the only source of the manufacturing-data check, and the only source at all when the machine is offline or the CLI is not logged in. What changed is that it can no longer sink the command.

**Precedence:** the device wins on anything it could actually answer — that is the hardware in front of you, whereas a cloud record is only as fresh as the last handshake. The cloud fills gaps and adds what it alone knows. The output says when a value came from the cloud. Fields nothing could supply are omitted rather than printed as `Unknown`.

The lookup never throws: not logged in, device never connected, and no network all leave the local answer untouched, so `identify` keeps working offline and unauthenticated as it does today.

## Why it matters beyond cosmetics

Setup treats an `Unknown` region as `NA`:

```js
optionsFromDevice.region = deviceInfo.region.toLowerCase() !== 'unknown' ? deviceInfo.region : 'NA';
```

So a RoW device whose marker is missing silently gets an NA image — different cellular bands, and a device that cannot reach its network.

## Verified on hardware (head2, real EDL device)

**On this branch alone (based on `master`, so the 24.04 partition read still fails):**

```
Could not read the device directly: Partition boot_a not found in device partition table
Verify your logs /tmp/tachyon_422a060000000000d0c7965f_identify_1788145638626.log for more information

Device ID: 422a060000000000d0c7965f
Name: bobs-yellow-hat-d0c7965f
Region: NA (from Particle Cloud)
Serial number: P06400000000000
Modem firmware: SG560DNAPAR60A01
Image: 1.2.17 (headless)
Product: 35245
```

Previously this run produced nothing but the `boot_a` error. `Manufacturing data` and `OS Version` are correctly absent — only the local read can supply them.

**Stacked on #933, where the local read succeeds:**

```
Device ID: 422a060000000000d0c7965f
Name: bobs-yellow-hat-d0c7965f
Region: NA (from Particle Cloud)
Serial number: P06400000000000
Modem firmware: SG560DNAPAR60A01
Manufacturing data: Found
OS Version: Ubuntu 24.04
Image: 1.2.17 (headless)
Product: 35245
```

Both sources merged. `Region: NA` corroborates the device's own `syscon.json`, and `Serial number: P06400000000000` matches it exactly.

## Notes for review

- **Stacking:** this is based on `master` and will conflict with #933 in `src/lib/tachyon-utils.js` (both add to the block above `module.exports` and to the export list). The conflict is additive and mechanical. #933 should land first — without it, `identify` cannot complete a local read on 24.04 at all.
- Tests live in a new `src/cmd/identify-tachyon.test.js` rather than `src/lib/tachyon-utils.test.js`, which #933 also creates, to avoid an add/add conflict. Happy to move them once #933 lands.
- 17 new tests; full unit suite 1076 passing, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SSL8pbMoVJzoAkb6uXtkZA